### PR TITLE
PR-2: PD120/180 decoder + polyphase FIR resampler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed (PR-2 CR round 1)
+- `SstvDecoder::process` now preserves trailing audio after `ImageComplete`,
+  so a back-to-back VIS burst (ARISS multi-image case) is not lost.
+- `PdDemod::pixel_freq` no longer allocates a `Vec<Complex<f32>>` per pixel
+  — reuses a preallocated `fft_buf` field. ~635k allocs/image saved on PD180.
+- `SstvEvent::ImageComplete::partial` doc clarified — V1 always emits
+  `partial: false`; `reset()` discards in-flight state silently. The
+  `partial: true` case is reserved for future mid-image VIS handling.
+
 ### Added (PR-2)
 - PD120 and PD180 mode decoding: `mode_pd::PdDemod` (256-pt FFT-based per-pixel
   demod with Gaussian-log peak interpolation, matching slowrx `video.c:391-394`),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed (PR-2 CR round 2)
+- `SstvDecoder::reset()` now also clears polyphase FIR resampler state and
+  PdDemod state. Previously residual FIR history could contaminate audio
+  after a user reset.
+- Strengthened `reset_during_decoding` test to actually trigger VIS detection
+  (added FIR-group-delay padding + explicit VIS assertion) before testing reset.
+- Fixed CHANGELOG symbol path: `SstvDecoder.sample_offset` →
+  `SstvEvent::VisDetected.sample_offset`.
+
 ### Fixed (PR-2 CR round 1)
 - `SstvDecoder::process` now preserves trailing audio after `ImageComplete`,
   so a back-to-back VIS burst (ARISS multi-image case) is not lost.
@@ -27,8 +36,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `SstvEvent::LineDecoded { mode, line_index, pixels }` and
   `SstvEvent::ImageComplete { image, partial }` are now produced during a
   decoded pass.
-- `SstvDecoder.sample_offset` field on `VisDetected` documents working-rate
-  units (was inconsistent across input rates).
+- `SstvEvent::VisDetected.sample_offset` documents working-rate (11025 Hz)
+  units; was inconsistent across input rates before this PR.
 - Synthetic encode → decode round-trip integration tests
   (`tests/roundtrip.rs`, gated on `test-support` cargo feature).
 - VIS detector now preserves leading post-stop-bit audio for the decoder

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed (PR-2 CR round 3)
+- Polyphase FIR resampler: `build_kernel` was generating a single
+  fixed-phase kernel and `process()` was dropping `center.fract()`,
+  making the resampler a quantized integer-delay FIR rather than a
+  true fractional-delay polyphase. For non-integer ratios (48k →
+  11.025k), this injected ~0.5 samples of phase jitter per output =
+  ~10 Hz wobble at the recovered tone = ~3 grey levels of pixel
+  noise. Now computes each tap on-the-fly using `frac = phase.fract()`
+  to shift the sinc, with the Hann window staying anchored to the
+  kernel grid. Added a 48k → 11.025k quality test asserting >50×
+  SNR ratio at 1900 Hz that would have caught this regression.
+
 ### Fixed (PR-2 CR round 2)
 - `SstvDecoder::reset()` now also clears polyphase FIR resampler state and
   PdDemod state. Previously residual FIR history could contaminate audio

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added (PR-2)
+- PD120 and PD180 mode decoding: `mode_pd::PdDemod` (256-pt FFT-based per-pixel
+  demod with Gaussian-log peak interpolation, matching slowrx `video.c:391-394`),
+  `mode_pd::decode_pd_line_pair` (Y(odd)/Cr/Cb/Y(even) channel layout, chroma
+  sharing). New `rustfft = "6"` dependency for slowrx algorithmic parity.
+- Polyphase FIR resampler (`resample.rs`) replacing PR-0's passthrough. 64-tap
+  Hann-windowed sinc kernel, stride-walked phase accumulator. Caller's audio
+  rate → 11025 Hz working rate, with state preserved across `process` calls.
+- `SstvEvent::LineDecoded { mode, line_index, pixels }` and
+  `SstvEvent::ImageComplete { image, partial }` are now produced during a
+  decoded pass.
+- `SstvDecoder.sample_offset` field on `VisDetected` documents working-rate
+  units (was inconsistent across input rates).
+- Synthetic encode → decode round-trip integration tests
+  (`tests/roundtrip.rs`, gated on `test-support` cargo feature).
+- VIS detector now preserves leading post-stop-bit audio for the decoder
+  (was previously lost, breaking line alignment).
+
+### Deferred
+- Mid-image VIS detection: requires VIS-window re-alignment after a previous
+  burst's residual buffer transition; tracked as a follow-up issue.
+
 ### Added (PR-1)
 - VIS header detection via `Goertzel` filter + parity check (`src/vis.rs`).
 - `SstvDecoder` now emits `SstvEvent::VisDetected` when a clean PD120 or

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,6 +176,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -207,6 +225,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn",
+]
+
+[[package]]
+name = "primal-check"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0d895b311e3af9902528fbb8f928688abbd95872819320517cc24ca6b2bd08"
+dependencies = [
+ "num-integer",
 ]
 
 [[package]]
@@ -309,6 +336,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "rustfft"
+version = "6.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21db5f9893e91f41798c88680037dba611ca6674703c1a18601b01a72c8adb89"
+dependencies = [
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "primal-check",
+ "strength_reduce",
+ "transpose",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -386,8 +427,15 @@ name = "slowrx"
 version = "0.0.0"
 dependencies = [
  "proptest",
+ "rustfft",
  "thiserror",
 ]
+
+[[package]]
+name = "strength_reduce"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
 
 [[package]]
 name = "syn"
@@ -431,6 +479,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "transpose"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad61aed86bc3faea4300c7aee358b4c6d0c8d6ccc36524c96e4c92ccf26e77e"
+dependencies = [
+ "num-integer",
+ "strength_reduce",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ expect_used = "warn"
 
 [dependencies]
 thiserror = "2"
+rustfft = "6"
 
 [dev-dependencies]
 proptest = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,3 +37,10 @@ rustfft = "6"
 
 [dev-dependencies]
 proptest = "1"
+
+[features]
+test-support = []
+
+[[test]]
+name = "roundtrip"
+required-features = ["test-support"]

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -33,13 +33,16 @@ pub enum SstvEvent {
         /// Row pixels in `[r, g, b]` order, length = mode's `line_pixels`.
         pixels: Vec<[u8; 3]>,
     },
-    /// Image complete. `partial: true` when the in-flight image was
-    /// closed via [`SstvDecoder::reset`] rather than reaching its
-    /// natural line count.
+    /// Image complete (`LineDecoded` for the final line was just emitted).
+    /// `partial` is reserved for future mid-image VIS handling — V1 always
+    /// emits `partial: false`. `reset()` discards in-flight images silently
+    /// without emitting any event.
     ImageComplete {
         /// Final pixel buffer.
         image: SstvImage,
-        /// `true` if the image was cut short by reset/mid-image VIS.
+        /// Reserved for future mid-image VIS handling. V1 always sets this
+        /// to `false`. See the deferred mid-image VIS TODO in
+        /// [`SstvDecoder::process`] for details.
         partial: bool,
     },
 }
@@ -227,7 +230,14 @@ impl SstvDecoder {
                                 image: final_image,
                                 partial: false,
                             });
+                            // Preserve trailing audio not consumed by the last line pair — it
+                            // may contain the leading edge of a follow-up VIS burst (ARISS
+                            // multi-image case). Feed it into the VIS detector so the next
+                            // process() call sees that audio already buffered.
+                            let trailing = std::mem::take(buffer);
                             self.state = State::AwaitingVis;
+                            self.vis = crate::vis::VisDetector::new();
+                            self.vis.process(&trailing, self.working_samples_emitted);
                             break;
                         }
                     }

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -20,7 +20,8 @@ pub enum SstvEvent {
     VisDetected {
         /// Mode identified by the VIS bits.
         mode: SstvMode,
-        /// Decoder-relative sample offset where VIS finished.
+        /// Working-rate (11025 Hz) sample offset where the VIS stop bit ended.
+        /// Useful for callers that want to align audio captures with decoder events.
         sample_offset: u64,
     },
     /// One scan line completed (callers may render incrementally).
@@ -44,11 +45,16 @@ pub enum SstvEvent {
 }
 
 /// Internal state of the decoder.
-#[derive(Clone, Debug)]
 enum State {
     AwaitingVis,
-    // PR-1 fills in:
-    // Decoding { mode: SstvMode, line: u32, line_start_sample: u64 },
+    Decoding {
+        mode: SstvMode,
+        spec: crate::modespec::ModeSpec,
+        line_pair_index: u32,
+        image: SstvImage,
+        /// Buffered working-rate samples not yet consumed by per-pixel decode.
+        buffer: Vec<f32>,
+    },
 }
 
 /// Streaming SSTV decoder. Push audio buffers in via
@@ -56,8 +62,13 @@ enum State {
 pub struct SstvDecoder {
     resampler: Resampler,
     vis: crate::vis::VisDetector,
+    pd_demod: crate::mode_pd::PdDemod,
     state: State,
     samples_processed: u64,
+    /// Cumulative working-rate samples emitted by the resampler.
+    /// Used as the unit for `SstvEvent::VisDetected.sample_offset` so
+    /// that value is consistent regardless of caller's input rate.
+    working_samples_emitted: u64,
 }
 
 impl SstvDecoder {
@@ -70,37 +81,145 @@ impl SstvDecoder {
         Ok(Self {
             resampler: Resampler::new(input_sample_rate_hz)?,
             vis: crate::vis::VisDetector::new(),
+            pd_demod: crate::mode_pd::PdDemod::new(),
             state: State::AwaitingVis,
             samples_processed: 0,
+            working_samples_emitted: 0,
         })
     }
 
     /// Process a chunk of mono `f32` audio samples in caller's rate.
     ///
     /// Returns events produced during this call's processing window.
+    #[allow(
+        clippy::cast_precision_loss,
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss
+    )]
     pub fn process(&mut self, audio: &[f32]) -> Vec<SstvEvent> {
         let working = self.resampler.process(audio);
         self.samples_processed = self.samples_processed.saturating_add(audio.len() as u64);
+        self.working_samples_emitted = self
+            .working_samples_emitted
+            .saturating_add(working.len() as u64);
 
         let mut out = Vec::new();
-        if matches!(self.state, State::AwaitingVis) {
-            // NOTE: in passthrough mode (input_rate == WORKING_SAMPLE_RATE_HZ),
-            // samples_processed and the VisDetector's working-rate counter are
-            // unit-equivalent. PR-2 Task 2.1 introduces real resampling and will
-            // need to track working-rate samples separately for correct
-            // sample-offset reporting in non-passthrough mode.
-            self.vis.process(&working, self.samples_processed);
-            if let Some(detected) = self.vis.take_detected() {
-                if let Some(spec) = crate::modespec::lookup(detected.code) {
-                    out.push(SstvEvent::VisDetected {
-                        mode: spec.mode,
-                        sample_offset: detected.end_sample,
-                    });
-                    // PR-2 transitions to State::Decoding(spec.mode) here.
+        let mut remaining: &[f32] = working.as_slice();
+        loop {
+            match &mut self.state {
+                State::AwaitingVis => {
+                    self.vis.process(remaining, self.working_samples_emitted);
+                    remaining = &[];
+                    if let Some(detected) = self.vis.take_detected() {
+                        if let Some(spec) = crate::modespec::lookup(detected.code) {
+                            out.push(SstvEvent::VisDetected {
+                                mode: spec.mode,
+                                sample_offset: detected.end_sample,
+                            });
+                            let image =
+                                SstvImage::new(spec.mode, spec.line_pixels, spec.image_lines);
+                            // Recover any post-stop-bit audio that the VIS
+                            // detector buffered but did not consume — it is
+                            // the leading edge of the image data.
+                            let residual = self.vis.take_residual_buffer();
+                            self.state = State::Decoding {
+                                mode: spec.mode,
+                                spec,
+                                line_pair_index: 0,
+                                image,
+                                buffer: residual,
+                            };
+                            continue; // re-enter loop to process leftover audio
+                        }
+                        // Unknown VIS codes silently drop. Reset the
+                        // detector's buffer so it does not accumulate
+                        // forever on uninterpretable bursts.
+                        let _ = self.vis.take_residual_buffer();
+                    }
+                    break;
                 }
-                // Unknown VIS codes silently drop (we already validated parity,
-                // so an unknown code means an SSTV mode not yet implemented in V1
-                // — V2 will unlock these via modespec table additions).
+                State::Decoding {
+                    mode,
+                    spec,
+                    line_pair_index,
+                    image,
+                    buffer,
+                } => {
+                    buffer.extend_from_slice(remaining);
+
+                    let work_rate = f64::from(crate::resample::WORKING_SAMPLE_RATE_HZ);
+                    // Per-pixel FFT window is centered on the pixel's
+                    // expected sample, so we need FFT_LEN/2 trailing
+                    // samples beyond the last pixel of the pair.
+                    let lookahead = crate::mode_pd::FFT_LEN / 2;
+
+                    // Compute the cumulative sample boundary for the
+                    // CURRENT pair's start vs. the NEXT pair's start.
+                    // Using rounded-cumulative-time matches how a
+                    // continuous-phase encoder would lay out samples,
+                    // and prevents a per-pair rounding bias from
+                    // accumulating (PD180 drifts ~0.05 samples/pair, so
+                    // by row 250 a fixed `samples_per_pair` is off by
+                    // ~12 samples — enough to misalign the line pair).
+                    loop {
+                        let cur_pair = u64::from(*line_pair_index);
+                        // buffer always begins at the current pair's start sample.
+                        // The next pair begins at:
+                        //   round((cur_pair + 1) * line_seconds * sr) -
+                        //   round(cur_pair * line_seconds * sr)
+                        // samples after the current start.
+                        let cur_off = (cur_pair as f64 * spec.line_seconds * work_rate).round();
+                        let next_off =
+                            ((cur_pair + 1) as f64 * spec.line_seconds * work_rate).round();
+                        let samples_per_pair = (next_off - cur_off) as usize;
+                        let needed = samples_per_pair + lookahead;
+                        if buffer.len() < needed {
+                            break;
+                        }
+
+                        // Pass a window that overlaps the next pair's
+                        // leading samples so the rightmost pixels see
+                        // a full FFT window.
+                        crate::mode_pd::decode_pd_line_pair(
+                            *spec,
+                            *line_pair_index,
+                            &buffer[..needed],
+                            image,
+                            &mut self.pd_demod,
+                        );
+
+                        let row0 = *line_pair_index * 2;
+                        let row1 = row0 + 1;
+                        let line_pixels = spec.line_pixels as usize;
+                        for r in [row0, row1] {
+                            let start = (r as usize) * line_pixels;
+                            let end = start + line_pixels;
+                            out.push(SstvEvent::LineDecoded {
+                                mode: *mode,
+                                line_index: r,
+                                pixels: image.pixels[start..end].to_vec(),
+                            });
+                        }
+
+                        buffer.drain(..samples_per_pair);
+                        *line_pair_index += 1;
+
+                        if *line_pair_index * 2 >= spec.image_lines {
+                            // Image complete.
+                            let final_image = std::mem::replace(
+                                image,
+                                SstvImage::new(*mode, spec.line_pixels, spec.image_lines),
+                            );
+                            out.push(SstvEvent::ImageComplete {
+                                image: final_image,
+                                partial: false,
+                            });
+                            self.state = State::AwaitingVis;
+                            break;
+                        }
+                    }
+                    break;
+                }
             }
         }
         out
@@ -110,6 +229,7 @@ impl SstvDecoder {
     pub fn reset(&mut self) {
         self.state = State::AwaitingVis;
         self.samples_processed = 0;
+        self.working_samples_emitted = 0;
         self.vis = crate::vis::VisDetector::new();
     }
 

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -147,6 +147,19 @@ impl SstvDecoder {
                 } => {
                     buffer.extend_from_slice(remaining);
 
+                    // TODO(future): mid-image VIS detection. When a new VIS
+                    // burst arrives during decoding the spec calls for flushing
+                    // the in-flight image as `partial: true` and restarting.
+                    // The straightforward approach — running `self.vis` against
+                    // `buffer` each call — fails because the decoding buffer is
+                    // not aligned to 30 ms window boundaries: the residual from
+                    // the previous VIS detection starts at an arbitrary sample
+                    // offset, so the first classifier window is a mix of silence
+                    // and leader tone and does not reliably pass the 5× dominance
+                    // threshold. A correct implementation would re-align the VIS
+                    // window scan to the next 30 ms boundary, or run a separate
+                    // correlator tuned to the 1900 Hz leader. Deferred to PR-3.
+
                     let work_rate = f64::from(crate::resample::WORKING_SAMPLE_RATE_HZ);
                     // Per-pixel FFT window is centered on the pixel's
                     // expected sample, so we need FFT_LEN/2 trailing
@@ -401,4 +414,36 @@ mod tests {
         let est = estimate_freq(&window);
         assert!((est - 1450.0).abs() < 30.0, "expected ≈1450, got {est}");
     }
+
+    #[test]
+    fn reset_during_decoding_emits_partial_via_subsequent_process() {
+        let mut d = SstvDecoder::new(crate::resample::WORKING_SAMPLE_RATE_HZ).unwrap();
+        // Push a VIS so the decoder transitions to Decoding.
+        let burst = crate::vis::tests::synth_vis(0x5F, 0.0);
+        let _ = d.process(&burst);
+        // We're now in Decoding (post-VIS state assertion via the next call's
+        // outputs not being VisDetected events).
+        d.reset();
+        // After reset, the decoder is back in AwaitingVis. The next process
+        // call with quiet audio yields no events.
+        let events = d.process(&[0.0_f32; 100]);
+        assert!(
+            events.is_empty(),
+            "reset should clear in-flight; got {events:?}"
+        );
+    }
+
+    // TODO(future/PR-3): mid_image_vis_emits_partial_then_new_vis
+    //
+    // When a new VIS burst arrives during Decoding the spec calls for
+    // emitting `ImageComplete { partial: true }` for the in-flight image,
+    // then transitioning to AwaitingVis.
+    //
+    // The naive approach (running `self.vis` against the decoding buffer
+    // each call) fails because the residual buffer from a previous VIS
+    // detection is not aligned to 30 ms window boundaries: the first
+    // classifier window is a mix of silence and leader tone and does not
+    // reliably pass the 5× dominance threshold. A correct implementation
+    // would re-align the scan to the next 30 ms boundary or run a separate
+    // 1900 Hz energy detector. Deferred to PR-3 (cross-validation).
 }

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -169,7 +169,10 @@ mod tests {
         use crate::resample::WORKING_SAMPLE_RATE_HZ;
         use crate::vis::tests::synth_vis;
         let mut d = SstvDecoder::new(WORKING_SAMPLE_RATE_HZ).expect("decoder");
-        let burst = synth_vis(0x5F, 0.0);
+        // Pad with trailing silence so the polyphase FIR's ~64-sample group
+        // delay still yields a full set of stop-bit windows (PR-2 T2.1).
+        let mut burst = synth_vis(0x5F, 0.0);
+        burst.extend(std::iter::repeat_n(0.0_f32, 512));
         let events = d.process(&burst);
         let any_vis = events.iter().any(|e| {
             matches!(
@@ -188,7 +191,8 @@ mod tests {
         use crate::resample::WORKING_SAMPLE_RATE_HZ;
         use crate::vis::tests::synth_vis;
         let mut d = SstvDecoder::new(WORKING_SAMPLE_RATE_HZ).expect("decoder");
-        let burst = synth_vis(0x60, 0.0);
+        let mut burst = synth_vis(0x60, 0.0);
+        burst.extend(std::iter::repeat_n(0.0_f32, 512));
         let events = d.process(&burst);
         assert!(events.iter().any(|e| matches!(
             e,

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -254,6 +254,8 @@ impl SstvDecoder {
         self.samples_processed = 0;
         self.working_samples_emitted = 0;
         self.vis = crate::vis::VisDetector::new();
+        self.resampler.reset_state();
+        self.pd_demod = crate::mode_pd::PdDemod::new();
     }
 
     /// Total samples processed since construction (or last `reset`).
@@ -428,14 +430,24 @@ mod tests {
     #[test]
     fn reset_during_decoding_emits_partial_via_subsequent_process() {
         let mut d = SstvDecoder::new(crate::resample::WORKING_SAMPLE_RATE_HZ).unwrap();
-        // Push a VIS so the decoder transitions to Decoding.
-        let burst = crate::vis::tests::synth_vis(0x5F, 0.0);
-        let _ = d.process(&burst);
-        // We're now in Decoding (post-VIS state assertion via the next call's
-        // outputs not being VisDetected events).
+        // Push a VIS so the decoder transitions to Decoding. Trailing zeros
+        // accommodate the FIR group delay so the burst actually triggers
+        // detection (without the padding the test would mask Finding 1
+        // by never entering Decoding).
+        let mut burst = crate::vis::tests::synth_vis(0x5F, 0.0);
+        burst.extend(std::iter::repeat_n(0.0_f32, 512));
+        let events = d.process(&burst);
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, SstvEvent::VisDetected { .. })),
+            "expected VIS detection before reset, got {events:?}"
+        );
+        // We're now in Decoding state.
         d.reset();
-        // After reset, the decoder is back in AwaitingVis. The next process
-        // call with quiet audio yields no events.
+        // After reset, the decoder is back in AwaitingVis with FIR resampler
+        // and PdDemod state cleared. The next process call with quiet audio
+        // yields no events.
         let events = d.process(&[0.0_f32; 100]);
         assert!(
             events.is_empty(),

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -120,12 +120,58 @@ impl SstvDecoder {
     }
 }
 
+/// Estimate the dominant tone frequency in `window` (working-rate samples).
+/// Returns the estimated frequency in Hz, biased toward 1500-2300 Hz
+/// (the SSTV video band).
+///
+/// Algorithm: Goertzel-bank evaluated at 25-Hz steps from 1450 to 2350 Hz,
+/// then quadratic peak interpolation around the maximum bin.
+#[must_use]
+#[allow(clippy::cast_precision_loss, dead_code)]
+pub(crate) fn estimate_freq(window: &[f32]) -> f64 {
+    const STEP_HZ: f64 = 25.0;
+    const FIRST_HZ: f64 = 1450.0;
+    const N_BINS: usize = 37; // 1450..2350 inclusive at 25 Hz steps
+
+    let mut powers = [0.0_f64; N_BINS];
+    for (i, p) in powers.iter_mut().enumerate() {
+        let f = FIRST_HZ + (i as f64) * STEP_HZ;
+        *p = crate::vis::goertzel_power(window, f);
+    }
+    let (mut max_i, mut max_p) = (0_usize, powers[0]);
+    for (i, &p) in powers.iter().enumerate().skip(1) {
+        if p > max_p {
+            max_p = p;
+            max_i = i;
+        }
+    }
+    let center_hz = FIRST_HZ + (max_i as f64) * STEP_HZ;
+    // Quadratic interpolation if we have both neighbours.
+    if max_i > 0 && max_i < N_BINS - 1 && max_p > 0.0 {
+        let a = powers[max_i - 1];
+        let b = max_p;
+        let c = powers[max_i + 1];
+        let denom = a - 2.0 * b + c;
+        if denom.abs() > 1e-12 {
+            let delta = 0.5 * (a - c) / denom;
+            return center_hz + delta * STEP_HZ;
+        }
+    }
+    center_hz
+}
+
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::cast_precision_loss,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss
+)]
 mod tests {
     use super::*;
     use crate::error::Error;
-    use crate::resample::MAX_INPUT_SAMPLE_RATE_HZ;
+    use crate::resample::{MAX_INPUT_SAMPLE_RATE_HZ, WORKING_SAMPLE_RATE_HZ};
 
     #[test]
     fn rejects_invalid_sample_rates() {
@@ -166,7 +212,6 @@ mod tests {
 
     #[test]
     fn process_emits_vis_detected_for_pd120_burst() {
-        use crate::resample::WORKING_SAMPLE_RATE_HZ;
         use crate::vis::tests::synth_vis;
         let mut d = SstvDecoder::new(WORKING_SAMPLE_RATE_HZ).expect("decoder");
         // Pad with trailing silence so the polyphase FIR's ~64-sample group
@@ -188,7 +233,6 @@ mod tests {
 
     #[test]
     fn process_emits_vis_detected_for_pd180_burst() {
-        use crate::resample::WORKING_SAMPLE_RATE_HZ;
         use crate::vis::tests::synth_vis;
         let mut d = SstvDecoder::new(WORKING_SAMPLE_RATE_HZ).expect("decoder");
         let mut burst = synth_vis(0x60, 0.0);
@@ -209,5 +253,32 @@ mod tests {
         let _ = d.process(&[0.0_f32; 1024]);
         d.reset();
         assert_eq!(d.samples_processed(), 0);
+    }
+
+    // 40 ms tones make every 25-Hz bank bin map to a unique Goertzel k
+    // (11025/441 = 25.0). Production windows are ~5 ms; ~50 Hz suffices.
+    fn synth_tone_at_working(freq_hz: f64, secs: f64) -> Vec<f32> {
+        let sr = f64::from(WORKING_SAMPLE_RATE_HZ);
+        let n = (secs * sr).round() as usize;
+        (0..n)
+            .map(|i| (2.0 * std::f64::consts::PI * freq_hz * (i as f64) / sr).sin() as f32)
+            .collect()
+    }
+
+    #[test]
+    fn estimate_freq_recovers_known_tone() {
+        for &f in &[1500.0_f64, 1700.0, 1900.0, 2100.0, 2300.0] {
+            let window = synth_tone_at_working(f, 0.040);
+            let est = estimate_freq(&window);
+            assert!((est - f).abs() < 30.0, "freq={f} estimate={est}");
+        }
+    }
+
+    #[test]
+    fn estimate_freq_no_interp_at_left_boundary() {
+        // Tone at 1450 Hz lands on bin 0; no left neighbour → no interp.
+        let window = synth_tone_at_working(1450.0, 0.040);
+        let est = estimate_freq(&window);
+        assert!((est - 1450.0).abs() < 30.0, "expected ≈1450, got {est}");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,3 +40,18 @@ pub use crate::error::{Error, Result};
 pub use crate::image::SstvImage;
 pub use crate::modespec::{for_mode, lookup as lookup_vis, ChannelLayout, ModeSpec, SstvMode};
 pub use crate::resample::{Resampler, WORKING_SAMPLE_RATE_HZ};
+
+/// Test-support — exposed under the `test-support` feature for integration
+/// tests in this crate (e.g., `tests/roundtrip.rs`). NOT part of the stable
+/// public API; will be hidden behind `#[doc(hidden)]` until V1 publishes.
+#[cfg(any(test, feature = "test-support"))]
+#[doc(hidden)]
+pub mod __test_support {
+    pub mod vis {
+        pub use crate::vis::tests::synth_vis;
+    }
+    pub mod mode_pd {
+        pub use crate::mode_pd::test_encoder::encode_pd;
+        pub use crate::mode_pd::ycbcr_to_rgb;
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@
 pub mod decoder;
 pub mod error;
 pub mod image;
+pub mod mode_pd;
 pub mod modespec;
 pub mod resample;
 pub mod vis;

--- a/src/mode_pd.rs
+++ b/src/mode_pd.rs
@@ -20,7 +20,6 @@ use rustfft::{num_complex::Complex, FftPlanner};
 /// `StoredLum[SampleNum] = clip((Freq - 1500) / 3.1372549);`
 /// where `3.1372549 = (2300 - 1500) / 255`.
 #[must_use]
-#[allow(dead_code)] // Consumed by the upcoming PD line decoder (Task 2.3+).
 pub(crate) fn freq_to_luminance(freq_hz: f64) -> u8 {
     let v = (freq_hz - 1500.0) / 3.137_254_9;
     // Truncation-via-`as` matches slowrx's clip() semantics
@@ -40,7 +39,6 @@ pub(crate) fn freq_to_luminance(freq_hz: f64) -> u8 {
 /// ```
 #[must_use]
 #[doc(hidden)]
-#[allow(dead_code)] // Consumed by the upcoming PD line decoder (Task 2.3+).
 pub fn ycbcr_to_rgb(y: u8, cr: u8, cb: u8) -> [u8; 3] {
     let yi = i32::from(y);
     let cri = i32::from(cr);

--- a/src/mode_pd.rs
+++ b/src/mode_pd.rs
@@ -69,11 +69,12 @@ fn hann_window() -> Vec<f32> {
         .collect()
 }
 
-/// Per-pixel demod context: holds an FFT plan + a reusable scratch buffer.
+/// Per-pixel demod context: holds an FFT plan + reusable buffers.
 /// Construct once per decoder; reuse for many `pixel_freq` calls.
 pub(crate) struct PdDemod {
     fft: std::sync::Arc<dyn rustfft::Fft<f32>>,
     hann: Vec<f32>,
+    fft_buf: Vec<Complex<f32>>,
     scratch: Vec<Complex<f32>>,
 }
 
@@ -85,6 +86,7 @@ impl PdDemod {
         Self {
             fft,
             hann: hann_window(),
+            fft_buf: vec![Complex { re: 0.0, im: 0.0 }; FFT_LEN],
             scratch: vec![Complex { re: 0.0, im: 0.0 }; scratch_len.max(FFT_LEN)],
         }
     }
@@ -103,25 +105,23 @@ impl PdDemod {
         clippy::cast_possible_wrap
     )]
     pub fn pixel_freq(&mut self, audio: &[f32], center_sample: i64) -> f64 {
-        // Build a 256-sample windowed buffer.
+        // Fill the reusable buffer in-place — avoids a per-call Vec allocation.
         let half = (FFT_LEN as i64) / 2;
-        let mut buf: Vec<Complex<f32>> = (0..FFT_LEN)
-            .map(|i| {
-                let idx = center_sample - half + i as i64;
-                let s = if idx >= 0 && (idx as usize) < audio.len() {
-                    audio[idx as usize]
-                } else {
-                    0.0
-                };
-                Complex {
-                    re: s * self.hann[i],
-                    im: 0.0,
-                }
-            })
-            .collect();
+        for i in 0..FFT_LEN {
+            let idx = center_sample - half + i as i64;
+            let s = if idx >= 0 && (idx as usize) < audio.len() {
+                audio[idx as usize]
+            } else {
+                0.0
+            };
+            self.fft_buf[i] = Complex {
+                re: s * self.hann[i],
+                im: 0.0,
+            };
+        }
 
         self.fft
-            .process_with_scratch(&mut buf, &mut self.scratch[..]);
+            .process_with_scratch(&mut self.fft_buf, &mut self.scratch[..]);
 
         // Search peak in bins corresponding to 1500..2300 Hz.
         let bin_for = |hz: f64| -> usize {
@@ -138,8 +138,8 @@ impl PdDemod {
         };
 
         let mut max_bin = lo;
-        let mut max_p = power(buf[lo]);
-        for (k, &c) in buf.iter().enumerate().take(hi + 1).skip(lo + 1) {
+        let mut max_p = power(self.fft_buf[lo]);
+        for (k, &c) in self.fft_buf.iter().enumerate().take(hi + 1).skip(lo + 1) {
             let p = power(c);
             if p > max_p {
                 max_p = p;
@@ -149,9 +149,9 @@ impl PdDemod {
 
         // Gaussian-log peak interpolation (slowrx video.c:391-394).
         // Freq_bin = MaxBin + log(P[k+1]/P[k-1]) / (2 * log(P[k]^2 / (P[k+1] * P[k-1])))
-        let p_prev = power(buf[max_bin - 1]);
+        let p_prev = power(self.fft_buf[max_bin - 1]);
         let p_curr = max_p;
-        let p_next = power(buf[max_bin + 1]);
+        let p_next = power(self.fft_buf[max_bin + 1]);
 
         // If any neighbor power is non-positive, skip interpolation
         // (log of zero blows up). slowrx falls back to a clipped centre.

--- a/src/mode_pd.rs
+++ b/src/mode_pd.rs
@@ -1,0 +1,111 @@
+//! PD-family mode decoder.
+//!
+//! PD modes encode each radio "frame" as four channels — Y(odd line),
+//! Cr (shared), Cb (shared), Y(even line) — producing two image rows
+//! per radio frame with chroma subsampling between them.
+//!
+//! Translated from slowrx's `video.c` (Oona Räisänen, ISC License).
+//! Channel layout: video.c lines 81-93. YUV→RGB matrix: video.c lines
+//! 446-451. See `NOTICE.md` for full attribution.
+
+/// Map a demodulated FM frequency (Hz) to an 8-bit luminance value.
+///
+/// SSTV video lives in 1500–2300 Hz: 1500 Hz = black (0), 2300 Hz = white (255).
+/// Linear scaling: `lum = (freq - 1500) / (2300 - 1500) * 255`.
+/// Out-of-band frequencies are clamped.
+///
+/// Translated from slowrx's `video.c:406`:
+/// `StoredLum[SampleNum] = clip((Freq - 1500) / 3.1372549);`
+/// where `3.1372549 = (2300 - 1500) / 255`.
+#[must_use]
+#[allow(dead_code)] // Consumed by the upcoming PD line decoder (Task 2.3+).
+pub(crate) fn freq_to_luminance(freq_hz: f64) -> u8 {
+    let v = (freq_hz - 1500.0) / 3.137_254_9;
+    // Truncation-via-`as` matches slowrx's clip() semantics
+    // (slowrx uses `(unsigned char)a` which truncates the fractional part).
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    let lum = v.clamp(0.0, 255.0) as u8;
+    lum
+}
+
+/// Convert a single PD-family `[Y, Cr, Cb]` triple to `[R, G, B]`.
+///
+/// Translated from slowrx's `video.c:447-450`:
+/// ```text
+/// R = clip((100*Y + 140*Cr - 17850) / 100)
+/// G = clip((100*Y -  71*Cr -  33*Cb + 13260) / 100)
+/// B = clip((100*Y + 178*Cb - 22695) / 100)
+/// ```
+#[must_use]
+#[allow(dead_code)] // Consumed by the upcoming PD line decoder (Task 2.3+).
+pub(crate) fn ycbcr_to_rgb(y: u8, cr: u8, cb: u8) -> [u8; 3] {
+    let yi = i32::from(y);
+    let cri = i32::from(cr);
+    let cbi = i32::from(cb);
+    // i32 multiplications: max magnitude is 255 * 178 = 45_390, well within i32.
+    // Integer division truncates toward zero (matches slowrx's `(int)` cast).
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    let r = ((100 * yi + 140 * cri - 17_850) / 100).clamp(0, 255) as u8;
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    let g = ((100 * yi - 71 * cri - 33 * cbi + 13_260) / 100).clamp(0, 255) as u8;
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    let b = ((100 * yi + 178 * cbi - 22_695) / 100).clamp(0, 255) as u8;
+    [r, g, b]
+}
+
+#[cfg(test)]
+#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn freq_1500_is_black() {
+        assert_eq!(freq_to_luminance(1500.0), 0);
+    }
+
+    #[test]
+    fn freq_2300_is_white() {
+        assert_eq!(freq_to_luminance(2300.0), 255);
+    }
+
+    #[test]
+    fn freq_below_band_clamps_to_zero() {
+        assert_eq!(freq_to_luminance(1000.0), 0);
+        assert_eq!(freq_to_luminance(0.0), 0);
+    }
+
+    #[test]
+    fn freq_above_band_clamps_to_max() {
+        assert_eq!(freq_to_luminance(3000.0), 255);
+    }
+
+    #[test]
+    fn freq_midband_is_midgrey() {
+        // 1900 Hz is exactly halfway → ~127.5 → 127 after truncation
+        let v = freq_to_luminance(1900.0);
+        assert!(
+            (i32::from(v) - 127).abs() <= 1,
+            "midband should be ~127, got {v}"
+        );
+    }
+
+    #[test]
+    fn ycbcr_neutral_grey_is_grey() {
+        // Y=128, Cr=128, Cb=128 → grey (no chroma offset)
+        // R = (100*128 + 140*128 - 17850)/100 = (12800 + 17920 - 17850)/100 = 128.7 → 128
+        // G = (100*128 -  71*128 -  33*128 + 13260)/100 = (12800-9088-4224+13260)/100 = 127.48 → 127
+        // B = (100*128 + 178*128 - 22695)/100 = (12800+22784-22695)/100 = 128.89 → 128
+        let rgb = ycbcr_to_rgb(128, 128, 128);
+        for ch in &rgb {
+            assert!((i32::from(*ch) - 128).abs() <= 2, "got {rgb:?}");
+        }
+    }
+
+    #[test]
+    fn ycbcr_pure_red() {
+        // Roughly: max Cr, mid Y, mid Cb → strong red.
+        let rgb = ycbcr_to_rgb(76, 255, 85);
+        assert!(rgb[0] > 200, "red channel should dominate, got {rgb:?}");
+        assert!(rgb[2] < 100);
+    }
+}

--- a/src/mode_pd.rs
+++ b/src/mode_pd.rs
@@ -8,6 +8,8 @@
 //! Channel layout: video.c lines 81-93. YUV→RGB matrix: video.c lines
 //! 446-451. See `NOTICE.md` for full attribution.
 
+use rustfft::{num_complex::Complex, FftPlanner};
+
 /// Map a demodulated FM frequency (Hz) to an 8-bit luminance value.
 ///
 /// SSTV video lives in 1500–2300 Hz: 1500 Hz = black (0), 2300 Hz = white (255).
@@ -37,8 +39,9 @@ pub(crate) fn freq_to_luminance(freq_hz: f64) -> u8 {
 /// B = clip((100*Y + 178*Cb - 22695) / 100)
 /// ```
 #[must_use]
+#[doc(hidden)]
 #[allow(dead_code)] // Consumed by the upcoming PD line decoder (Task 2.3+).
-pub(crate) fn ycbcr_to_rgb(y: u8, cr: u8, cb: u8) -> [u8; 3] {
+pub fn ycbcr_to_rgb(y: u8, cr: u8, cb: u8) -> [u8; 3] {
     let yi = i32::from(y);
     let cri = i32::from(cr);
     let cbi = i32::from(cb);
@@ -53,8 +56,345 @@ pub(crate) fn ycbcr_to_rgb(y: u8, cr: u8, cb: u8) -> [u8; 3] {
     [r, g, b]
 }
 
+/// FFT length used for per-pixel demod. Matches slowrx's bin spacing:
+/// 256/11025 Hz = 43.07 Hz/bin, equal to slowrx's 1024/44100 Hz.
+pub(crate) const FFT_LEN: usize = 256;
+
+/// Hann window of length [`FFT_LEN`], precomputed once per decoder invocation.
+#[allow(clippy::cast_precision_loss)]
+fn hann_window() -> Vec<f32> {
+    (0..FFT_LEN)
+        .map(|i| {
+            let m = (FFT_LEN - 1) as f32;
+            0.5 * (1.0 - (2.0 * std::f32::consts::PI * (i as f32) / m).cos())
+        })
+        .collect()
+}
+
+/// Per-pixel demod context: holds an FFT plan + a reusable scratch buffer.
+/// Construct once per decoder; reuse for many `pixel_freq` calls.
+pub(crate) struct PdDemod {
+    fft: std::sync::Arc<dyn rustfft::Fft<f32>>,
+    hann: Vec<f32>,
+    scratch: Vec<Complex<f32>>,
+}
+
+impl PdDemod {
+    pub fn new() -> Self {
+        let mut planner = FftPlanner::<f32>::new();
+        let fft = planner.plan_fft_forward(FFT_LEN);
+        let scratch_len = fft.get_inplace_scratch_len();
+        Self {
+            fft,
+            hann: hann_window(),
+            scratch: vec![Complex { re: 0.0, im: 0.0 }; scratch_len.max(FFT_LEN)],
+        }
+    }
+
+    /// Estimate the dominant tone frequency in a 256-sample window centered
+    /// near `center_sample` of the working-rate audio buffer. The actual
+    /// window is `audio[center_sample - FFT_LEN/2 .. center_sample + FFT_LEN/2]`,
+    /// clamped at audio boundaries.
+    ///
+    /// Returns the estimated frequency in Hz. Uses Gaussian-log peak
+    /// interpolation matching slowrx `video.c:391-394`.
+    #[allow(
+        clippy::cast_precision_loss,
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        clippy::cast_possible_wrap
+    )]
+    pub fn pixel_freq(&mut self, audio: &[f32], center_sample: i64) -> f64 {
+        // Build a 256-sample windowed buffer.
+        let half = (FFT_LEN as i64) / 2;
+        let mut buf: Vec<Complex<f32>> = (0..FFT_LEN)
+            .map(|i| {
+                let idx = center_sample - half + i as i64;
+                let s = if idx >= 0 && (idx as usize) < audio.len() {
+                    audio[idx as usize]
+                } else {
+                    0.0
+                };
+                Complex {
+                    re: s * self.hann[i],
+                    im: 0.0,
+                }
+            })
+            .collect();
+
+        self.fft
+            .process_with_scratch(&mut buf, &mut self.scratch[..]);
+
+        // Search peak in bins corresponding to 1500..2300 Hz.
+        let bin_for = |hz: f64| -> usize {
+            (hz * (FFT_LEN as f64) / f64::from(crate::resample::WORKING_SAMPLE_RATE_HZ)).round()
+                as usize
+        };
+        let lo = bin_for(1500.0).saturating_sub(1).max(1);
+        let hi = bin_for(2300.0).saturating_add(1).min(FFT_LEN / 2 - 1);
+
+        let power = |c: Complex<f32>| -> f64 {
+            let r = f64::from(c.re);
+            let i = f64::from(c.im);
+            r * r + i * i
+        };
+
+        let mut max_bin = lo;
+        let mut max_p = power(buf[lo]);
+        for (k, &c) in buf.iter().enumerate().take(hi + 1).skip(lo + 1) {
+            let p = power(c);
+            if p > max_p {
+                max_p = p;
+                max_bin = k;
+            }
+        }
+
+        // Gaussian-log peak interpolation (slowrx video.c:391-394).
+        // Freq_bin = MaxBin + log(P[k+1]/P[k-1]) / (2 * log(P[k]^2 / (P[k+1] * P[k-1])))
+        let p_prev = power(buf[max_bin - 1]);
+        let p_curr = max_p;
+        let p_next = power(buf[max_bin + 1]);
+
+        // If any neighbor power is non-positive, skip interpolation
+        // (log of zero blows up). slowrx falls back to a clipped centre.
+        let interp_ok = p_prev > 0.0 && p_curr > 0.0 && p_next > 0.0;
+        let freq_bin = if interp_ok {
+            let num = (p_next / p_prev).ln();
+            let denom = 2.0 * (p_curr * p_curr / (p_next * p_prev)).ln();
+            if denom.abs() > 1e-12 {
+                (max_bin as f64) + num / denom
+            } else {
+                max_bin as f64
+            }
+        } else {
+            max_bin as f64
+        };
+
+        freq_bin * f64::from(crate::resample::WORKING_SAMPLE_RATE_HZ) / (FFT_LEN as f64)
+    }
+}
+
+/// Decode one PD radio frame (one Y(odd)/Cr/Cb/Y(even) sequence) into two
+/// image rows of `image`. Translated from slowrx `video.c:81-93` (channel
+/// layout) + `video.c:411-450` (per-pixel demod + chroma combine).
+///
+/// Per channel, we extract a copy of just that channel's samples and run
+/// the FFT against that isolated slice. This prevents the per-pixel FFT
+/// window from leaking into the adjacent channel at the channel edges
+/// (where the other tone would otherwise corrupt the peak search). The
+/// trade-off is a per-channel allocation; for V1's PD120/PD180 sizes
+/// this is negligible (<3 KB / channel / line pair).
+#[allow(
+    clippy::cast_precision_loss,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    clippy::cast_possible_wrap
+)]
+pub(crate) fn decode_pd_line_pair(
+    spec: crate::modespec::ModeSpec,
+    pair_index: u32,
+    window: &[f32],
+    image: &mut crate::image::SstvImage,
+    demod: &mut PdDemod,
+) {
+    let work_rate = f64::from(crate::resample::WORKING_SAMPLE_RATE_HZ);
+    let sync_secs = spec.sync_seconds;
+    let porch_secs = spec.porch_seconds;
+    let pixel_secs = spec.pixel_seconds;
+    let width = spec.line_pixels;
+
+    // PD channel time offsets (seconds from start of line pair):
+    // Y(odd) → Cr → Cb → Y(even). slowrx video.c:81-93.
+    let chan_starts_sec = [
+        sync_secs + porch_secs,                                       // Y(odd)
+        sync_secs + porch_secs + f64::from(width) * pixel_secs,       // Cr
+        sync_secs + porch_secs + 2.0 * f64::from(width) * pixel_secs, // Cb
+        sync_secs + porch_secs + 3.0 * f64::from(width) * pixel_secs, // Y(even)
+    ];
+
+    let row0 = pair_index * 2;
+    let row1 = row0 + 1;
+
+    let mut y_odd = vec![0_u8; width as usize];
+    let mut cr = vec![0_u8; width as usize];
+    let mut cb = vec![0_u8; width as usize];
+    let mut y_even = vec![0_u8; width as usize];
+
+    for (chan_idx, channel_buf) in [&mut y_odd, &mut cr, &mut cb, &mut y_even]
+        .iter_mut()
+        .enumerate()
+    {
+        let start_sec = chan_starts_sec[chan_idx];
+        let end_sec = start_sec + f64::from(width) * pixel_secs;
+        let chan_start = (start_sec * work_rate).round() as i64;
+        let chan_end = (end_sec * work_rate).round() as i64;
+
+        // Extract just this channel's samples (zero-pad if the input window
+        // doesn't fully cover the channel — happens at line-pair end-of-input).
+        let chan_len = (chan_end - chan_start).max(0) as usize;
+        let mut chan_samples = vec![0.0_f32; chan_len];
+        for (i, dst) in chan_samples.iter_mut().enumerate() {
+            let src_idx = chan_start + i as i64;
+            if src_idx >= 0 && (src_idx as usize) < window.len() {
+                *dst = window[src_idx as usize];
+            }
+        }
+
+        for x in 0..width as usize {
+            // Center sample relative to the channel slice.
+            let center_sec_rel = (x as f64 + 0.5) * pixel_secs;
+            let center_sample_rel = (center_sec_rel * work_rate).round() as i64;
+            let freq = demod.pixel_freq(&chan_samples, center_sample_rel);
+            channel_buf[x] = freq_to_luminance(freq);
+        }
+    }
+
+    for x in 0..width as usize {
+        let rgb_odd = ycbcr_to_rgb(y_odd[x], cr[x], cb[x]);
+        let rgb_even = ycbcr_to_rgb(y_even[x], cr[x], cb[x]);
+        image.put_pixel(x as u32, row0, rgb_odd);
+        image.put_pixel(x as u32, row1, rgb_even);
+    }
+}
+
+#[cfg(any(test, feature = "test-support"))]
+#[doc(hidden)]
+#[allow(
+    clippy::cast_precision_loss,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    clippy::cast_possible_wrap
+)]
+pub mod test_encoder {
+    //! Synthetic PD encoder for round-trip testing. Produces continuous-phase
+    //! FM audio matching the encoder side of the SSTV protocol.
+
+    use crate::modespec::SstvMode;
+    use crate::resample::WORKING_SAMPLE_RATE_HZ;
+    use std::f64::consts::PI;
+
+    const SYNC_HZ: f64 = 1200.0;
+    const PORCH_HZ: f64 = 1500.0;
+    const BLACK_HZ: f64 = 1500.0;
+    const WHITE_HZ: f64 = 2300.0;
+
+    fn lum_to_freq(lum: u8) -> f64 {
+        BLACK_HZ + (WHITE_HZ - BLACK_HZ) * f64::from(lum) / 255.0
+    }
+
+    /// Encoder helper: emit samples up to sample index `target_n` (exclusive)
+    /// at frequency `freq_hz`, advancing both the running sample count `n`
+    /// and the running phase. Using cumulative sample targets prevents the
+    /// per-tone rounding error that would otherwise compound over the line
+    /// (640 pixels × ~0.094 sample/pixel rounding error per pixel adds up to
+    /// 60+ samples per line at PD120, breaking decoder line alignment).
+    fn fill_to(out: &mut Vec<f32>, freq_hz: f64, target_n: usize, phase: &mut f64) {
+        let dphi = 2.0 * PI * freq_hz / f64::from(WORKING_SAMPLE_RATE_HZ);
+        while out.len() < target_n {
+            out.push(phase.sin() as f32);
+            *phase += dphi;
+            if *phase > 2.0 * PI {
+                *phase -= 2.0 * PI;
+            }
+        }
+    }
+
+    /// Encode an image as PD120 / PD180 audio. `ycrcb` is row-major
+    /// `[Y, Cr, Cb]` triples of length `width * height`. Pairs of rows
+    /// share averaged chroma, matching how the decoder will recover them.
+    #[must_use]
+    #[doc(hidden)]
+    #[allow(dead_code)]
+    pub fn encode_pd(mode: SstvMode, ycrcb: &[[u8; 3]]) -> Vec<f32> {
+        assert!(matches!(mode, SstvMode::Pd120 | SstvMode::Pd180));
+        let spec = crate::modespec::for_mode(mode);
+        let w = spec.line_pixels;
+        let h = spec.image_lines;
+        assert_eq!(ycrcb.len() as u32, w * h);
+        assert_eq!(h % 2, 0);
+
+        let sr = f64::from(WORKING_SAMPLE_RATE_HZ);
+        let mut out = Vec::new();
+        let mut phase = 0.0_f64;
+
+        // Cumulative time tracker (seconds). Targets are computed as
+        // `(running_t * sr).round()` so per-event rounding doesn't drift.
+        let mut t = 0.0_f64;
+        let advance = |t: &mut f64, secs: f64| -> usize {
+            *t += secs;
+            (*t * sr).round() as usize
+        };
+
+        for y_pair in 0..h / 2 {
+            fill_to(
+                &mut out,
+                SYNC_HZ,
+                advance(&mut t, spec.sync_seconds),
+                &mut phase,
+            );
+            fill_to(
+                &mut out,
+                PORCH_HZ,
+                advance(&mut t, spec.porch_seconds),
+                &mut phase,
+            );
+
+            // Y(odd row).
+            for x in 0..w {
+                let lum = ycrcb[((y_pair * 2) * w + x) as usize][0];
+                fill_to(
+                    &mut out,
+                    lum_to_freq(lum),
+                    advance(&mut t, spec.pixel_seconds),
+                    &mut phase,
+                );
+            }
+            // Cr (averaged across pair).
+            for x in 0..w {
+                let cr_a = ycrcb[((y_pair * 2) * w + x) as usize][1];
+                let cr_b = ycrcb[((y_pair * 2 + 1) * w + x) as usize][1];
+                let cr = u8::midpoint(cr_a, cr_b);
+                fill_to(
+                    &mut out,
+                    lum_to_freq(cr),
+                    advance(&mut t, spec.pixel_seconds),
+                    &mut phase,
+                );
+            }
+            // Cb (averaged).
+            for x in 0..w {
+                let cb_a = ycrcb[((y_pair * 2) * w + x) as usize][2];
+                let cb_b = ycrcb[((y_pair * 2 + 1) * w + x) as usize][2];
+                let cb = u8::midpoint(cb_a, cb_b);
+                fill_to(
+                    &mut out,
+                    lum_to_freq(cb),
+                    advance(&mut t, spec.pixel_seconds),
+                    &mut phase,
+                );
+            }
+            // Y(even row).
+            for x in 0..w {
+                let lum = ycrcb[((y_pair * 2 + 1) * w + x) as usize][0];
+                fill_to(
+                    &mut out,
+                    lum_to_freq(lum),
+                    advance(&mut t, spec.pixel_seconds),
+                    &mut phase,
+                );
+            }
+        }
+        out
+    }
+}
+
 #[cfg(test)]
-#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+#[allow(
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    clippy::cast_precision_loss,
+    clippy::cast_possible_wrap
+)]
 mod tests {
     use super::*;
 
@@ -107,5 +447,54 @@ mod tests {
         let rgb = ycbcr_to_rgb(76, 255, 85);
         assert!(rgb[0] > 200, "red channel should dominate, got {rgb:?}");
         assert!(rgb[2] < 100);
+    }
+
+    use crate::resample::WORKING_SAMPLE_RATE_HZ;
+    use std::f64::consts::PI;
+
+    fn synth_tone(freq_hz: f64, secs: f64) -> Vec<f32> {
+        let n = (secs * f64::from(WORKING_SAMPLE_RATE_HZ)).round() as usize;
+        (0..n)
+            .map(|i| {
+                let t = (i as f64) / f64::from(WORKING_SAMPLE_RATE_HZ);
+                (2.0 * PI * freq_hz * t).sin() as f32
+            })
+            .collect()
+    }
+
+    #[test]
+    fn pdfft_recovers_known_tone_within_5hz() {
+        let mut d = PdDemod::new();
+        // 100 ms of pure tone at 1900 Hz; ample for FFT_LEN=256.
+        let audio = synth_tone(1900.0, 0.100);
+        let center = (audio.len() / 2) as i64;
+        let est = d.pixel_freq(&audio, center);
+        assert!((est - 1900.0).abs() < 5.0, "expected ≈1900, got {est}");
+    }
+
+    #[test]
+    fn pdfft_recovers_band_edges() {
+        let mut d = PdDemod::new();
+        for &f in &[1500.0_f64, 1700.0, 2100.0, 2300.0] {
+            let audio = synth_tone(f, 0.100);
+            let center = (audio.len() / 2) as i64;
+            let est = d.pixel_freq(&audio, center);
+            assert!(
+                (est - f).abs() < 8.0,
+                "f={f} estimate={est} (band edge precision)"
+            );
+        }
+    }
+
+    #[test]
+    fn pdfft_returns_finite_for_silence() {
+        let mut d = PdDemod::new();
+        let audio = vec![0.0_f32; 1024];
+        let est = d.pixel_freq(&audio, 512);
+        assert!(est.is_finite(), "got {est}");
+        // Silence has no peak; the search expands by ±1 bin around the
+        // 1500-2300 band, and bin width is ~43 Hz, so the fallback may
+        // land within ~50 Hz of either edge.
+        assert!((1450.0..=2350.0).contains(&est), "out of band: {est}");
     }
 }

--- a/src/resample.rs
+++ b/src/resample.rs
@@ -126,6 +126,14 @@ impl Resampler {
     pub fn input_rate(&self) -> u32 {
         self.input_rate
     }
+
+    /// Clear FIR tail buffer + phase accumulator so a subsequent call to
+    /// `process` starts with a clean state. Keeps the input rate, kernel,
+    /// and stride — the rate doesn't change across `reset_state` calls.
+    pub(crate) fn reset_state(&mut self) {
+        self.tail.clear();
+        self.phase = 0.0;
+    }
 }
 
 #[cfg(test)]

--- a/src/resample.rs
+++ b/src/resample.rs
@@ -1,16 +1,10 @@
 //! Internal rational resampler: caller's audio rate → 11025 Hz working rate.
 //!
-//! Hand-rolled polyphase FIR. We picked this over `rubato` because:
-//! 1. Zero extra dependencies (the rest of the crate is `thiserror`-only).
-//! 2. Fits comfortably under the ≤ 400 LOC cap on this file.
-//! 3. Quality target is "audible loss < 0.1 dB across SSTV-relevant
-//!    frequencies (1500-2300 Hz)" — easily met with a 64-tap windowed-sinc
-//!    kernel at typical input rates (44.1k, 48k).
-//!
-//! Translated in spirit from slowrx's resampling done implicitly inside
-//! `pcm.c`'s 44.1 kHz read loop.
-//!
-//! PR-2 Task 2.1 replaces this scaffold with the real polyphase FIR state.
+//! Hand-rolled 64-tap Hann-windowed-sinc polyphase FIR. We picked this over
+//! `rubato` for zero extra deps and a small file. Quality target is "audible
+//! loss < 0.1 dB across SSTV-relevant frequencies (1500-2300 Hz)" — easily
+//! met at typical input rates (44.1k, 48k). Translated in spirit from
+//! slowrx's implicit resampling inside `pcm.c`'s 44.1 kHz read loop.
 
 use crate::error::{Error, Result};
 
@@ -21,12 +15,45 @@ pub const WORKING_SAMPLE_RATE_HZ: u32 = 11_025;
 /// Maximum supported caller input sample rate.
 pub const MAX_INPUT_SAMPLE_RATE_HZ: u32 = 192_000;
 
-/// Polyphase FIR resampler. Stateful — accumulates input samples and
-/// emits output samples at the working rate.
-///
-/// The FIR state fields will be added in PR-2 Task 2.1.
+/// Number of FIR taps. Higher = sharper transition + more CPU.
+/// 64 is the sweet spot at our quality target.
+const FIR_TAPS: usize = 64;
+
+/// Polyphase FIR resampler. Stateful — holds a tail buffer to avoid
+/// glitches across `process` calls.
 pub struct Resampler {
     input_rate: u32,
+    // ratio = input_rate / WORKING_SAMPLE_RATE_HZ, expressed as a stride
+    // we walk through input audio per output sample.
+    stride: f64,
+    // Position into the input buffer (fractional, accumulates across calls).
+    phase: f64,
+    // Carry-over input samples from the previous call.
+    tail: Vec<f32>,
+    // Pre-computed FIR kernel.
+    kernel: Vec<f32>,
+}
+
+#[allow(clippy::cast_precision_loss, clippy::cast_possible_truncation)]
+fn build_kernel(input_rate: u32) -> Vec<f32> {
+    // Cutoff = min(in/2, working/2) * 0.45, hard-capped at 4500 Hz. Then
+    // normalize to input rate (taps spaced at 1/input_rate seconds).
+    let cutoff_hz = (f64::from(input_rate.min(WORKING_SAMPLE_RATE_HZ)) * 0.45).min(4500.0);
+    let fc = cutoff_hz / f64::from(input_rate);
+    let m = FIR_TAPS as f64;
+    let mut k = Vec::with_capacity(FIR_TAPS);
+    for i in 0..FIR_TAPS {
+        let n = i as f64 - (m - 1.0) / 2.0;
+        let sinc = if n == 0.0 {
+            2.0 * fc
+        } else {
+            (2.0 * std::f64::consts::PI * fc * n).sin() / (std::f64::consts::PI * n)
+        };
+        let w = 0.5 * (1.0 - (2.0 * std::f64::consts::PI * (i as f64) / (m - 1.0)).cos());
+        // Kernel values are bounded in [-1, 1]; the f32 cast is exact-enough.
+        k.push((sinc * w) as f32);
+    }
+    k
 }
 
 impl Resampler {
@@ -39,22 +66,59 @@ impl Resampler {
         if input_rate == 0 || input_rate > MAX_INPUT_SAMPLE_RATE_HZ {
             return Err(Error::InvalidSampleRate { got: input_rate });
         }
-        Ok(Self { input_rate })
+        Ok(Self {
+            input_rate,
+            stride: f64::from(input_rate) / f64::from(WORKING_SAMPLE_RATE_HZ),
+            phase: 0.0,
+            tail: Vec::new(),
+            kernel: build_kernel(input_rate),
+        })
     }
 
-    /// Push input samples; receive resampled output.
-    ///
-    /// The current implementation is a passthrough placeholder for PR-0.
-    /// PR-2 Task 2.1 wires in the polyphase kernel.
+    /// Resample a chunk of input audio into working-rate output.
     #[must_use]
+    #[allow(
+        clippy::cast_precision_loss,
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        clippy::cast_possible_wrap
+    )]
     pub fn process(&mut self, input: &[f32]) -> Vec<f32> {
-        // PR-0 placeholder: pass-through identity when input_rate
-        // already matches the working rate, otherwise empty.
-        if self.input_rate == WORKING_SAMPLE_RATE_HZ {
-            input.to_vec()
-        } else {
-            Vec::new()
+        // Concatenate carry-over with the new chunk.
+        let mut buf = std::mem::take(&mut self.tail);
+        buf.extend_from_slice(input);
+
+        let mut out = Vec::new();
+        let half = (FIR_TAPS as f64) / 2.0;
+        loop {
+            let center = self.phase + half;
+            let needed_end = (center + half).ceil() as usize;
+            if needed_end > buf.len() {
+                break;
+            }
+            let start = (center - half).floor() as isize;
+            // Convolve.
+            let mut acc: f32 = 0.0;
+            for (k, &tap) in self.kernel.iter().enumerate() {
+                let idx = start + k as isize;
+                if (0..buf.len() as isize).contains(&idx) {
+                    acc += tap * buf[idx as usize];
+                }
+            }
+            out.push(acc);
+            self.phase += self.stride;
         }
+
+        // Keep the trailing samples that the next call will need.
+        let drop = self.phase.floor() as usize;
+        if drop < buf.len() {
+            self.tail = buf[drop..].to_vec();
+            self.phase -= drop as f64;
+        } else {
+            self.tail.clear();
+            self.phase -= buf.len() as f64;
+        }
+        out
     }
 
     /// Caller-provided input sample rate.
@@ -65,9 +129,28 @@ impl Resampler {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::cast_precision_loss,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    clippy::cast_possible_wrap,
+    clippy::float_cmp,
+    clippy::expect_used
+)]
 mod tests {
     use super::*;
+    use std::f64::consts::PI;
+
+    fn synth_tone_at(rate: u32, freq_hz: f64, secs: f64) -> Vec<f32> {
+        let n = (secs * f64::from(rate)).round() as usize;
+        (0..n)
+            .map(|i| {
+                let t = (i as f64) / f64::from(rate);
+                (2.0 * PI * freq_hz * t).sin() as f32
+            })
+            .collect()
+    }
 
     #[test]
     fn rejects_zero_rate() {
@@ -94,8 +177,73 @@ mod tests {
 
     #[test]
     fn passthrough_when_rate_matches_working_rate() {
+        // At equal rates the resampler still applies its FIR (no special-case
+        // bypass). Verify the output length is approximately equal to input
+        // length and that a 1500 Hz tone survives.
         let mut r = Resampler::new(WORKING_SAMPLE_RATE_HZ).unwrap();
-        let input = vec![0.1_f32, 0.2, 0.3, 0.4];
-        assert_eq!(r.process(&input), input);
+        let in_audio = synth_tone_at(WORKING_SAMPLE_RATE_HZ, 1500.0, 0.1);
+        let out = r.process(&in_audio);
+        // Allow up to FIR_TAPS samples of length variance (group delay + tail).
+        let expected = in_audio.len();
+        assert!(
+            (out.len() as isize - expected as isize).abs() < 100,
+            "len mismatch: out={} expected≈{}",
+            out.len(),
+            expected
+        );
+        let p = crate::vis::goertzel_power(&out, 1500.0);
+        let p_off = crate::vis::goertzel_power(&out, 800.0);
+        assert!(p > 10.0 * p_off, "tone should survive: {p} vs {p_off}");
+    }
+
+    #[test]
+    fn resamples_44100_to_11025_preserves_tone_frequency() {
+        // 1 second of 1900 Hz at 44100 Hz → resample → expect 1900 Hz at 11025 Hz.
+        let mut r = Resampler::new(44_100).expect("44.1k resampler");
+        let in_audio = synth_tone_at(44_100, 1900.0, 1.0);
+        let out = r.process(&in_audio);
+        // Output should be ~11025 samples (1 second at working rate)
+        let expected = WORKING_SAMPLE_RATE_HZ as usize;
+        assert!(
+            (out.len() as isize - expected as isize).abs() < 200,
+            "out.len()={} expected≈{expected}",
+            out.len()
+        );
+        // Goertzel power at 1900 Hz should be much greater than at 1700/2100 Hz.
+        let p_target = crate::vis::goertzel_power(&out, 1900.0);
+        let p_off1 = crate::vis::goertzel_power(&out, 1700.0);
+        let p_off2 = crate::vis::goertzel_power(&out, 2100.0);
+        assert!(
+            p_target > 10.0 * p_off1.max(p_off2),
+            "p1900={p_target} p1700={p_off1} p2100={p_off2}"
+        );
+    }
+
+    #[test]
+    fn resamples_48000_to_11025() {
+        let mut r = Resampler::new(48_000).expect("48k resampler");
+        let in_audio = synth_tone_at(48_000, 1500.0, 0.5);
+        let out = r.process(&in_audio);
+        let expected = (WORKING_SAMPLE_RATE_HZ / 2) as usize;
+        assert!((out.len() as isize - expected as isize).abs() < 200);
+    }
+
+    #[test]
+    fn streaming_calls_are_consistent() {
+        let mut r = Resampler::new(44_100).unwrap();
+        let in_audio = synth_tone_at(44_100, 1900.0, 0.5);
+        let single = r.process(&in_audio);
+        let mut r2 = Resampler::new(44_100).unwrap();
+        let mid = in_audio.len() / 2;
+        let mut split = r2.process(&in_audio[..mid]);
+        split.extend_from_slice(&r2.process(&in_audio[mid..]));
+        // Length should match within ±2 samples; per-sample diff should be
+        // tiny (filter edge effects).
+        assert!((single.len() as isize - split.len() as isize).abs() <= 2);
+        let common = single.len().min(split.len());
+        let max_diff = (0..common)
+            .map(|i| (single[i] - split[i]).abs())
+            .fold(0.0_f32, f32::max);
+        assert!(max_diff < 0.01, "max_diff={max_diff}");
     }
 }

--- a/src/resample.rs
+++ b/src/resample.rs
@@ -23,37 +23,42 @@ const FIR_TAPS: usize = 64;
 /// glitches across `process` calls.
 pub struct Resampler {
     input_rate: u32,
-    // ratio = input_rate / WORKING_SAMPLE_RATE_HZ, expressed as a stride
-    // we walk through input audio per output sample.
+    /// `input_rate / WORKING_SAMPLE_RATE_HZ`, expressed as a stride.
     stride: f64,
-    // Position into the input buffer (fractional, accumulates across calls).
+    /// Position into the input buffer (fractional, accumulates across calls).
     phase: f64,
-    // Carry-over input samples from the previous call.
+    /// Carry-over input samples from the previous call.
     tail: Vec<f32>,
-    // Pre-computed FIR kernel.
-    kernel: Vec<f32>,
+    /// Cutoff frequency normalized to input rate (taps spaced at `1/input_rate`).
+    cutoff_norm: f64,
 }
 
+/// Cutoff frequency (Hz) for the resampler, derived from the input rate.
+/// Min of (`input_rate/2`, `working_rate/2`) × 0.45, hard-capped at 4500 Hz.
+fn cutoff_hz(input_rate: u32) -> f64 {
+    (f64::from(input_rate.min(WORKING_SAMPLE_RATE_HZ)) * 0.45).min(4500.0)
+}
+
+/// Compute one FIR tap value for a given tap index and fractional phase.
+/// `tap_index` is in 0..`FIR_TAPS`. `frac` is in [0, 1) — the sub-sample
+/// offset of the output sample's center from the integer input grid.
+/// `fc` is the cutoff normalized to input rate (`cutoff_hz / input_rate`).
+///
+/// Sinc shifts with `frac`; Hann window stays anchored to the tap grid.
+/// This is the standard windowed-sinc fractional-delay formulation —
+/// see e.g. Smith, "Digital Audio Resampling Home Page" (CCRMA, 2002).
 #[allow(clippy::cast_precision_loss, clippy::cast_possible_truncation)]
-fn build_kernel(input_rate: u32) -> Vec<f32> {
-    // Cutoff = min(in/2, working/2) * 0.45, hard-capped at 4500 Hz. Then
-    // normalize to input rate (taps spaced at 1/input_rate seconds).
-    let cutoff_hz = (f64::from(input_rate.min(WORKING_SAMPLE_RATE_HZ)) * 0.45).min(4500.0);
-    let fc = cutoff_hz / f64::from(input_rate);
+fn fir_tap(tap_index: usize, frac: f64, fc: f64) -> f32 {
     let m = FIR_TAPS as f64;
-    let mut k = Vec::with_capacity(FIR_TAPS);
-    for i in 0..FIR_TAPS {
-        let n = i as f64 - (m - 1.0) / 2.0;
-        let sinc = if n == 0.0 {
-            2.0 * fc
-        } else {
-            (2.0 * std::f64::consts::PI * fc * n).sin() / (std::f64::consts::PI * n)
-        };
-        let w = 0.5 * (1.0 - (2.0 * std::f64::consts::PI * (i as f64) / (m - 1.0)).cos());
-        // Kernel values are bounded in [-1, 1]; the f32 cast is exact-enough.
-        k.push((sinc * w) as f32);
-    }
-    k
+    let n = (tap_index as f64) - (m - 1.0) / 2.0 - frac;
+    let sinc = if n.abs() < 1e-12 {
+        2.0 * fc
+    } else {
+        (2.0 * std::f64::consts::PI * fc * n).sin() / (std::f64::consts::PI * n)
+    };
+    let w = 0.5 * (1.0 - (2.0 * std::f64::consts::PI * (tap_index as f64) / (m - 1.0)).cos());
+    // Tap values are bounded in [-1, 1]; the f32 cast is exact-enough.
+    (sinc * w) as f32
 }
 
 impl Resampler {
@@ -71,7 +76,7 @@ impl Resampler {
             stride: f64::from(input_rate) / f64::from(WORKING_SAMPLE_RATE_HZ),
             phase: 0.0,
             tail: Vec::new(),
-            kernel: build_kernel(input_rate),
+            cutoff_norm: cutoff_hz(input_rate) / f64::from(input_rate),
         })
     }
 
@@ -96,10 +101,15 @@ impl Resampler {
             if needed_end > buf.len() {
                 break;
             }
-            let start = (center - half).floor() as isize;
-            // Convolve.
+            let frac = self.phase.fract();
+            let start = self.phase.floor() as isize;
+
+            // Convolve, computing each tap on-the-fly with the fractional
+            // phase shift. This makes the resampler a true fractional-delay
+            // FIR rather than the quantized integer-delay version.
             let mut acc: f32 = 0.0;
-            for (k, &tap) in self.kernel.iter().enumerate() {
+            for k in 0..FIR_TAPS {
+                let tap = fir_tap(k, frac, self.cutoff_norm);
                 let idx = start + k as isize;
                 if (0..buf.len() as isize).contains(&idx) {
                     acc += tap * buf[idx as usize];
@@ -128,7 +138,7 @@ impl Resampler {
     }
 
     /// Clear FIR tail buffer + phase accumulator so a subsequent call to
-    /// `process` starts with a clean state. Keeps the input rate, kernel,
+    /// `process` starts with a clean state. Keeps the input rate, cutoff,
     /// and stride — the rate doesn't change across `reset_state` calls.
     pub(crate) fn reset_state(&mut self) {
         self.tail.clear();
@@ -234,6 +244,25 @@ mod tests {
         let out = r.process(&in_audio);
         let expected = (WORKING_SAMPLE_RATE_HZ / 2) as usize;
         assert!((out.len() as isize - expected as isize).abs() < 200);
+    }
+
+    #[test]
+    fn resamples_48000_to_11025_preserves_tone_quality() {
+        // 0.5 s of 1900 Hz at 48 kHz, non-integer ratio (4.354...).
+        // Pre-fix this test would have shown ~10× signal-to-noise margin
+        // around 1900 Hz; with proper polyphase the margin should be 100×+.
+        let mut r = Resampler::new(48_000).expect("48k resampler");
+        let in_audio = synth_tone_at(48_000, 1900.0, 0.5);
+        let out = r.process(&in_audio);
+        let p_target = crate::vis::goertzel_power(&out, 1900.0);
+        let p_off1 = crate::vis::goertzel_power(&out, 1700.0);
+        let p_off2 = crate::vis::goertzel_power(&out, 2100.0);
+        // Tighter than the integer-ratio 10× threshold — non-integer
+        // ratios with broken polyphase would NOT meet this.
+        assert!(
+            p_target > 50.0 * p_off1.max(p_off2),
+            "p1900={p_target} p1700={p_off1} p2100={p_off2} (polyphase quality)"
+        );
     }
 
     #[test]

--- a/src/vis.rs
+++ b/src/vis.rs
@@ -117,15 +117,23 @@ impl VisDetector {
         }
     }
 
-    /// Take the detected VIS (if any) and clear internal state to
-    /// resume awaiting a new VIS.
+    /// Take the detected VIS (if any). Tone history is cleared so the
+    /// next call to [`Self::process`] starts fresh; the audio buffer is
+    /// NOT cleared so callers can recover post-stop-bit residue via
+    /// [`Self::take_residual_buffer`].
     pub fn take_detected(&mut self) -> Option<DetectedVis> {
         let d = self.detected.take();
         if d.is_some() {
             self.tones.clear();
-            self.buffer.clear();
         }
         d
+    }
+
+    /// Take any audio still buffered by the detector (post-stop-bit residue).
+    /// The caller is expected to hand this audio to the next stage of the
+    /// decoder so no samples are lost across a state transition.
+    pub fn take_residual_buffer(&mut self) -> Vec<f32> {
+        std::mem::take(&mut self.buffer)
     }
 }
 
@@ -189,21 +197,25 @@ fn match_vis_pattern(tones: &[Tone]) -> Option<u8> {
     Some(code)
 }
 
-#[cfg(test)]
+#[cfg(any(test, feature = "test-support"))]
+#[doc(hidden)]
 #[allow(
     clippy::cast_precision_loss,
     clippy::cast_possible_truncation,
     clippy::cast_sign_loss,
     clippy::cast_possible_wrap,
     clippy::float_cmp,
-    clippy::expect_used
+    clippy::expect_used,
+    clippy::wildcard_imports,
+    clippy::must_use_candidate,
+    dead_code
 )]
-pub(crate) mod tests {
+pub mod tests {
     use super::*;
     use std::f64::consts::PI;
 
     /// Generate `secs` of pure tone at `freq_hz` at the working sample rate.
-    pub(crate) fn synth_tone(freq_hz: f64, secs: f64) -> Vec<f32> {
+    pub fn synth_tone(freq_hz: f64, secs: f64) -> Vec<f32> {
         let n = (secs * f64::from(WORKING_SAMPLE_RATE_HZ)).round() as usize;
         (0..n)
             .map(|i| {
@@ -217,7 +229,7 @@ pub(crate) mod tests {
     /// with even parity. Pads `pre_silence_secs` of zeros before the
     /// leader so the detector has to find the burst inside a longer
     /// audio buffer.
-    pub(crate) fn synth_vis(code: u8, pre_silence_secs: f64) -> Vec<f32> {
+    pub fn synth_vis(code: u8, pre_silence_secs: f64) -> Vec<f32> {
         assert!(code < 0x80, "VIS codes are 7 bits");
 
         let mut out: Vec<f32> = Vec::new();
@@ -370,40 +382,44 @@ pub(crate) mod tests {
         assert!(det.take_detected().is_none());
     }
 
-    use proptest::prelude::*;
+    #[cfg(test)]
+    mod prop {
+        use super::*;
+        use proptest::prelude::*;
 
-    proptest! {
-        #![proptest_config(ProptestConfig::with_cases(64))]
+        proptest! {
+            #![proptest_config(ProptestConfig::with_cases(64))]
 
-        #[test]
-        fn detector_does_not_panic_on_arbitrary_audio(
-            len in 0usize..32_000,
-            seed in 0u64..u64::MAX,
-        ) {
-            // Deterministic pseudo-random audio in [-1, 1].
-            let mut x = seed;
-            let mut audio = Vec::with_capacity(len);
-            for _ in 0..len {
-                // xorshift
-                x ^= x << 13;
-                x ^= x >> 7;
-                x ^= x << 17;
-                let v = ((x as i64) as f64) / (i64::MAX as f64);
-                audio.push(v as f32);
+            #[test]
+            fn detector_does_not_panic_on_arbitrary_audio(
+                len in 0usize..32_000,
+                seed in 0u64..u64::MAX,
+            ) {
+                // Deterministic pseudo-random audio in [-1, 1].
+                let mut x = seed;
+                let mut audio = Vec::with_capacity(len);
+                for _ in 0..len {
+                    // xorshift
+                    x ^= x << 13;
+                    x ^= x >> 7;
+                    x ^= x << 17;
+                    let v = ((x as i64) as f64) / (i64::MAX as f64);
+                    audio.push(v as f32);
+                }
+                let mut det = VisDetector::new();
+                det.process(&audio, audio.len() as u64);
+                // Whatever it returns is fine; it just must not panic.
+                let _ = det.take_detected();
             }
-            let mut det = VisDetector::new();
-            det.process(&audio, audio.len() as u64);
-            // Whatever it returns is fine; it just must not panic.
-            let _ = det.take_detected();
-        }
 
-        #[test]
-        fn every_valid_vis_code_decodes_correctly(code in 0u8..0x80) {
-            let mut det = VisDetector::new();
-            let audio = synth_vis(code, 0.0);
-            det.process(&audio, audio.len() as u64);
-            let d = det.take_detected().expect("clean VIS always decodes");
-            prop_assert_eq!(d.code, code);
+            #[test]
+            fn every_valid_vis_code_decodes_correctly(code in 0u8..0x80) {
+                let mut det = VisDetector::new();
+                let audio = synth_vis(code, 0.0);
+                det.process(&audio, audio.len() as u64);
+                let d = det.take_detected().expect("clean VIS always decodes");
+                prop_assert_eq!(d.code, code);
+            }
         }
     }
 }

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -1,0 +1,104 @@
+//! Synthetic encode → decode round-trip for PD120 and PD180.
+
+#![cfg(feature = "test-support")]
+#![allow(clippy::expect_used, clippy::cast_possible_truncation)]
+
+use slowrx::{SstvDecoder, SstvEvent, SstvMode, WORKING_SAMPLE_RATE_HZ};
+
+/// Build a synthetic image: horizontal luma gradient + alternating chroma stripes.
+#[allow(
+    clippy::cast_precision_loss,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss
+)]
+fn test_image(mode: SstvMode) -> (u32, u32, Vec<[u8; 3]>) {
+    let spec = slowrx::for_mode(mode);
+    let w = spec.line_pixels;
+    let h = spec.image_lines;
+    let mut ycrcb = Vec::with_capacity((w * h) as usize);
+    for y in 0..h {
+        for x in 0..w {
+            let lum = ((f64::from(x)) / (f64::from(w)) * 255.0) as u8;
+            // Smooth chroma (so adjacent-row averaging in the encoder doesn't
+            // discard high-frequency chroma the decoder can't recover).
+            let cr = if y % 4 < 2 { 200 } else { 56 };
+            let cb = if (y / 2) % 2 == 0 { 200 } else { 56 };
+            ycrcb.push([lum, cr, cb]);
+        }
+    }
+    (w, h, ycrcb)
+}
+
+#[allow(
+    clippy::cast_precision_loss,
+    clippy::cast_possible_wrap,
+    clippy::cast_sign_loss
+)]
+fn run_roundtrip(mode: SstvMode) {
+    let (w, h, ycrcb) = test_image(mode);
+
+    // Build VIS + image audio.
+    let vis_code = match mode {
+        SstvMode::Pd120 => 0x5F,
+        SstvMode::Pd180 => 0x60,
+        _ => unreachable!(),
+    };
+    let mut audio = slowrx::__test_support::vis::synth_vis(vis_code, 0.0);
+    audio.extend(slowrx::__test_support::mode_pd::encode_pd(mode, &ycrcb));
+    // Padding to absorb resampler group delay.
+    audio.extend(std::iter::repeat_n(0.0_f32, 2048));
+
+    let mut d = SstvDecoder::new(WORKING_SAMPLE_RATE_HZ).expect("decoder");
+    let events = d.process(&audio);
+
+    let img = events
+        .iter()
+        .find_map(|e| match e {
+            SstvEvent::ImageComplete {
+                image,
+                partial: false,
+            } => Some(image.clone()),
+            _ => None,
+        })
+        .expect("ImageComplete event");
+
+    assert_eq!(img.mode, mode);
+    assert_eq!(img.width, w);
+    assert_eq!(img.height, h);
+
+    // Compare per-pixel against the encoded source.
+    let mut max_diff = 0_u8;
+    let mut sum_diff: u64 = 0;
+    let mut n: u64 = 0;
+    for (i, src) in ycrcb.iter().enumerate() {
+        let src_rgb = slowrx::__test_support::mode_pd::ycbcr_to_rgb(src[0], src[1], src[2]);
+        let dec = img.pixels[i];
+        for ch in 0..3 {
+            let d = (i32::from(src_rgb[ch]) - i32::from(dec[ch])).unsigned_abs() as u8;
+            if d > max_diff {
+                max_diff = d;
+            }
+            sum_diff += u64::from(d);
+            n += 1;
+        }
+    }
+    let mean = sum_diff as f64 / n as f64;
+    // Tier B for synthetic round-trip: looser than slowrx-cross-validate
+    // because no continuous-phase porch transitions and no anti-aliasing
+    // filter on the synthetic encoder. ≤ 25 max, mean < 5 is healthy.
+    assert!(
+        max_diff <= 25,
+        "{mode:?}: max_diff={max_diff} mean={mean:.2}"
+    );
+    assert!(mean < 5.0, "{mode:?}: max_diff={max_diff} mean={mean:.2}");
+}
+
+#[test]
+fn pd120_roundtrip() {
+    run_roundtrip(SstvMode::Pd120);
+}
+
+#[test]
+fn pd180_roundtrip() {
+    run_roundtrip(SstvMode::Pd180);
+}


### PR DESCRIPTION
Closes #5. Part of #2 (V1 epic).

## Summary

PR-2 of the V1 plan — the math-heavy stretch. PD120 and PD180 decode end-to-end with a working polyphase FIR resampler and FFT-based per-pixel demod. Adds `rustfft` for slowrx algorithmic parity.

## What ships

- **`mode_pd.rs`** — \`PdDemod\` (256-pt FFT per-pixel demod with Gaussian-log peak interpolation matching slowrx \`video.c:391-394\` exactly), \`decode_pd_line_pair\` (Y(odd)/Cr/Cb/Y(even) channel layout from slowrx \`video.c:81-93\`, chroma sharing).
- **\`freq_to_luminance\` + \`ycbcr_to_rgb\`** primitives translated row-for-row from slowrx \`video.c:406, 447-450\`.
- **\`resample.rs\`** — real polyphase FIR replacing PR-0's passthrough scaffold. 64-tap Hann-windowed sinc kernel, stride-walked phase accumulator, tail buffer state preserved across \`process\` calls.
- **\`SstvDecoder\` state machine** extended with \`State::Decoding { mode, spec, line_pair_index, image, buffer }\`. Emits \`SstvEvent::LineDecoded\` per row + \`SstvEvent::ImageComplete { partial }\` at the end.
- **Synthetic round-trip** integration test (\`tests/roundtrip.rs\`), gated on \`test-support\` cargo feature.

## Three subtle DSP bugs caught in implementation

The plan's T2.4 needed 3 corrections during implementation; the Opus reviewer validated the math on each:

1. **Per-channel isolated FFT slices.** Naive single-window-spans-pair would let the 256-sample FFT span across channel boundaries, picking up the adjacent channel's tone (~800 Hz different) and biasing the peak search at edge pixels. Fix: extract just the channel's samples into a zero-padded buffer and FFT against that.
2. **Cumulative-time pair-boundary tracking.** Fixed-rounding \`samples_per_pair = round(line_seconds * sr)\` accumulates ~0.05 samples/pair drift on PD180; by line 250 the decoder would be misaligned by ~12 samples — enough to shift Y(even)'s leftmost pixels into Cb territory. Fix: \`samples_per_pair = round((p+1) * line_secs * sr) - round(p * line_secs * sr)\` so cumulative drift stays bounded at ±0.5.
3. **VIS detector residual-buffer recovery.** \`VisDetector::take_detected\` was clearing the buffer on consume, dropping ~150-300 samples of leading image data and breaking line alignment. Fix: \`take_detected\` now clears tones only; \`take_residual_buffer\` returns the buffered post-stop-bit audio for the decoder to seed the new \`Decoding\` state.

Plus a units fix: \`SstvEvent::VisDetected.sample_offset\` now documented as working-rate (11025 Hz) samples; the decoder tracks \`working_samples_emitted\` separately from input-rate \`samples_processed\`.

## Round-trip Tier B margins

| Mode | max_abs_diff | mean_abs_diff | target |
|---|---|---|---|
| PD120 | 19 | 1.27 | ≤ 25 / < 5.0 |
| PD180 | 17 | 0.79 | ≤ 25 / < 5.0 |

PR-3's slowrx cross-validation will tighten these to ≤ 2 / < 0.5 on real ARISS audio (synthetic encoder lacks anti-alias filtering and continuous-phase porches that real radio waveforms have).

## Stats

- 8 source files: mode_pd 498, decoder 449, vis 425, resample 249, modespec 148, image 115, lib 57, error 48 LOC — all under the 500 LOC cap.
- 51 unit tests + 2 round-trip integration tests + 1 doctest = **54 passing**.
- Coverage **97.84% lines / 98.08% regions** aggregate.
- New dep: \`rustfft = "6"\` (MIT/Apache, ~250 dependent crates on crates.io). Used for slowrx algorithmic parity.

## Test plan

- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\`
- [x] \`cargo test --all-features\` (54 passing)
- [x] \`cargo llvm-cov --fail-under-lines 92 --fail-under-regions 92\` (97.84%/98.08%)
- [x] \`cargo doc --no-deps --all-features\` (no rustdoc warnings)
- [x] \`cargo check --workspace --locked\` (Cargo.lock consistent)

## Deferred

- **Mid-image VIS detection.** The plan called for in-flight image abandonment when a new VIS arrives during \`Decoding\`, but the implementation surfaced that the VIS detector's 30-ms window-aligned scan can't pick up a new burst from the residual buffer (which starts at an arbitrary sample offset, not aligned to 30 ms boundaries). Tracked in code via TODO + comment in \`decoder.rs\`. Non-blocking for V1 — ARISS use case is one VIS per pass.

## Plan deviation: per-pixel demod uses FFT (rustfft) not Goertzel-bank

The original plan used a Goertzel-bank for per-pixel demod. After T2.3 surfaced that 8-sample windows can't achieve the precision Tier B needs (~3 Hz per grey level over the 1500-2300 Hz band), we switched to a 256-pt sliding FFT matching slowrx's algorithm exactly. Same algorithm class (FFT peak with log-power Gaussian interpolation) → tightest possible numerical compatibility for PR-3's cross-validation.

## Attribution

Per-file rustdoc credits the corresponding slowrx C source. \`mode_pd.rs\` cites \`video.c:81-93\` (channel layout), \`video.c:391-394\` (peak interpolation), \`video.c:406\` (luminance map), \`video.c:447-450\` (YCbCr matrix). \`resample.rs\` cites \`pcm.c\`'s 44.1 kHz read loop in spirit. \`decoder.rs\` cites \`slowrx.c\`'s \`Listen()\` loop pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PD120/PD180 SSTV decoding support added.

* **Improvements**
  * Stateful, high-quality FIR resampling for continuous streaming.
  * VIS timing and sample-offsets clarified; detector preserves leading/trailing audio for alignment.
  * Decoder emits per-line decoded and non-partial image-complete events; reset now clears in-flight images silently.
  * FFT-based per-pixel demodulator with improved peak estimation.

* **Bug Fixes**
  * Corrected fractional-delay resampler behavior and recovered prior phase handling.

* **Tests**
  * Added synthetic encode→decode round-trip tests for PD modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->