### PR TITLE
Phase 1: VIS detector rewrite — slowrx parity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,10 @@ Thumbs.db
 # Local reference clone of slowrx (not committed; use clone-slowrx.sh
 # or clone manually from https://github.com/windytan/slowrx)
 /original
+
+# Local ARISS reference fixtures used for the real-data success gate.
+# Real ARISS recordings (audio + decoded reference images) live here for
+# manual validation against our decoder. NOT committed — the redistribution
+# license for community-shared captures is unclear, and we don't want to
+# bloat the published crate with ~250 MB of fixtures.
+/docs/wav_files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed (Phase 1: VIS parity)
+
+Faithful rewrite of `vis.rs` to mirror slowrx's `vis.c` algorithm
+(closes #13, #14, #15, #17, #30, #36, #37, #38). The PR-1/PR-2 detector
+classified non-overlapping 30 ms Goertzel windows against absolute
+1900/1200/1300/1100 Hz tones with a 5× dominance threshold, never saw
+the leader's actual frequency, and so could not catch real-radio bursts
+mistuned by tens of Hz. The new detector matches slowrx exactly:
+
+- 10 ms hop / 20 ms Hann-windowed sliding window (slowrx vis.c lines 30,
+  45-48). Closes #13 (no Hann window) and #14 (no overlap).
+- 512-FFT (zero-padded from 220 samples), Gaussian-log peak interpolation
+  in 500-3300 Hz (slowrx vis.c lines 54-70). Closes #37 (Goertzel-bank
+  vs FFT) and #30 (FIR-transient sensitivity — overlap dominates).
+- 45-entry circular frequency history feeding a 9-iteration `i × j`
+  pattern matcher with **relative** ±25 Hz tolerance from the observed
+  leader (slowrx vis.c lines 82-104). Closes #15 (absolute-vs-relative
+  tolerance), #36 (5× dominance threshold), #38 (single-alignment scan).
+- `HedrShift = leader_observed - 1900` is now extracted at VIS time
+  (slowrx vis.c line 106) and plumbed through `SstvEvent::VisDetected`,
+  the decoder state, `decode_pd_line_pair`, `PdDemod::pixel_freq`
+  (peak-search range), and `freq_to_luminance` (luminance base) — so a
+  mistuned radio's pixel band shifts in lock-step. Closes #17.
+- New tests: `detects_pd120_with_50hz_offset`,
+  `detects_pd180_with_minus_70hz_offset`,
+  `handles_misaligned_burst` (off-grid pre-silence proves overlap),
+  `rejects_constant_off_band_tone`, `pixel_freq_with_hedr_shift`,
+  `freq_to_luminance_with_hedr_shift_scales_band`.
+- `synth_vis` is now continuous-phase across tone boundaries — phase
+  discontinuities at bit edges previously pulled FFT peaks off-tone
+  enough to mask alignment bugs in 30 ms-window unit tests.
+
+`SstvEvent::VisDetected` gains a `hedr_shift_hz: f64` field. The struct
+is `#[non_exhaustive]` so this is additive at the wire level for callers
+that match by name; positional `match` patterns must add the new field.
+The synthetic round-trip integration tests for PD120/PD180 still pass
+unchanged (max_diff ≤ 25, mean < 5 per-channel against encoder source).
+
 ### Fixed (PR-2 CR round 3)
 - Polyphase FIR resampler: `build_kernel` was generating a single
   fixed-phase kernel and `process()` was dropping `center.fract()`,

--- a/docs/audits/2026-05-01-slowrx-c-rust-parity-audit.md
+++ b/docs/audits/2026-05-01-slowrx-c-rust-parity-audit.md
@@ -1,5 +1,3 @@
-I have enough context from the source code to perform a thorough audit without reading the design docs cover-to-cover. Now I'll write the comprehensive audit report.
-
 # slowrx ↔ slowrx.rs Side-by-Side Parity Audit
 
 ## Section 1 — Coverage table (mandatory enumeration)

--- a/docs/audits/2026-05-01-slowrx-c-rust-parity-audit.md
+++ b/docs/audits/2026-05-01-slowrx-c-rust-parity-audit.md
@@ -1,0 +1,1284 @@
+I have enough context from the source code to perform a thorough audit without reading the design docs cover-to-cover. Now I'll write the comprehensive audit report.
+
+# slowrx ↔ slowrx.rs Side-by-Side Parity Audit
+
+## Section 1 — Coverage table (mandatory enumeration)
+
+### `common.h` / `common.c` (utilities & constants)
+
+| C source | Rust source | Match? | Notes |
+|---|---|---|---|
+| `common.h::MINSLANT 30`, `MAXSLANT 150` | NOT TRANSLATED | NOT-PORTED | Hough transform constants for sync.c slant correction. Rust port has no slant correction. |
+| `common.h::BUFLEN 4096` | NOT TRANSLATED | NOT-PORTED | C's hard-coded PCM ring-buffer length. Rust uses streaming `Vec<f32>` — no fixed buffer. |
+| `common.h::SYNCPIXLEN 1.5e-3` | NOT TRANSLATED | NOT-PORTED | Sync pixel duration; only referenced by sync.c. |
+| `common.h::CurrentPic.HedrShift` (gshort) | NOT TRANSLATED | NOT-PORTED | **Critical: radio mistuning offset**. C carries this through entire pipeline. Rust has no equivalent. |
+| `common.h::CurrentPic.Mode/Rate/Skip` | `decoder::State::Decoding{mode, spec, line_pair_index, ...}` | DIVERGE | Rust does not track `Rate` or `Skip` (no slant/skip refinement). |
+| `common.h::HasSync` array | NOT TRANSLATED | NOT-PORTED | Sync band power tracking buffer. |
+| `common.h::StoredLum` array | NOT TRANSLATED | NOT-PORTED | Cached luminance per sample for redraw. Rust does not redraw — single-pass. |
+| `common.h::Adaptive` flag | NOT TRANSLATED | NOT-PORTED | **Adaptive FFT-window flag.** Rust uses fixed FFT_LEN=256. |
+| `common.h::ModeSpec[]` array indexed by enum | `modespec.rs::for_mode/lookup` | DIVERGE-IN-COVERAGE | Rust ports only PD120 and PD180. C has all 25+ modes. |
+| `common.c::GetBin(Freq, FFTLen)` | inlined `bin_for(hz)` closure in `mode_pd::pixel_freq`, also inlined in `vis::goertzel_power` | MATCH (semantically) | Rust uses `WORKING_SAMPLE_RATE_HZ=11025` rather than C's hard-coded `44100`. |
+| `common.c::power(coeff)` | inlined `power(c)` closure in `mode_pd::pixel_freq` | MATCH | `r*r + i*i`. |
+| `common.c::clip(a)` | `mode_pd::freq_to_luminance` clamp + `ycbcr_to_rgb` clamp | DIVERGE-IN-SEMANTICS | C does `(guchar)round(a)`; Rust does `as u8` (truncation). See Finding 4. |
+| `common.c::deg2rad/rad2deg` | NOT TRANSLATED | NOT-PORTED | sync.c-only helpers. |
+| `common.c::ensure_dir_exists/saveCurrentPic` | NOT TRANSLATED | NOT-PORTED | I/O — out of crate scope. |
+| `common.c::evt_*` GTK handlers | NOT TRANSLATED | NOT-PORTED | UI layer. |
+
+### `vis.c` (VIS detection)
+
+| C source | Rust source | Match? | Notes |
+|---|---|---|---|
+| `vis.c::Hann[882]` window (20 ms) | `vis.rs::goertzel_power` (no Hann window!) | DIVERGE | **Critical: no windowing.** See Finding 1. |
+| `vis.c::FFTLen=2048`, `Plan2048` | `vis.rs::goertzel_power` (no FFT) | DIVERGE | C uses 2048-pt FFT looking for max bin in 500-3300 Hz; Rust uses 4 fixed Goertzels at 1900/1200/1100/1300 Hz. |
+| `vis.c::readPcm(441)` (10 ms hop, sliding) | `vis.rs::process` 30 ms boundary windows | DIVERGE | **Critical: no overlap.** See Finding 2. |
+| `vis.c::HedrBuf[100]` (45-window history) | `vis.rs::tones[14]` (14-window history) | DIVERGE | C remembers ~450 ms (45 × 10 ms hops) and pattern-matches with offset `i` and reference `j`; Rust matches on rigid 14 × 30 ms slots. |
+| `vis.c::Gaussian-interpolated peak` (lines 63-66) | NOT TRANSLATED | NOT-PORTED | C extracts continuous frequency; Rust doesn't (no need with Goertzel). |
+| `vis.c::tone[i]` storage in Hz | `vis.rs::Tone` enum (categorical) | DIVERGE | C stores continuous frequency in Hz; Rust stores 5-way enum classification. |
+| `vis.c::±25 Hz tolerance` (lines 85-91) | `vis.rs::classify` 5× power dominance | DIVERGE | **Critical: relative-vs-absolute tolerance.** See Finding 3. |
+| `vis.c::HedrShift = tone[0+j] - 1900` (line 106) | NOT TRANSLATED | NOT-PORTED | **Critical: radio mistuning measurement.** See Finding 5. |
+| `vis.c::3-position phase scan (i=0..2)` | NOT TRANSLATED | NOT-PORTED | C scans i=0,1,2 to handle window misalignment by ±10 ms. Rust has no such scan. |
+| `vis.c::3-leader scan (j=0..2)` | NOT TRANSLATED | NOT-PORTED | C uses any of 3 leader windows as the reference for tolerance; Rust requires absolute match. |
+| `vis.c::Parity check + R12BW special-case` | `vis.rs::match_vis_pattern` parity check | MATCH (partial) | Rust does parity, but R12BW negation is not present (mode not implemented). |
+| `vis.c::VISmap[VIS] lookup` | `modespec.rs::lookup` | MATCH (partial) | Only PD120/PD180 — see modespec.rs section. |
+| `vis.c::"Skip the rest of the stop bit" 20 ms read` (line 169) | `decoder::process` consumes residual buffer | DIVERGE | C explicitly skips 20 ms after stop bit; Rust hands trailing window contents to PD decoder as residual. |
+| `vis.c::ManualActivated/ManualResync` | NOT TRANSLATED | NOT-PORTED | UI flags. |
+
+### `modespec.c` (mode timing tables)
+
+| C source | Rust source | Match? | Notes |
+|---|---|---|---|
+| `ModeSpec[PD120]` (lines 260-271) | `modespec.rs::PD120` const | **MISSING-FIELD** | Rust omits `septr_seconds` (C: 0e-3, used in PD ChanStart calculations). |
+| `ModeSpec[PD180]` (lines 286-297) | `modespec.rs::PD180` const | **MISSING-FIELD** | Same omission. |
+| `ModeSpec.SyncTime/PorchTime/PixelTime/LineTime` | matching fields | MATCH | Numeric values verified row-by-row. |
+| `ModeSpec.SeptrTime` for PD = 0e-3 | NOT TRANSLATED | NOT-PORTED | PD ChanStart uses `+ SeptrTime` between channels; for PD it's 0 so omission is functionally OK, but spec field is missing (would break if non-PD mode added). |
+| `ModeSpec.LineHeight` | NOT TRANSLATED | NOT-PORTED | Used by C's PNG saver and click-to-set-edge handler. Not needed in Rust pixel buffer. |
+| `ModeSpec.ColorEnc=YUV` for PD | `modespec.rs::ChannelLayout::PdYcbcr` | MATCH | |
+| `VISmap[]` 0x5F → PD120 (line 381) | `modespec.rs::lookup` | MATCH | |
+| `VISmap[]` 0x60 → PD180 (line 382) | `modespec.rs::lookup` | MATCH | |
+| `VISmap[]` for all other modes | `modespec.rs::lookup` returns None | NOT-PORTED-BY-DESIGN | V1 scope. |
+
+### `sync.c` (slant correction)
+
+| C source | Rust source | Match? | Notes |
+|---|---|---|---|
+| `FindSync` (whole function) | NOT TRANSLATED | NOT-PORTED | **Important.** No Hough-transform slant correction. See Finding 7. |
+| Linear Hough transform (lines 50-69) | NOT TRANSLATED | NOT-PORTED | |
+| Sample rate adjustment (line 81) | NOT TRANSLATED | NOT-PORTED | C corrects sample rate by inverse-tangent of slant angle. |
+| 8-point convolution sync edge finder (lines 105-113) | NOT TRANSLATED | NOT-PORTED | **Important.** Determines `Skip` (where the line actually starts). See Finding 8. |
+| `Skip` calculation (lines 119-127) | `decoder::process` uses pair_index × line_seconds, no skip | DIVERGE | Rust assumes line 0 starts immediately at end of stop bit + residual. |
+| Scottie-mode skip adjustment | NOT TRANSLATED | NOT-PORTED | Scottie modes not implemented in V1. |
+
+### `video.c` (per-pixel decode)
+
+| C source | Rust source | Match? | Notes |
+|---|---|---|---|
+| `GetVideo` setup (lines 19-50) | `decoder::process` State::Decoding | MATCH | Rust state machine vs C single function. |
+| Hann windows of 7 lengths (lines 53-57) | `mode_pd::hann_window` (single 256 length) | DIVERGE | **Critical: no SNR adaptation.** See Finding 6. |
+| HannLens[7] = {48, 64, 96, 128, 256, 512, 1024} | NOT TRANSLATED | NOT-PORTED | C adapts FFT window 48..1024 by SNR. |
+| Channel time offsets `ChanStart[]` (lines 81-93 PD case) | `mode_pd::chan_starts_sec` | MATCH | Both use sync+porch + n×width×pixel offsets. SeptrTime=0 for PD. |
+| `NumChans=4` for PD (lines 117-125) | implicit in `mode_pd::decode_pd_line_pair` (4 channels) | MATCH | |
+| PixelGrid construction PD (lines 135-176) | `mode_pd::decode_pd_line_pair` | DIVERGE | Different structure: C pre-plans per-pixel sample times globally; Rust loops within each line pair. See Finding 12. |
+| PixelGrid `Time` formula (line 140-142) | Rust per-channel `start_sec * work_rate.round()` + `(x + 0.5) * pixel_secs` | MATCH (semantically) | C: `Rate * (y/2 * LineTime + ChanStart + PixelTime * (x + 0.5))`; Rust: same formula in two parts. |
+| `PixelIdx` → first non-negative `Time` skip (lines 211-216) | NOT TRANSLATED | NOT-PORTED | C handles negative skip times (when Skip is negative, PD odd starts before t=0). Rust doesn't have skip. |
+| Length calculation (lines 251-254) | `decoder::process` cumulative `cur_off`/`next_off` | DIVERGE | C: total frames × line_time × 44100. Rust: per-pair samples_per_pair from cumulative rounding. |
+| `SyncTargetBin = GetBin(1200 + HedrShift)` (line 255) | NOT TRANSLATED | NOT-PORTED | Sync band tracking uses HedrShift; Rust has no sync band tracking. |
+| Sync band Praw/Psync power tracking (lines 271-298) | NOT TRANSLATED | NOT-PORTED | **Important.** Used by sync.c for slant detection. |
+| `HasSync[SyncSampleNum]` array fill | NOT TRANSLATED | NOT-PORTED | |
+| SNR estimation (lines 304-344) | NOT TRANSLATED | NOT-PORTED | **Critical.** Drives `WinIdx` adaptive window selection. See Finding 6. |
+| FM demod every 6 samples (line 350) | per-pixel FFT (one per pixel) | DIVERGE | **Important.** C runs sliding FFT every 6 samples (= 7350 Hz analysis rate at 44100). Rust runs FFT only at pixel centers. See Finding 11. |
+| Window-size selection by SNR (lines 354-367) | fixed 256 | DIVERGE | See Finding 6. |
+| Window centered on `WindowPtr - WinLength/2` (line 375) | `mode_pd::pixel_freq` centered on `center_sample - FFT_LEN/2` | MATCH | Both centered. |
+| Peak search 1500-2300 Hz with HedrShift offset (line 382) | `mode_pd::pixel_freq` peak search 1500-2300 Hz, NO HedrShift | DIVERGE | **Critical: missing HedrShift.** See Finding 5. |
+| Out-of-band freq fallback to 1500 or 2300 (line 397) | `mode_pd::pixel_freq` returns `max_bin` (no HedrShift, no fallback to 1500/2300) | DIVERGE | C clips to band edges (with HedrShift); Rust returns interpolated bin. |
+| Gaussian peak interpolation (lines 391-394) | `mode_pd::pixel_freq` Gaussian interp | MATCH | Same formula. |
+| `StoredLum[SampleNum] = clip((Freq - 1500 - HedrShift) / 3.1372549)` (line 406) | `mode_pd::freq_to_luminance(freq)` | DIVERGE | **Critical: missing HedrShift in luminance scale.** See Finding 5 + Finding 4. |
+| `Image[x][y][Channel] = StoredLum[SampleNum]` at PixelGrid time (line 421) | `decode_pd_line_pair` per-pixel `pixel_freq` then `freq_to_luminance` | DIVERGE | **Important.** Slowrx uses cached `StoredLum` indexed by sample number; Rust re-runs FFT centered at each pixel. See Finding 11. |
+| YUV→RGB matrix (lines 446-451) | `mode_pd::ycbcr_to_rgb` | MATCH | Coefficients verified identical: 100/140/-17850, 100/-71/-33/13260, 100/178/-22695. |
+| `Image[x][y+1][Channel]` for R36/R24 (line 425) | NOT TRANSLATED | NOT-PORTED | Robot modes not implemented. |
+| `setVU` calls | NOT TRANSLATED | NOT-PORTED | UI. |
+| Abort handling | NOT TRANSLATED | NOT-PORTED | Caller's responsibility. |
+
+### `slowrx.c` (`Listen` orchestrator)
+
+| C source | Rust source | Match? | Notes |
+|---|---|---|---|
+| `Listen()` outer loop | `SstvDecoder::process` driver | MATCH (in spirit) | |
+| `GetVIS()` → `GetVideo()` sequencing | `State::AwaitingVis` → `State::Decoding` | MATCH | |
+| `CurrentPic.Rate = 44100` (initial) | `WORKING_SAMPLE_RATE_HZ = 11025` | DIVERGE | Different working rate (intentional). |
+| First-pass `GetVideo(Mode, 44100, 0, FALSE)` then `FindSync` then second-pass `GetVideo(..., TRUE)` (lines 115-149) | single-pass `decode_pd_line_pair` | DIVERGE | **Important.** Rust skips two-pass slant refinement entirely. See Finding 7. |
+| `StoredLum` calloc'd to whole-image size (line 86) | NOT TRANSLATED | NOT-PORTED | Rust streams pixels as decoded. |
+| `HasSync` calloc'd (line 93) | NOT TRANSLATED | NOT-PORTED | |
+| FSK ID reception (line 127) | NOT TRANSLATED | NOT-PORTED | Out of V1 scope. |
+| FFT plan allocation (lines 218-232) | per-`PdDemod` rustfft planner | MATCH | |
+| `ManualResync` redraw path (lines 57-67) | NOT TRANSLATED | NOT-PORTED | UI. |
+
+---
+
+## Section 2 — Per-file walk-through
+
+### `common.h` — Read.
+A 151-line header defining `_ModeSpec`, `_PicMeta`, the SSTV mode enum, the `FFTStuff`/`PcmData`/`GuiObjs` structs, and externs. Maps to `modespec.rs` (mode enum + spec table — partial, only PD120/PD180), `decoder.rs::State` (subsumes `_PicMeta` partially: Mode is tracked, but `Rate` and `HedrShift` and `Skip` are NOT tracked). `_PicMeta.HedrShift` is the most consequential omission — it threads through `vis.c → video.c` as a frequency offset for SSTV mistuning. The enum covers 25+ modes; only PD120 and PD180 are in the Rust enum.
+
+### `common.c` — Read.
+A 215-line file mostly of GTK glue plus three pure helpers: `GetBin`, `power`, `clip`, and `deg2rad/rad2deg`. `GetBin` and `power` are inlined in Rust at their callsites (with the bin formula updated for the 11025 Hz working rate). `clip` is split into `freq_to_luminance` (for grayscale) and `ycbcr_to_rgb`'s clamps. **One semantic divergence**: `clip` calls `round(a)` then casts to `guchar` — Rust uses `as u8` (truncation). `deg2rad`/`rad2deg` are unused in Rust (slant correction not ported). `saveCurrentPic` is out of crate scope.
+
+### `vis.c` — Read.
+The 175-line file is **architecturally different from the Rust port**, not just translated. C uses a 2048-point FFT with a 20 ms Hann window, slid every 10 ms (= 882 sample window with 441 sample hops, overlapping 50%), maintaining a 450 ms history buffer (45 frequency samples). Pattern matching scans 3 sub-window offsets × 3 reference-leader positions, with ±25 Hz tolerance relative to the detected leader frequency. Rust replaces all of this with 4 fixed-frequency Goertzel filters at exact 1900/1200/1100/1300 Hz, scanned on rigid 30 ms boundaries (no overlap, no Hann window). Rust loses: HedrShift detection, frequency-tolerance to off-frequency captures, sub-window time alignment, and Hann windowing for spectral leakage suppression.
+
+### `modespec.c` — Read.
+A 385-line table-driven file. Only PD120 and PD180 are ported. Field-by-field comparison of those two entries shows numeric values match (SyncTime=20e-3, PorchTime=2.08e-3, PixelTime=0.19e-3 (PD120) / 0.286e-3 (PD180), LineTime=0.50848 / 0.75424, ImgWidth=640, NumLines=496). The Rust `ModeSpec` struct **omits `SeptrTime`**: in C this is 0e-3 for PD modes so it's a no-op in `ChanStart` arithmetic, but the field is structurally absent — adding any non-PD mode would expose it. `LineHeight` and `Name`/`ShortName` are also absent (cosmetic / used only by C's PNG path).
+
+### `sync.c` — Read.
+The 133-line file is **completely unported** in Rust. It does two things: (a) Hough-transform-based slant angle detection, with up to 4 retries refining the sample rate, and (b) 8-point convolution sync-edge detection driving the `Skip` value (where line 0 truly starts within the audio). Without these, the Rust port has no defense against sample-rate mismatches (sound card clock drift) or sync-phase misalignment between the VIS stop bit and the first scan line. For real off-air recordings these matter — the C code's design centers `GetVideo` first, then re-runs it after `FindSync` recalculates Rate and Skip.
+
+### `video.c` — Read.
+The 491-line core. Three subsystems live here that Rust doesn't have: (1) **HedrShift application**: every `GetBin(... + HedrShift, ...)` call shifts the analysis bands by the radio mistuning offset detected during VIS. (2) **SNR-adaptive Hann window** chooses one of 7 window lengths (48..1024) based on continuously updated SNR. (3) **Sync-band power tracking** writes the `HasSync` array consumed by sync.c. The luminance pipeline itself (`StoredLum[SampleNum] = clip((Freq - 1500 - HedrShift) / 3.1372549)`) is structurally similar to Rust's `freq_to_luminance`, but Rust runs FFT only at pixel-center sample times whereas C runs FFT every 6 samples and indexes `StoredLum` at the pixel times — meaning C effectively low-pass filters luminance over ~136 µs while Rust takes a single instantaneous reading. The PD channel-layout / YUV→RGB code is a clean match.
+
+### `slowrx.c` — Read.
+The 256-line `Listen()` thread. Two-pass decode flow: (1) GetVIS, (2) GetVideo with default 44100 Rate and 0 Skip (cached luminance via StoredLum), (3) FindSync to refine Rate/Skip, (4) GetVideo again in `Redraw=TRUE` mode that re-uses the cached luminance with new pixel-time grid. Rust collapses this to a single-pass `decode_pd_line_pair` with no Rate/Skip refinement step. The `Adaptive` checkbox state is read here (passed to GetVideo via global) — Rust has no equivalent toggle (it's effectively `Adaptive=FALSE, WinIdx=0` always, which means C's largest 1024-tap window).
+
+---
+
+## Section 3 — Detailed divergence findings
+
+### Finding 1: VIS detection has no Hann window
+
+**Severity:** Important
+**Likely impact on real-audio decoder failure:** Yes
+**Files:** `vis.c:30, 47-48` ↔ `src/vis.rs:23-42`
+
+#### C source
+
+```c
+// Create 20ms Hann window
+for (i = 0; i < 882; i++) Hann[i] = 0.5 * (1 - cos( (2 * M_PI * (double)i) / 881 ) );
+
+// ...
+
+// Apply Hann window
+for (i = 0; i < 882; i++) fft.in[i] = pcm.Buffer[pcm.WindowPtr + i - 441] / 32768.0 * Hann[i];
+
+// FFT of last 20 ms
+fftw_execute(fft.Plan2048);
+```
+
+#### Rust source
+
+```rust
+pub(crate) fn goertzel_power(samples: &[f32], target_hz: f64) -> f64 {
+    #[allow(clippy::cast_precision_loss)]
+    let n = samples.len() as f64;
+    if n == 0.0 {
+        return 0.0;
+    }
+    let k = (0.5 + n * target_hz / f64::from(WORKING_SAMPLE_RATE_HZ)).floor();
+    let omega = 2.0 * std::f64::consts::PI * k / n;
+    let coeff = 2.0 * omega.cos();
+
+    let mut s_prev = 0.0_f64;
+    let mut s_prev2 = 0.0_f64;
+    for &sample in samples {
+        let s = f64::from(sample) + coeff * s_prev - s_prev2;
+        s_prev2 = s_prev;
+        s_prev = s;
+    }
+    s_prev2.mul_add(s_prev2, s_prev.mul_add(s_prev, -coeff * s_prev * s_prev2))
+}
+```
+
+#### Divergence
+
+Slowrx applies a 882-sample Hann window to the time-domain PCM before FFT. This suppresses spectral leakage from the rectangular boxcar implicit in `samples`. Rust's Goertzel filter operates on the raw rectangular-windowed sequence — equivalent to using a `sinc`-shaped (boxcar) frequency-domain response with ~4% peak sidelobes vs. Hann's ~0.4% sidelobes (a 10× difference in nearby-tone rejection). The Rust comment claims "mathematically equivalent for VIS purposes" — that's true for a pure single tone in clean audio but false when nearby spectral energy from speech, hum (60/120 Hz), noise, or adjacent SSTV tones leaks into the bin.
+
+Quantitatively: a real-radio capture has noise + occasional speech in the audio band. The boxcar window's first sidelobe at 13 dB below peak means a noise tone 110 Hz away from 1900 Hz (near `WINDOW_SAMPLES = 330` × frequency-resolution ≈ 33 Hz, so ~3 bins) leaks at -13 dB; with Hann that drops to -32 dB.
+
+#### Why this might cause the real-audio failure (or not)
+
+This is plausible but not the strongest candidate. ARISS captures are known for noise + adjacent transmissions. Without Hann windowing the 5×-dominance threshold could fail to classify any tone (returning `Tone::Other`) when noise leaks into the bin. However, the real failure mode is "0 ImageComplete events on 6/7 captures" — if VIS detection itself were the bottleneck the 1 success would be unexplained too. **More likely contributor than primary cause.**
+
+---
+
+### Finding 2: VIS windows do not overlap (no 10 ms hop)
+
+**Severity:** Critical
+**Likely impact on real-audio decoder failure:** Yes
+**Files:** `vis.c:40-48, 73, 165` ↔ `src/vis.rs:94-118`
+
+#### C source
+
+```c
+while ( TRUE ) {
+
+    if (Abort || ManualResync) return(0);
+
+    // Read 10 ms from sound card
+    readPcm(441);
+
+    // Apply Hann window
+    for (i = 0; i < 882; i++) fft.in[i] = pcm.Buffer[pcm.WindowPtr + i - 441] / 32768.0 * Hann[i];
+
+    // FFT of last 20 ms
+    fftw_execute(fft.Plan2048);
+    ...
+    // Header buffer holds 45 * 10 msec = 450 msec
+    HedrPtr = (HedrPtr + 1) % 45;
+    ...
+    pcm.WindowPtr += 441;
+}
+```
+
+#### Rust source
+
+```rust
+pub fn process(&mut self, samples: &[f32], total_samples_consumed: u64) {
+    self.buffer.extend_from_slice(samples);
+
+    while self.buffer.len() >= WINDOW_SAMPLES && self.detected.is_none() {
+        let window: Vec<f32> = self.buffer.drain(..WINDOW_SAMPLES).collect();
+        let tone = classify(&window);
+        self.tones.push(tone);
+        if self.tones.len() > 14 {
+            self.tones.remove(0);
+        }
+        if self.tones.len() == 14 {
+            if let Some(code) = match_vis_pattern(&self.tones) {
+                ...
+            }
+        }
+    }
+}
+```
+
+(Where `WINDOW_SAMPLES = 330` = 30 ms at 11025 Hz.)
+
+#### Divergence
+
+This is the single most important finding. Slowrx classifies on a **20 ms window slid 10 ms at a time** (50% overlap). Rust classifies on **30 ms boundary-aligned windows with 0 ms overlap** and uses the most recent 14 windows.
+
+Consequences:
+1. **VIS bit boundary alignment.** A VIS bit is 30 ms long. If the burst arrives at a sub-window phase offset, the C decoder has 3 candidate alignments per 30 ms (the `i = 0..2` loop, lines 82-84) corresponding to 0/10/20 ms phase offsets. Rust has only one alignment — whichever the boundary lands at. If the VIS burst starts at a buffer offset that's not a multiple of 330 samples, **every bit window straddles two adjacent bits**, mixing the two tones and yielding `Tone::Other` (5×-dominance failure).
+2. **Tone history depth.** C remembers 450 ms, allowing it to find the VIS pattern anywhere within that window. Rust remembers exactly 14 × 30 ms = 420 ms — basically just the VIS pattern length itself, so a single-bit misclassification kills detection until 14 more good windows arrive.
+
+The Rust test `detects_vis_after_pre_silence` explicitly notes "Pre-silence is a whole multiple of WINDOW_SAMPLES so the burst aligns with detector window boundaries" — which calls out this bug. The synthetic tests align by construction; real audio does not.
+
+#### Why this might cause the real-audio failure
+
+VERY likely. If 6 of 7 ARISS captures fail to produce ImageComplete and the failure mode is "0 events" (not "1 event with corrupt image"), VIS detection failure is the most common cause: no VIS detected → never enter Decoding state → no LineDecoded events → no ImageComplete event. Real audio captures will not be aligned to 30 ms boundaries; the boundary alignment of the 1 successful capture is essentially a lucky coincidence.
+
+---
+
+### Finding 3: VIS classification uses absolute frequencies, not relative tolerance
+
+**Severity:** Critical
+**Likely impact on real-audio decoder failure:** Yes
+**Files:** `vis.c:80-110` ↔ `src/vis.rs:140-198`
+
+#### C source
+
+```c
+// Tolerance ±25 Hz
+CurrentPic.HedrShift = 0;
+gotvis    = FALSE;
+for (i = 0; i < 3; i++) {
+  if (CurrentPic.HedrShift != 0) break;
+  for (j = 0; j < 3; j++) {
+    if ( (tone[1*3+i]  > tone[0+j] - 25  && tone[1*3+i]  < tone[0+j] + 25)  && // 1900 Hz leader
+         (tone[2*3+i]  > tone[0+j] - 25  && tone[2*3+i]  < tone[0+j] + 25)  && // 1900 Hz leader
+         ...
+         (tone[5*3+i]  > tone[0+j] - 725 && tone[5*3+i]  < tone[0+j] - 675) && // 1200 Hz start bit
+         (tone[14*3+i] > tone[0+j] - 725 && tone[14*3+i] < tone[0+j] - 675)    // 1200 Hz stop bit
+       ) {
+      gotvis = TRUE;
+      for (k = 0; k < 8; k++) {
+        if      (tone[6*3+i+3*k] > tone[0+j] - 625 && tone[6*3+i+3*k] < tone[0+j] - 575) Bit[k] = 0;
+        else if (tone[6*3+i+3*k] > tone[0+j] - 825 && tone[6*3+i+3*k] < tone[0+j] - 775) Bit[k] = 1;
+        ...
+      }
+      if (gotvis) {
+        CurrentPic.HedrShift = tone[0+j] - 1900;
+```
+
+#### Rust source
+
+```rust
+fn classify(window: &[f32]) -> Tone {
+    let p_leader = goertzel_power(window, LEADER_HZ);  // 1900.0
+    let p_break = goertzel_power(window, BREAK_HZ);    // 1200.0
+    let p0 = goertzel_power(window, BIT_ZERO_HZ);      // 1300.0
+    let p1 = goertzel_power(window, BIT_ONE_HZ);       // 1100.0
+    let mut ranked = [...];
+    ranked.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+    if ranked[0].1 > 5.0 * ranked[1].1 {
+        ranked[0].0
+    } else {
+        Tone::Other
+    }
+}
+```
+
+#### Divergence
+
+Slowrx's tolerance is **relative to the actually-observed leader frequency**: it scans `j = 0..2` candidate leader windows, takes that window's measured frequency as the reference (`tone[0+j]`), and checks all subsequent windows are within ±25 Hz of the offsets that VIS specifies (leader = 0, break = -700, bit 0 = -600, bit 1 = -800). The break bit thus is matched at `[reference - 725, reference - 675]` — *not* at exactly 1200 Hz. This means a radio mistuned by, say, +60 Hz (so 1900 Hz leader appears as 1960 Hz, break as 1260 Hz) is still classified correctly: the reference is 1960, the break window appears at 1260 ≈ 1960 - 700 (within ±25).
+
+Rust's classifier compares against fixed absolute bins at 1900/1200/1100/1300 Hz. A VIS burst from a +60 Hz mistuned radio:
+- Leader at 1960 Hz → Goertzel at 1900 Hz sees a tone ~60 Hz off, well outside `WINDOW_SAMPLES=330`'s frequency resolution (33 Hz/bin). Power at 1900 bin drops to noise level.
+- Break at 1260 Hz → Goertzel at 1200 Hz sees a tone 60 Hz off → similar power drop.
+- The 5× dominance test fails for **every window** → all classify as `Tone::Other` → no VIS detected.
+
+Real radios drift. The 25 Hz tolerance in slowrx is there precisely because typical SSTV radios mistune by tens of Hz. The Rust port lost both the tolerance AND the detection of the offset (Finding 5).
+
+#### Why this might cause the real-audio failure
+
+VERY likely contributor. ARISS is well-known for drift due to Doppler shift on the ISS uplink (~10 kHz/s closing rate at 144-145 MHz = ~3 Hz/s in audio band, but accumulated over a pass is significant — and the ground station's tuner correction may overshoot). Combined with Finding 2 (alignment) this is the most plausible explanation for the 6/7 zero-detection failure pattern.
+
+---
+
+### Finding 4: Luminance clip uses truncation, not rounding
+
+**Severity:** Minor
+**Likely impact on real-audio decoder failure:** No
+**Files:** `common.c:49-53` ↔ `src/mode_pd.rs:23-30`
+
+#### C source
+
+```c
+// Clip to [0..255]
+guchar clip (double a) {
+  if      (a < 0)   return 0;
+  else if (a > 255) return 255;
+  return  (guchar)round(a);
+}
+```
+
+#### Rust source
+
+```rust
+pub(crate) fn freq_to_luminance(freq_hz: f64) -> u8 {
+    let v = (freq_hz - 1500.0) / 3.137_254_9;
+    // Truncation-via-`as` matches slowrx's clip() semantics
+    // (slowrx uses `(unsigned char)a` which truncates the fractional part).
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    let lum = v.clamp(0.0, 255.0) as u8;
+    lum
+}
+```
+
+#### Divergence
+
+The Rust comment is **factually wrong**: slowrx uses `(guchar)round(a)`, which rounds-to-nearest. Rust uses `as u8`, which truncates toward zero. For a value like 127.7, slowrx outputs 128, Rust outputs 127. This applies to luminance and to all three RGB channels in `ycbcr_to_rgb` (where the integer divisions also truncate toward zero — though that's pre-divide truncation, slightly different math).
+
+Worst-case error per pixel is ±1 in luminance, mostly bias-toward-darker. Cumulative effect: image is consistently 0.5 units dimmer on average. Visible if you compare side-by-side; not likely the cause of decode failure.
+
+#### Why this might cause the real-audio failure
+
+No. This is a rounding-error finding, off by one bit per channel. It would not cause a complete-image failure.
+
+---
+
+### Finding 5: HedrShift (radio mistuning offset) is not detected or applied
+
+**Severity:** Critical
+**Likely impact on real-audio decoder failure:** Yes
+**Files:** `vis.c:106` + `video.c:255, 282-326, 397, 406` ↔ `src/vis.rs` (none) + `src/mode_pd.rs:127, 24` (none)
+
+#### C source
+
+```c
+// vis.c:106
+CurrentPic.HedrShift = tone[0+j] - 1900;
+
+// video.c:255 (in GetVideo setup)
+SyncTargetBin = GetBin(1200 + CurrentPic.HedrShift, FFTLen);
+
+// video.c:282 (Praw range)
+for (i=GetBin(1500+CurrentPic.HedrShift,FFTLen); i<=GetBin(2300+CurrentPic.HedrShift, FFTLen); i++)
+
+// video.c:382 (peak search)
+for (n = GetBin(1500 + CurrentPic.HedrShift, FFTLen) - 1; n <= GetBin(2300 + CurrentPic.HedrShift, FFTLen) + 1; n++) {
+
+// video.c:397 (out-of-band fallback)
+Freq = ( (MaxBin > GetBin(1900 + CurrentPic.HedrShift, FFTLen)) ? 2300 : 1500 ) + CurrentPic.HedrShift;
+
+// video.c:406 (luminance scale)
+StoredLum[SampleNum] = clip((Freq - (1500 + CurrentPic.HedrShift)) / 3.1372549);
+```
+
+#### Rust source
+
+```rust
+// mode_pd.rs:127 (peak search hardcoded at 1500-2300 Hz)
+let bin_for = |hz: f64| -> usize {
+    (hz * (FFT_LEN as f64) / f64::from(crate::resample::WORKING_SAMPLE_RATE_HZ)).round()
+        as usize
+};
+let lo = bin_for(1500.0).saturating_sub(1).max(1);
+let hi = bin_for(2300.0).saturating_add(1).min(FFT_LEN / 2 - 1);
+
+// mode_pd.rs:24 (luminance: hardcoded 1500.0 / 3.1372549)
+let v = (freq_hz - 1500.0) / 3.137_254_9;
+```
+
+#### Divergence
+
+Slowrx detects the radio mistuning offset during VIS (the leader was supposed to be 1900 Hz; you measured it at 1900+δ; therefore radio is offset by δ Hz) and applies that offset throughout the entire decode pipeline. Every place that says "1500 Hz" or "2300 Hz" or "1200 Hz" actually means "the corresponding tone, offset by HedrShift".
+
+Rust does not detect HedrShift (it's not a field on any struct, nor returned by `VisDetector`) and uses fixed unshifted bands. Consequence for a radio mistuned by, say, +40 Hz (small for ARISS):
+- Black tone (1500 Hz) becomes 1540 Hz on the air → freq_to_luminance returns `(1540-1500)/3.137 ≈ 12.7` → 12 (instead of 0).
+- White tone (2300 Hz) becomes 2340 Hz → freq_to_luminance returns `(2340-1500)/3.137 ≈ 267.7` → clamped to 255 (correct, but with no headroom).
+
+But more critically: the peak-search range `[1500, 2300]` shifts to actual `[1540, 2340]` on the air. The Rust search is hardcoded to bins for `[1500, 2300]`, so the 2340 Hz tone may fall **just past** the search region (FFT_LEN=256, bin 53.4 = 2300 Hz, bin 54.5 = 2340 Hz; the search includes `bin_for(2300).saturating_add(1)` = bin 54, so 2340 Hz at bin 54.5 is right at the edge). For mistuning > ~50 Hz, white tones drop entirely out of the peak search and get classified as their nearest in-band neighbor.
+
+For HedrShift > ~80 Hz the entire image is unreadable in the Rust port even though slowrx would still recover it perfectly.
+
+Combined with Finding 3, this is the most plausible explanation: ARISS captures with measurable Doppler / radio offset would have HedrShift in the 30-100 Hz range → VIS detection fails (Finding 3) → no decoding path even attempted.
+
+#### Why this might cause the real-audio failure
+
+VERY likely. Even if Findings 2 and 3 are fixed, real captures with non-zero HedrShift will produce dim/dark/wrong-color images because the luminance scale is wrong. This is the kind of bug where 1 of 7 captures with near-zero offset works perfectly and the others fail (or produce garbled output). Pattern matches the observed behavior.
+
+---
+
+### Finding 6: No SNR-adaptive FFT window length
+
+**Severity:** Important
+**Likely impact on real-audio decoder failure:** Yes (low SNR ARISS captures)
+**Files:** `video.c:30, 53-57, 354-367, 374-377` ↔ `src/mode_pd.rs:59, 63-70, 122`
+
+#### C source
+
+```c
+// video.c:30, 53-57
+double Hann[7][1024] = {{0}};
+gushort HannLens[7] = { 48, 64, 96, 128, 256, 512, 1024 };
+for (j = 0; j < 7; j++)
+  for (i = 0; i < HannLens[j]; i++)
+    Hann[j][i] = 0.5 * (1 - cos( (2 * M_PI * i) / (HannLens[j] - 1)) );
+
+// video.c:354-367
+// Adapt window size to SNR
+if      (!Adaptive)  WinIdx = 0;
+else if (SNR >=  20) WinIdx = 0;
+else if (SNR >=  10) WinIdx = 1;
+else if (SNR >=   9) WinIdx = 2;
+else if (SNR >=   3) WinIdx = 3;
+else if (SNR >=  -5) WinIdx = 4;
+else if (SNR >= -10) WinIdx = 5;
+else                 WinIdx = 6;
+
+// Minimum winlength can be doubled for Scottie DX
+if (Mode == SDX && WinIdx < 6) WinIdx++;
+...
+WinLength = HannLens[WinIdx];
+for (i = 0; i < WinLength; i++) fft.in[i] = pcm.Buffer[pcm.WindowPtr + i - WinLength/2] / 32768.0 * Hann[WinIdx][i];
+```
+
+#### Rust source
+
+```rust
+/// FFT length used for per-pixel demod. Matches slowrx's bin spacing:
+/// 256/11025 Hz = 43.07 Hz/bin, equal to slowrx's 1024/44100 Hz.
+pub(crate) const FFT_LEN: usize = 256;
+
+#[allow(clippy::cast_precision_loss)]
+fn hann_window() -> Vec<f32> {
+    (0..FFT_LEN)
+        .map(|i| {
+            let m = (FFT_LEN - 1) as f32;
+            0.5 * (1.0 - (2.0 * std::f32::consts::PI * (i as f32) / m).cos())
+        })
+        .collect()
+}
+```
+
+#### Divergence
+
+Slowrx adapts FFT window length to SNR: short windows (48 samples = ~1.1 ms at 44.1 kHz) for high SNR (better time resolution = sharper edges between pixels), long windows (1024 samples = ~23 ms) for low SNR (better frequency resolution = recover from noise). At -10 dB SNR slowrx uses a 1024-sample window for noise rejection.
+
+Rust uses fixed 256 samples (= ~23 ms at 11.025 kHz, matching slowrx's 1024@44.1kHz **at the floor of slowrx's adaptive range**). The Rust comment "matches slowrx's bin spacing: 256/11025 Hz = 43.07 Hz/bin, equal to slowrx's 1024/44100 Hz" is true but misleading — that equivalence is only with slowrx's *worst-case* (lowest SNR) window choice. In high-SNR conditions slowrx uses a 48-sample window (= 918 Hz/bin at 44.1 kHz) which is much sharper temporally — by a factor of ~21×.
+
+For real radio with widely varying SNR, two issues:
+1. **High-SNR pixels are blurred.** The fixed 23 ms window blurs across multiple PD pixels (PD120 PixelTime = 0.19 ms → 23 ms covers 121 pixels worth of time). Even with the hann window the frequency estimate is the average over those 121 pixels.
+2. **Low-SNR pixels are usable but only because the fixed window happens to be at the slowrx low-SNR setting.** This is actually a (perhaps unintended) good default for real radio — high SNR is rare.
+
+The bigger problem is that **with FFT_LEN=256 every per-pixel FFT covers 23 ms** while pixels are only 0.19 ms apart. Each FFT includes its left and right ~60 neighbors. The Rust code then averages over 121 pixels of frequency content per pixel sample. This is essentially a low-pass filter in image space — fine details are gone.
+
+Wait, let me re-read. The FFT *centers* on the pixel sample. For PD120 (pixel time 0.19 ms = 2.1 samples at 11025 Hz), an FFT_LEN=256 window covers 256 samples = 23.2 ms ≈ 122 PD120 pixels. So adjacent pixels' FFTs overlap by 99.2%. The frequency estimate at pixel x is dominated by content from pixel x-60 to x+60.
+
+#### Why this might cause the real-audio failure
+
+Possibly contributor. A 121-pixel-wide spatial blur means you'd see a *smeared* image, but you'd still see *something* and ImageComplete would still fire. So this isn't the "0 ImageComplete" mechanism — it's a degraded-quality mechanism. **More likely contributes to image quality issues than to total failure**.
+
+---
+
+### Finding 7: No slant correction (sync.c::FindSync not ported)
+
+**Severity:** Important
+**Likely impact on real-audio decoder failure:** Yes (degrades image, maybe mode-detection-fail)
+**Files:** `sync.c:18-133` ↔ none in Rust
+
+#### C source
+
+```c
+double FindSync (guchar Mode, double Rate, int *Skip) {
+  ...
+  // Linear Hough transform (lines 50-69)
+  ...
+  // Adjust sample rate (line 81)
+  Rate += tan(deg2rad(90 - slantAngle)) / LineWidth * Rate;
+  ...
+  // Skip until the start of the line (lines 119-127)
+  s = xmax / 700.0 * ModeSpec[Mode].LineTime - ModeSpec[Mode].SyncTime;
+  if (Mode == S1 || Mode == S2 || Mode == SDX)
+    s = s - ModeSpec[Mode].PixelTime * ModeSpec[Mode].ImgWidth / 2.0
+          + ModeSpec[Mode].PorchTime * 2;
+  *Skip = s * Rate;
+  return (Rate);
+}
+```
+
+```c
+// slowrx.c:144-149
+printf("  FindSync @ %.1f Hz\n",CurrentPic.Rate);
+CurrentPic.Rate = FindSync(CurrentPic.Mode, CurrentPic.Rate, &CurrentPic.Skip);
+// Final image
+printf("  getvideo @ %.1f Hz, Skip %d, HedrShift %+d Hz\n", CurrentPic.Rate, CurrentPic.Skip, CurrentPic.HedrShift);
+GetVideo(CurrentPic.Mode, CurrentPic.Rate, CurrentPic.Skip, TRUE);
+```
+
+#### Rust source
+
+```rust
+// decoder.rs:180-220 (no FindSync; line pair indexing assumes constant cadence)
+loop {
+    let cur_pair = u64::from(*line_pair_index);
+    let cur_off = (cur_pair as f64 * spec.line_seconds * work_rate).round();
+    let next_off =
+        ((cur_pair + 1) as f64 * spec.line_seconds * work_rate).round();
+    let samples_per_pair = (next_off - cur_off) as usize;
+    ...
+    crate::mode_pd::decode_pd_line_pair(*spec, *line_pair_index, &buffer[..needed], image, &mut self.pd_demod);
+    ...
+    buffer.drain(..samples_per_pair);
+    *line_pair_index += 1;
+}
+```
+
+#### Divergence
+
+Slowrx's two-pass decode flow: GetVIS → first GetVideo (sample-rate=44100, skip=0) → FindSync analyzes the captured `HasSync[]` array → adjusts sample rate to cancel the slant + finds the true line-start offset → second GetVideo (rate=adjusted, skip=found, redraw=TRUE) re-reads the cached `StoredLum` at the corrected pixel times.
+
+Rust does only the first pass. If the audio source's sample rate is off by even 0.1% from the assumed 11025 (which is **always true** — sound cards drift, recordings are nominally 16 kHz mono but actually 16001.3 Hz, etc), each line drifts by 0.1% × line_seconds. For PD180 (line_seconds = 0.75424), that's 754 µs/line × 248 lines = 187 ms drift. By line 248 the decoder is sampling 248 lines later than audio actually is — pixels come from where the sync pulse is, not the image data.
+
+Two consequences:
+1. **Slant in the image** — visible diagonal stripes if you look at the output.
+2. **End-of-image runs out of samples**: if drift accumulates past the captured audio length, the decoder's `if buffer.len() < needed { break; }` exits early — meaning **ImageComplete is never emitted**.
+
+This is highly relevant to the failure mode. Real ARISS captures are typically 2-5 minutes long (PD120 image runs ~120s; if the decoder drifts and runs out of audio before line 248, you get 0 ImageComplete events).
+
+#### Why this might cause the real-audio failure
+
+YES — likely contributor. Sample rate mismatch is the canonical cause of "decoder hangs at end of image". For the 1 capture that succeeded, either the recording happened to be sample-perfect, or it had enough trailing audio that even with drift the decoder reached line 496.
+
+---
+
+### Finding 8: No Skip computation (line 0 phase alignment)
+
+**Severity:** Important
+**Likely impact on real-audio decoder failure:** Yes
+**Files:** `sync.c:96-127` + `slowrx.c:115-149` ↔ `src/decoder.rs:127-134`
+
+#### C source
+
+```c
+// sync.c:96-127
+// accumulate a 1-dim array of the position of the sync pulse
+memset(xAcc, 0, sizeof(xAcc[0]) * 700);
+for (y=0; y<ModeSpec[Mode].NumLines; y++) {
+  for (x=0; x<700; x++) { 
+    t = y * ModeSpec[Mode].LineTime + x/700.0 * ModeSpec[Mode].LineTime;
+    xAcc[x] += HasSync[ (int)(t / (13.0/44100) * Rate/44100) ];
+  }
+}
+
+// find falling edge of the sync pulse by 8-point convolution
+for (x=0;x<700-8;x++) {
+  convd = 0;
+  for (int i=0;i<8;i++) convd += xAcc[x+i] * ConvoFilter[i];
+  if (convd > maxconvd) {
+    maxconvd = convd;
+    xmax = x+4;
+  }
+}
+
+if (xmax > 350) xmax -= 350;
+s = xmax / 700.0 * ModeSpec[Mode].LineTime - ModeSpec[Mode].SyncTime;
+*Skip = s * Rate;
+```
+
+#### Rust source
+
+```rust
+// vis.rs::take_residual_buffer + decoder.rs:127-134
+let residual = self.vis.take_residual_buffer();
+self.state = State::Decoding {
+    mode: spec.mode,
+    spec,
+    line_pair_index: 0,
+    image,
+    buffer: residual,
+};
+```
+
+#### Divergence
+
+Slowrx computes a `Skip` in samples = where line 0 actually starts within the captured audio, by 8-point convolutional edge detection on the accumulated sync-pulse position across every line. This handles the case where there's audio between the VIS stop bit and the first sync pulse (radio settling, gap).
+
+Rust assumes the first sample of the residual buffer (post-VIS-stop-bit) is the start of line 0's sync pulse. In `vis.c:169` slowrx explicitly skips 20 ms after the stop bit (`readPcm(20e-3 * 44100); pcm.WindowPtr += 20e-3 * 44100;`). Rust does *not* — it hands raw post-stop residual to the PD decoder.
+
+Combined with PD's expectation that line 0 starts with a 20 ms sync pulse: the Rust decoder reads **VIS stop bit residue + post-stop silence** as the first 20 ms of "line 0 sync." If the residual happened to be 5 ms of stop bit + 15 ms of silence + actual sync starts at 20 ms from buffer head, then PD's chan_starts[0] = sync+porch = 22.08 ms is the `Y(odd)` start — but the actual `Y(odd)` data lives at `~37 ms` from buffer head. The decoder reads 22 ms of audio that's actually part of the radio's pre-sync transient or even silence.
+
+For low-SNR signals where the sync pulse onset is ambiguous, even slowrx's approach has trouble — but the convolution-based localization handles up to ±175 ms of misalignment (`if (xmax > 350) xmax -= 350`).
+
+#### Why this might cause the real-audio failure
+
+YES, this is the second-most-likely smoking gun after Findings 3 and 5. With no Skip computation, every Rust-decoded image starts mid-pixel and the line-pair cadence is offset from real audio by a constant amount — likely tens to hundreds of milliseconds. After PD180's 248 line pairs at ~754 ms each, accumulated misalignment can exceed the captured audio length, returning early without ImageComplete.
+
+---
+
+### Finding 9: VIS post-stop-bit gap not skipped
+
+**Severity:** Important (related to Finding 8)
+**Likely impact on real-audio decoder failure:** Yes
+**Files:** `vis.c:168-170` ↔ `src/vis.rs:135-137` + `src/decoder.rs:127`
+
+#### C source
+
+```c
+// Skip the rest of the stop bit
+readPcm(20e-3 * 44100);
+pcm.WindowPtr += 20e-3 * 44100;
+
+if (VISmap[VIS] != UNKNOWN) return VISmap[VIS];
+```
+
+#### Rust source
+
+```rust
+// vis.rs:135-137
+pub fn take_residual_buffer(&mut self) -> Vec<f32> {
+    std::mem::take(&mut self.buffer)
+}
+
+// decoder.rs:127 (handed straight to State::Decoding)
+let residual = self.vis.take_residual_buffer();
+```
+
+#### Divergence
+
+Slowrx skips an additional 20 ms (= 882 samples at 44.1 kHz, or ~221 samples at 11.025 kHz) after detecting the VIS stop bit. The C comment is "Skip the rest of the stop bit" — meaning whatever fraction of the 30 ms stop bit overlaps the detection window's end is consumed. (In C, the detection window straddles 20 ms of past + 10 ms of future relative to `WindowPtr`, so when the stop bit is detected the read pointer is at the *middle* of the stop bit; an extra 20 ms read positions it past the stop bit's end.)
+
+In Rust, when VIS is detected the boundary-aligned 30 ms stop bit window has just been consumed (drained from buffer), so `take_residual_buffer` returns only the post-stop-bit audio — `vis.rs::process` already drained the stop window. **However**, because Rust uses 30 ms boundary windows, the stop bit detection actually completes at the END of the 30 ms stop window, meaning the residual *is* post-stop-bit audio — no extra skip needed. So far so good.
+
+The catch: slowrx's 20 ms extra-skip handles the boundary-misaligned case where the stop bit didn't end exactly at the window boundary. In real audio there can be 5-50 ms of dead air (radio AGC settling, transmitter timing) between the VIS stop bit and the start of line 0's sync pulse — slowrx absorbs this by relying on FindSync to compute Skip later.
+
+**The actual issue:** Rust hands the residual *as if it starts at line 0's sync pulse*. Without Skip computation (Finding 8), if any audio between stop bit and line 0 exists, it ends up consumed as part of "line 0's sync pulse + porch + Y(odd)." This pushes every pixel reading earlier than the actual audio content, and the misalignment compounds across all 248 line pairs.
+
+#### Why this might cause the real-audio failure
+
+Yes — directly related to Finding 8. Without the 20 ms skip + Skip recovery, line 0 alignment is sample-accurate only for synthetic signals where no inter-burst gap exists.
+
+---
+
+### Finding 10: Sample rate fixed at 11025 — no `Rate` adjustment from FindSync
+
+**Severity:** Important
+**Likely impact on real-audio decoder failure:** Yes
+**Files:** `slowrx.c:73, 145` ↔ `src/decoder.rs:166, 187-189`
+
+#### C source
+
+```c
+// slowrx.c:73
+CurrentPic.Rate = 44100;
+
+// slowrx.c:145
+CurrentPic.Rate = FindSync(CurrentPic.Mode, CurrentPic.Rate, &CurrentPic.Skip);
+```
+
+#### Rust source
+
+```rust
+// decoder.rs:166
+let work_rate = f64::from(crate::resample::WORKING_SAMPLE_RATE_HZ);
+
+// decoder.rs:187-189
+let cur_off = (cur_pair as f64 * spec.line_seconds * work_rate).round();
+let next_off =
+    ((cur_pair + 1) as f64 * spec.line_seconds * work_rate).round();
+```
+
+#### Divergence
+
+Slowrx caches an explicit `Rate` field on `CurrentPic` and FindSync mutates it. The second GetVideo pass uses the corrected rate, recomputing `PixelGrid[].Time = (int)round(Rate * (...))` for every pixel.
+
+Rust uses `WORKING_SAMPLE_RATE_HZ = 11025` as a constant. If the recording's effective rate is different (sound card clock drift, file actually 16000 Hz resampled "to 11025 Hz" with a slight error in the resampler, etc.), there is no way to compensate. The `cur_off`/`next_off` rounded-cumulative-time approach prevents per-pair drift from accumulating, but it cannot correct for an actual rate mismatch.
+
+#### Why this might cause the real-audio failure
+
+Yes — same root as Finding 7 (slant correction). Sample rate mismatches are normal for real audio. C handles them via FindSync; Rust does not.
+
+---
+
+### Finding 11: FFT once per pixel (Rust) vs every 6 samples (C)
+
+**Severity:** Important
+**Likely impact on real-audio decoder failure:** No (image quality, not detection)
+**Files:** `video.c:350-407, 421` ↔ `src/mode_pd.rs:241-247`
+
+#### C source
+
+```c
+// video.c:350
+if (SampleNum % 6 == 0) { // Take FFT every 6 samples
+  PrevFreq = Freq;
+  // ...adapt window, FFT, find peak, interpolate, set Freq...
+} /* endif */
+// Calculate luminency & store for later use
+StoredLum[SampleNum] = clip((Freq - (1500 + CurrentPic.HedrShift)) / 3.1372549);
+
+// video.c:411-421
+if (SampleNum == PixelGrid[PixelIdx].Time) {
+  while (SampleNum == PixelGrid[PixelIdx].Time) {
+    x = PixelGrid[PixelIdx].X;
+    ...
+    Image[x][y][Channel] = StoredLum[SampleNum];
+```
+
+#### Rust source
+
+```rust
+// mode_pd.rs:241-247
+for x in 0..width as usize {
+    let center_sec_rel = (x as f64 + 0.5) * pixel_secs;
+    let center_sample_rel = (center_sec_rel * work_rate).round() as i64;
+    let freq = demod.pixel_freq(&chan_samples, center_sample_rel);
+    channel_buf[x] = freq_to_luminance(freq);
+}
+```
+
+#### Divergence
+
+Slowrx computes FFT every 6 samples (= 7350 Hz analysis rate at 44.1 kHz, or 6 samples = 136 µs). The pipeline is: FFT → instantaneous Freq estimate → `StoredLum[SampleNum] = clip(...)`. The `Freq` variable stays stale between FFTs (only refreshed every 6 samples), so adjacent samples within the 6-sample interval all get the *same* `StoredLum` value. When the `PixelGrid[].Time`s are sampled, they read from this densely-populated `StoredLum` array.
+
+Effect: the per-pixel luminance is the freq estimate from the FFT closest in time to the pixel center, using whatever WinIdx (window length) was active when that FFT ran. The window centers shift with each FFT, so the pixel reads represent a continuous time-domain envelope.
+
+Rust does FFT *only* at pixel centers (one FFT per pixel × width × 4 channels = 2560 FFTs per line pair for PD180). The window CENTERED on each pixel time means `[pixel_center - 128, pixel_center + 128]` samples are analyzed.
+
+For most pixels, the two approaches are equivalent. The difference shows up at:
+- **Channel boundaries**: Rust *isolates* each channel into its own zero-padded slice (line 233-239) so the FFT doesn't see adjacent channel content. Slowrx allows the FFT to leak across channel boundaries — but only for the rightmost ~12 pixels of one channel and leftmost ~12 pixels of the next (PD pixel time 0.19 ms, FFT window 23 ms = 121 PD pixels, but only the half within the FFT window's other side leaks).
+
+Actually, let me re-think. The Rust isolation strategy means at the right edge of a channel, the FFT window has ~half its samples zero-padded. **This destroys the FFT estimate for the rightmost pixels of every channel.** Specifically: the rightmost 60 pixels of every channel have FFT windows that are progressively more zero-padded, biasing the frequency estimate toward DC.
+
+Compare to slowrx: the rightmost pixels of, e.g., the Y(odd) channel see a window that includes the Cr channel's left side. That's ALSO bad — but at least the Cr tone is in the analyzable band (1500-2300 Hz range), so the peak search finds *something*. With zero-padding, the peak search just finds whichever bin has the most spectral leakage from the truncated tone — typically biased toward DC.
+
+#### Why this might cause the real-audio failure
+
+Probably not the primary cause of "no ImageComplete." But this IS a quality issue: rightmost pixels of every channel have systematically wrong values. A 60-pixel-wide stripe of garbage at every channel boundary on every line pair would be visually obvious. Probably contributes to "the decoded image looks weird" but doesn't prevent decoding.
+
+---
+
+### Finding 12: PD line-pair `pixel_seconds` time-base misaligned with cumulative line offsets
+
+**Severity:** Important
+**Likely impact on real-audio decoder failure:** Possibly (subtle drift)
+**Files:** `video.c:140-142` ↔ `src/decoder.rs:181-220, src/mode_pd.rs:225-228`
+
+#### C source
+
+```c
+// video.c:140-142
+PixelGrid[PixelIdx].Time = (int)round(Rate * ( y/2 * ModeSpec[Mode].LineTime + ChanStart[Channel] +
+                                      ModeSpec[Mode].PixelTime * 1.0 * (x + 0.5))) +
+                                      Skip;
+```
+
+#### Rust source
+
+```rust
+// decoder.rs:181-194 (caller cuts the buffer at cumulative-rounded line-pair boundaries)
+let cur_off = (cur_pair as f64 * spec.line_seconds * work_rate).round();
+let next_off =
+    ((cur_pair + 1) as f64 * spec.line_seconds * work_rate).round();
+let samples_per_pair = (next_off - cur_off) as usize;
+let needed = samples_per_pair + lookahead;
+if buffer.len() < needed {
+    break;
+}
+crate::mode_pd::decode_pd_line_pair(
+    *spec,
+    *line_pair_index,
+    &buffer[..needed],
+    image,
+    &mut self.pd_demod,
+);
+buffer.drain(..samples_per_pair);
+
+// mode_pd.rs:225-228 (inside decode_pd_line_pair: each pair starts at relative time 0)
+let chan_start = (start_sec * work_rate).round() as i64;
+let chan_end = (end_sec * work_rate).round() as i64;
+```
+
+#### Divergence
+
+Both compute pixel times the same way globally, but Rust does it in *two stages*: the decoder cuts the audio buffer at cumulative-rounded line-pair boundaries, then the per-line-pair decoder treats time relative to that pair's start as `0`.
+
+Stage-1 rounding: `next_off = ((cur_pair + 1) * line_seconds * sr).round()` and the consumed length is `next_off - cur_off`. If `line_seconds = 0.50848`, `sr = 11025`, then `line_seconds * sr = 5606.09`. So pair 0 is 5606 samples (= round(5606.09)), pair 1 is round(11212.18) - round(5606.09) = 11212 - 5606 = 5606, pair 2 is round(16818.27) - round(11212.18) = 16818 - 11212 = 5606, ... The difference accumulates a 1-sample deviation per ~10 pairs (the comment in decoder.rs:178 says "PD180 drifts ~0.05 samples/pair"). So far OK.
+
+Stage-2 within-pair: each pair's `chan_start = (start_sec * work_rate).round() as i64` where `start_sec = sync + porch + n*width*pixel_secs` — but **anchored at relative-zero**, not at the actual pair start (which differs from relative-zero by a fraction of a sample due to stage-1 rounding).
+
+Effect: each pair has a sub-sample misalignment of up to 0.5 samples between the audio's actual content and the channel boundary. For PD180 with 248 line pairs, this is visually invisible — the channel-isolation slicing dominates (Finding 11) so most pixel samples are correct.
+
+But: the *first pair* (pair 0) starts at buffer index 0 in Rust; in slowrx, line 0 of GetVideo is at SampleNum = 0 too — but slowrx's `SampleNum = 0` corresponds to the audio sample where the post-VIS skip ended (i.e., line 0's sync pulse start). Rust assumes the same — but without Skip computation (Finding 8), line 0's sync pulse may not be at buffer[0] at all.
+
+#### Why this might cause the real-audio failure
+
+This finding alone is minor (sub-sample stage-2 rounding). But combined with Finding 8 (no Skip), the "buffer[0] = line 0 sync start" assumption breaks for any real recording.
+
+---
+
+### Finding 13: `PD` channel start formula uses `ChanStart[1] = ChanStart[0] + ChanLen[0] + SeptrTime` (with SeptrTime=0); Rust hardcodes `+ width*pixel_secs` (no SeptrTime field)
+
+**Severity:** Cosmetic for PD; would break for non-PD-zero-Septr modes
+**Likely impact on real-audio decoder failure:** No
+**Files:** `video.c:88-92` ↔ `src/mode_pd.rs:206-211`
+
+#### C source
+
+```c
+// video.c:88-92
+case PD50:
+case PD90:
+case PD120:
+...
+case PD290:
+  ChanLen[0]   = ChanLen[1] = ChanLen[2] = ChanLen[3] = ModeSpec[Mode].PixelTime * ModeSpec[Mode].ImgWidth;
+  ChanStart[0] = ModeSpec[Mode].SyncTime + ModeSpec[Mode].PorchTime;
+  ChanStart[1] = ChanStart[0] + ChanLen[0] + ModeSpec[Mode].SeptrTime;
+  ChanStart[2] = ChanStart[1] + ChanLen[1] + ModeSpec[Mode].SeptrTime;
+  ChanStart[3] = ChanStart[2] + ChanLen[2] + ModeSpec[Mode].SeptrTime;
+  break;
+```
+
+#### Rust source
+
+```rust
+// mode_pd.rs:206-211
+let chan_starts_sec = [
+    sync_secs + porch_secs,                                       // Y(odd)
+    sync_secs + porch_secs + f64::from(width) * pixel_secs,       // Cr
+    sync_secs + porch_secs + 2.0 * f64::from(width) * pixel_secs, // Cb
+    sync_secs + porch_secs + 3.0 * f64::from(width) * pixel_secs, // Y(even)
+];
+```
+
+#### Divergence
+
+For PD120/PD180, `SeptrTime = 0e-3` per modespec.c, so the channel start formulas are mathematically identical. Rust simply omitted the `SeptrTime` term entirely — there's no `septr_seconds` field on the Rust ModeSpec struct.
+
+For pure correctness this is fine for PD; for V2 modes (Robot, Scottie, Martin) the SeptrTime is non-zero and this approach would break. Right now, no risk.
+
+#### Why this might cause the real-audio failure
+
+No — for PD modes the term is 0.
+
+---
+
+### Finding 14: VIS `R12BW` parity inversion not applied (mode not implemented but the C code special-cases it)
+
+**Severity:** Cosmetic (V1 doesn't implement R12BW)
+**Likely impact on real-audio decoder failure:** No
+**Files:** `vis.c:116` ↔ `src/vis.rs:165-198`
+
+#### C source
+
+```c
+Parity = Bit[0] ^ Bit[1] ^ Bit[2] ^ Bit[3] ^ Bit[4] ^ Bit[5] ^ Bit[6];
+
+if (VISmap[VIS] == R12BW) Parity = !Parity;
+
+if (Parity != ParityBit) {
+  printf("  Parity fail\n");
+  gotvis = FALSE;
+}
+```
+
+#### Rust source
+
+```rust
+fn match_vis_pattern(tones: &[Tone]) -> Option<u8> {
+    ...
+    let mut code = 0u8;
+    let mut parity = 0u8;
+    for (i, tone) in tones[5..12].iter().enumerate() {
+        ...
+        code |= bit << i;
+        parity ^= bit;
+    }
+    ...
+    if parity != parity_bit {
+        return None;
+    }
+    Some(code)
+}
+```
+
+#### Divergence
+
+The C code inverts parity for R12BW (VIS code 0x06). Rust does not. Since R12BW is not implemented in `lookup`, this would never produce a successful decode anyway — but if a future PR adds R12BW without fixing the parity check, this will silently reject all R12BW VIS bursts.
+
+#### Why this might cause the real-audio failure
+
+No — V1 doesn't implement R12BW.
+
+---
+
+### Finding 15: `lookup` returns `None` for `0x00` instead of treating "VIS = 0" as silent-noise (compatibility)
+
+**Severity:** Cosmetic
+**Likely impact on real-audio decoder failure:** No
+**Files:** `vis.c:172-174` ↔ `src/modespec.rs:62-68`
+
+#### C source
+
+```c
+if (VISmap[VIS] != UNKNOWN) return VISmap[VIS];
+else                        printf("  No VIS found\n");
+return 0;
+```
+
+#### Rust source
+
+```rust
+pub fn lookup(vis_code: u8) -> Option<ModeSpec> {
+    match vis_code {
+        0x5F => Some(PD120),
+        0x60 => Some(PD180),
+        _ => None,
+    }
+}
+```
+
+In the decoder:
+```rust
+} else {
+    // Unknown VIS codes silently drop. Reset the
+    // detector's buffer so it does not accumulate
+    // forever on uninterpretable bursts.
+    let _ = self.vis.take_residual_buffer();
+}
+```
+
+#### Divergence
+
+Slowrx's GetVIS returns 0 for unknown codes, and Listen() loops back to `do { ... } while (Mode == 0);`. Rust does the same in spirit.
+
+#### Why this might cause the real-audio failure
+
+No.
+
+---
+
+### Finding 16: VIS bit timing — Rust's per-window-end time vs C's center-of-window time for "WindowPtr"
+
+**Severity:** Minor
+**Likely impact on real-audio decoder failure:** No
+**Files:** `vis.c:48` ↔ `src/vis.rs:97-118`
+
+#### C source
+
+```c
+// fft.in[i] = pcm.Buffer[pcm.WindowPtr + i - 441] / 32768.0 * Hann[i];
+// WindowPtr is at the END of the most recent 10 ms read.
+// The window is [WindowPtr - 441, WindowPtr - 441 + 882) = [WindowPtr - 441, WindowPtr + 441).
+// Effectively: the FFT analyzes 10 ms of past + 10 ms of future relative to WindowPtr.
+```
+
+#### Rust source
+
+```rust
+let window: Vec<f32> = self.buffer.drain(..WINDOW_SAMPLES).collect();
+```
+
+(Window is [drain_start, drain_start + 330) — purely 30 ms of past relative to where the next window starts.)
+
+#### Divergence
+
+C's analysis window is centered (10 ms past + 10 ms future); Rust's is purely past. This means the VIS pattern check uses different timing. C effectively detects the VIS burst after consuming ~half a window's worth more of audio than Rust would (since it can "look ahead" 10 ms).
+
+This is mostly invisible because both analyze a contiguous audio stream. Where it matters: the residual buffer left after detection. C's `pcm.WindowPtr` is at the *middle* of the stop-bit window when detection fires; Rust's `buffer` head is at the *end* of the stop-bit window. So C needs an additional `readPcm(20e-3 * 44100)` to skip past the stop bit; Rust is already past it. This is actually fine.
+
+#### Why this might cause the real-audio failure
+
+No.
+
+---
+
+### Finding 17: The `working_samples_emitted` is computed from resampler output but `vis::DetectedVis::end_sample` reports the input-buffer length, not the working-rate sample where the stop bit ended
+
+**Severity:** Cosmetic (informational field, not used by decoder logic)
+**Likely impact on real-audio decoder failure:** No
+**Files:** `src/vis.rs:113` (referenced from `src/decoder.rs:117-121`)
+
+#### Rust source
+
+```rust
+// vis.rs:113 (using `self.buffer.len()` to subtract back from the running counter)
+let end_sample =
+    total_samples_consumed.saturating_sub(self.buffer.len() as u64);
+self.detected = Some(DetectedVis { code, end_sample });
+```
+
+This is an informational field. The decoder emits it as `VisDetected.sample_offset`. Not used by downstream decoding logic.
+
+#### Why this might cause the real-audio failure
+
+No.
+
+---
+
+### Finding 18: Rust resampler — group delay and FIR transient
+
+**Severity:** Important
+**Likely impact on real-audio decoder failure:** Possibly
+**Files:** `src/resample.rs:91-132` ↔ slowrx (no resampler — fixed 44100)
+
+#### Rust source
+
+```rust
+pub fn process(&mut self, input: &[f32]) -> Vec<f32> {
+    let mut buf = std::mem::take(&mut self.tail);
+    buf.extend_from_slice(input);
+
+    let mut out = Vec::new();
+    let half = (FIR_TAPS as f64) / 2.0;
+    loop {
+        let center = self.phase + half;
+        let needed_end = (center + half).ceil() as usize;
+        if needed_end > buf.len() {
+            break;
+        }
+        ...
+    }
+    ...
+}
+```
+
+#### Divergence
+
+The 64-tap FIR introduces a 32-sample group delay at the working rate. The first 32 working-rate samples emitted from `Resampler::process` are convolutions involving phantom zero samples at the start of the input — effectively a transient. The Rust decoder test `process_emits_vis_detected_for_pd120_burst` adds 512 samples of trailing silence to compensate, which acknowledges this.
+
+Effect on VIS detection: the first ~32 working-rate samples (= ~3 ms) are biased toward zero. For a VIS burst that starts at audio[0], the first 3 ms of the leader is attenuated. This is short relative to the 30 ms VIS window, but combined with Finding 2 (boundary alignment), if the burst-start happens to land on a boundary, that 3 ms attenuation falls inside the first leader window. The Goertzel power for that window drops, possibly below the 5×-dominance threshold.
+
+#### Why this might cause the real-audio failure
+
+Possible. Real captures rarely have the VIS burst start at audio[0] — usually there's seconds of pre-burst audio, so the FIR transient is long absorbed before VIS-relevant content begins. **Probably not the primary cause** but contributes in edge cases.
+
+---
+
+### Finding 19: VIS detector skips real-time analysis after detection (no continuation for next-burst)
+
+**Severity:** Minor
+**Likely impact on real-audio decoder failure:** No (one-image-per-decoder use case)
+**Files:** `vis.c:40-167` (loops forever) ↔ `src/vis.rs:97-117` + `src/decoder.rs:127-141`
+
+#### Rust source
+
+```rust
+// vis.rs:97 — process exits as soon as detected.is_some()
+while self.buffer.len() >= WINDOW_SAMPLES && self.detected.is_none() {
+```
+
+#### Divergence
+
+C's GetVIS loop returns immediately upon detection; the next call re-enters a fresh loop. Rust's structure is the same. The Rust comment about mid-image VIS detection (lines 153-164 of decoder.rs) acknowledges this is deferred. For single-image decode, this matches.
+
+#### Why this might cause the real-audio failure
+
+No.
+
+---
+
+### Finding 20: `decode_pd_line_pair` per-channel zero-padding of the FFT input loses information at channel boundaries
+
+**Severity:** Important
+**Likely impact on real-audio decoder failure:** No (image quality)
+**Files:** `src/mode_pd.rs:230-247`
+
+#### Rust source
+
+```rust
+let chan_len = (chan_end - chan_start).max(0) as usize;
+let mut chan_samples = vec![0.0_f32; chan_len];
+for (i, dst) in chan_samples.iter_mut().enumerate() {
+    let src_idx = chan_start + i as i64;
+    if src_idx >= 0 && (src_idx as usize) < window.len() {
+        *dst = window[src_idx as usize];
+    }
+}
+
+for x in 0..width as usize {
+    let center_sec_rel = (x as f64 + 0.5) * pixel_secs;
+    let center_sample_rel = (center_sec_rel * work_rate).round() as i64;
+    let freq = demod.pixel_freq(&chan_samples, center_sample_rel);
+    channel_buf[x] = freq_to_luminance(freq);
+}
+```
+
+#### Divergence
+
+For PD120, `chan_len = round(640 * 0.19e-3 * 11025) = round(1340.4) = 1340 samples`. Each channel's audio slice is 1340 samples. The FFT_LEN is 256, centered on `(x + 0.5) * 0.19e-3 * 11025 = 2.094 * (x + 0.5)` — so for x=0, center is sample ~1; for x=639, center is sample ~1339.
+
+For x=0 (center=~1), the FFT window is `[1 - 128, 1 + 128) = [-127, 129)`. **127 of those samples are zero** (left of buffer start). Rust's FFT sees 127 zero samples + 129 actual samples — a massively zero-padded signal. The FFT power spectrum is dominated by the boxcar shape of the zero-padded gap, biasing the peak toward DC.
+
+Same effect at x=639 (center=~1339): window is `[1339-128, 1339+128) = [1211, 1467)`. Samples 1340..1467 are out-of-bounds → 127 zero samples on the right.
+
+So the leftmost ~60 and rightmost ~60 pixels of every channel have unreliable frequency estimates due to zero-padding. That's 120 of every 640 pixels per channel × 4 channels per pair = bad pixel count = 480 / 2560 ≈ 19% of every line pair has unreliable values.
+
+Slowrx avoids this by NOT isolating channels — each FFT sees ~128 samples to each side of the pixel center, including content from adjacent channels. This is technically wrong (cross-channel leakage), but the result is "use the dominant tone in the band" which still finds the correct video tone; with isolation Rust gets "the dominant tone of a heavily-zero-padded signal" which biases toward DC.
+
+#### Why this might cause the real-audio failure
+
+No, but a major image quality contributor. Visible as ~10% wide stripes of garbage at left/right of every channel = 4 vertical noise stripes per line pair. Would not prevent ImageComplete from firing.
+
+---
+
+### Finding 21: PD `decode_pd_line_pair` window passed as `&buffer[..needed]` may not extend far enough for last-pixel FFT
+
+**Severity:** Minor
+**Likely impact on real-audio decoder failure:** No
+**Files:** `src/decoder.rs:170, 192, 199-205`
+
+#### Rust source
+
+```rust
+let lookahead = crate::mode_pd::FFT_LEN / 2;
+...
+let needed = samples_per_pair + lookahead;
+if buffer.len() < needed {
+    break;
+}
+...
+crate::mode_pd::decode_pd_line_pair(
+    *spec,
+    *line_pair_index,
+    &buffer[..needed],
+    image,
+    &mut self.pd_demod,
+);
+```
+
+#### Divergence
+
+The decoder requests `samples_per_pair + FFT_LEN/2` samples to allow the last-pixel FFT to extend right of the line-pair end. But `decode_pd_line_pair` then slices each channel's content — for the Y(even) channel (last channel of the pair), `chan_end = (sync + porch + 4*width*pixel) * sr`. For PD180: `(0.020 + 0.00208 + 4*640*0.000286) * 11025 = (0.022 + 0.7322) * 11025 = 0.75424 * 11025 = 8316` samples. samples_per_pair = round(0.75424 * 11025) = 8316 too. So chan_end = samples_per_pair, meaning the FFT for the last pixel of Y(even) would want samples up to chan_end + FFT_LEN/2 = 8444, but the window is only `[..8316 + 128] = [..8444]` ... so just barely in bounds.
+
+But **mode_pd does not pass a window with that lookahead to the per-channel slice** — it just slices `[chan_start..chan_end]` (lines 232-239), throwing away any lookahead samples that the decoder bothered to pass in. So the last pixel of Y(even) gets zero-padded on the right (Finding 20's mechanism). The `lookahead` value computed in decoder.rs is **dead code** in `decode_pd_line_pair`'s actual analysis.
+
+#### Why this might cause the real-audio failure
+
+No — but it's dead code that suggests the original author intended to provide lookahead and forgot to wire it through.
+
+---
+
+### Finding 22: The `working_samples_emitted` counter is never decremented on `take_residual_buffer`
+
+**Severity:** Cosmetic
+**Likely impact on real-audio decoder failure:** No
+**Files:** `src/decoder.rs:104-107, 127`
+
+#### Rust source
+
+```rust
+self.samples_processed = self.samples_processed.saturating_add(audio.len() as u64);
+self.working_samples_emitted = self
+    .working_samples_emitted
+    .saturating_add(working.len() as u64);
+...
+let residual = self.vis.take_residual_buffer();
+```
+
+The counter does not subtract residual length when transferred to State::Decoding. Cosmetic — counter is informational only.
+
+---
+
+### Finding 23: `tones.remove(0)` is O(n) per window — minor but not material
+
+**Severity:** Cosmetic
+**Likely impact on real-audio decoder failure:** No
+**Files:** `src/vis.rs:101-103`
+
+```rust
+self.tones.push(tone);
+if self.tones.len() > 14 {
+    self.tones.remove(0);
+}
+```
+
+`Vec::remove(0)` shifts all 13 remaining elements. Trivial for 14-element vec. Use `VecDeque` for clarity. Cosmetic.
+
+---
+
+## Section 4 — Severity-ranked summary
+
+1. **[Critical]** Finding 5 — HedrShift (radio mistuning offset) is not detected or applied. Real radios drift by tens of Hz; without HedrShift, both VIS detection and per-pixel luminance scaling are broken.
+2. **[Critical]** Finding 3 — VIS classification uses absolute (not relative) frequency tolerance. A radio off by 50 Hz fails to match VIS bits at all → no detection.
+3. **[Critical]** Finding 2 — VIS windows do not overlap (no 10 ms hop). Real audio is not 30 ms boundary-aligned with the burst → bit windows straddle two adjacent bits → all classify as `Tone::Other` → no detection.
+4. **[Important]** Finding 7 — No slant correction. Sample rate drift accumulates; PD180's 248 line pairs may run out of audio before ImageComplete fires.
+5. **[Important]** Finding 8 — No Skip computation (line 0 phase alignment). The residual buffer's first sample is assumed to be the start of line 0's sync pulse, which is never true for real audio with any post-VIS settling time.
+6. **[Important]** Finding 10 — Sample rate fixed at 11025; no `Rate` adjustment from FindSync. Same root cause as Finding 7.
+7. **[Important]** Finding 9 — VIS post-stop-bit gap not skipped. Related to Finding 8.
+8. **[Important]** Finding 6 — No SNR-adaptive FFT window. Fixed 256 = 23 ms covers ~120 PD120 pixels of audio per FFT, blurring image detail.
+9. **[Important]** Finding 1 — VIS detection has no Hann window. Spectral leakage at boxcar -13 dB sidelobes vs Hann -32 dB. Lowers detection robustness in noisy audio.
+10. **[Important]** Finding 11 — FFT once per pixel (Rust) vs every 6 samples (C). Combined with Finding 20 (channel isolation) creates wide stripes of garbage at channel edges.
+11. **[Important]** Finding 20 — Per-channel zero-padding of FFT input loses information at channel boundaries. ~19% of pixels per line pair have unreliable estimates.
+12. **[Important]** Finding 18 — Rust resampler group delay / FIR transient. Edge case for VIS bursts at start of audio.
+13. **[Important]** Finding 12 — Stage-2 within-pair sub-sample misalignment. Minor on its own; compounds with Finding 8.
+14. **[Minor]** Finding 4 — `clip` uses truncation instead of round-to-nearest. ±1 LSB error per pixel.
+15. **[Minor]** Finding 16 — VIS WindowPtr semantics differ (center vs end). Functional difference is absorbed by the residual-buffer handling.
+16. **[Minor]** Finding 13 — `chan_starts_sec` lacks `septr_seconds` term (zero for PD; would break Robot/Scottie).
+17. **[Minor]** Finding 19 — VIS detector exits on first detection (matches C; fine).
+18. **[Minor]** Finding 21 — `decode_pd_line_pair` ignores the lookahead samples the decoder provides.
+19. **[Cosmetic]** Finding 14 — R12BW parity inversion not present (mode not implemented anyway).
+20. **[Cosmetic]** Finding 15 — `lookup` returns None for unknown codes (matches C semantics).
+21. **[Cosmetic]** Finding 17 — `working_samples_emitted` not decremented on residual transfer.
+22. **[Cosmetic]** Finding 22 — `working_samples_emitted` counter not decremented on take_residual.
+23. **[Cosmetic]** Finding 23 — `tones.remove(0)` is O(n) per window (n=14).
+
+---
+
+## Section 5 — What you DIDN'T find
+
+Things I expected to be divergences but were actually clean:
+
+- **YCbCr→RGB matrix coefficients** (`100/140/-17850`, `100/-71/-33/13260`, `100/178/-22695`) match slowrx's `video.c:447-450` exactly. The unit tests `ycbcr_neutral_grey_is_grey` / `ycbcr_pure_red` validate the matrix.
+- **Luminance scale slope** (`3.137_254_9 = (2300 - 1500) / 255`) matches slowrx's hardcoded `3.1372549`.
+- **PD channel order** (Y(odd) → Cr → Cb → Y(even)) matches slowrx exactly.
+- **PD120 / PD180 timing constants** (`SyncTime`, `PorchTime`, `PixelTime`, `LineTime`) match slowrx row-for-row.
+- **Gaussian peak interpolation formula** (`MaxBin + log(P[k+1]/P[k-1]) / (2*log(P[k]^2 / (P[k+1]*P[k-1])))`) matches slowrx's `video.c:391-394`.
+- **VIS LSB-first bit ordering** (Rust: `code |= bit << i`; C: `Bit[0] + (Bit[1]<<1) + ...`) matches.
+- **Even-parity convention** (XOR of all 7 data bits = parity bit) matches.
+- **PD120 / PD180 VIS codes** (0x5F / 0x60) match.
+- **Hann window formula** (`0.5 * (1 - cos(2π*i/(N-1)))`) matches slowrx in `mode_pd::hann_window` (though VIS lacks Hann entirely — Finding 1).
+- **PD even-line/odd-line image row mapping** (pair_index*2, pair_index*2+1) matches the C `(y, y+1)` convention.
+
+What I noticed but didn't dig into deeper:
+
+- The `match_vis_pattern` accepts any window where `tones[5..12]` are all `BitZero` or `BitOne`, but does not enforce a tone *change* between bits. A 7-bit pattern of all `BitZero` (which represents VIS code 0x00) would be accepted. C accepts 0x00 too (VISmap[0]=0=UNKNOWN, which Listen() loops on). So this is identical behavior — but a noisy-decoder-stuck-at-1300-Hz scenario could falsely "succeed" at parity check, matching C's behavior. Probably fine.
+- I did not verify the sign of slowrx's HedrShift application beyond the literal `(1500 + HedrShift)` in `video.c:406`. I'm assuming positive HedrShift means "radio is tuned high", which matches the leader observation `tone[0+j] - 1900` where tone > 1900 → HedrShift > 0.
+- I did not deeply audit the resample.rs FIR coefficient correctness — the tests verify tones survive at expected frequencies, which is a sufficient sanity check for the audit.
+- I did not verify the `take_residual_buffer` interaction with state-machine resets in detail.
+
+---
+
+**Conclusion (informational, not a fix proposal):** the leading candidates for the 6/7 real-audio failure are Findings 2, 3, and 5 — all VIS-detection-side. The pattern of "0 ImageComplete events" (rather than "1 partial decode") strongly implies the decoder is not entering the Decoding state at all, which is consistent with VIS detection failing due to non-boundary-aligned bursts (Finding 2) on radios with non-zero HedrShift (Findings 3 and 5). Fixing those should be the first investigation. Findings 7 / 8 / 10 (slant + Skip + rate) become relevant only after VIS detection is fixed, but they would explain why even *clean* captures fail to reach ImageComplete on long modes (PD180).
+
+Total findings: 23 across all 7 source files. Critical: 3. Important: 10. Minor: 5. Cosmetic: 5.

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -23,6 +23,13 @@ pub enum SstvEvent {
         /// Working-rate (11025 Hz) sample offset where the VIS stop bit ended.
         /// Useful for callers that want to align audio captures with decoder events.
         sample_offset: u64,
+        /// Radio mistuning offset in Hz: `observed_leader_hz - 1900`. The
+        /// decoder applies this offset internally to per-pixel demod so the
+        /// downstream pixel band shifts with the radio's tuning. Surfaced
+        /// here purely for caller diagnostics; consumers do not need to do
+        /// anything with it. Translated from slowrx's `CurrentPic.HedrShift`
+        /// (`vis.c` line 106 → `video.c` line 406).
+        hedr_shift_hz: f64,
     },
     /// One scan line completed (callers may render incrementally).
     LineDecoded {
@@ -57,6 +64,9 @@ enum State {
         image: SstvImage,
         /// Buffered working-rate samples not yet consumed by per-pixel decode.
         buffer: Vec<f32>,
+        /// Radio mistuning offset in Hz extracted at VIS time. Plumbed to
+        /// per-pixel demod so the pixel band shifts with radio tuning.
+        hedr_shift_hz: f64,
     },
 }
 
@@ -118,6 +128,7 @@ impl SstvDecoder {
                             out.push(SstvEvent::VisDetected {
                                 mode: spec.mode,
                                 sample_offset: detected.end_sample,
+                                hedr_shift_hz: detected.hedr_shift_hz,
                             });
                             let image =
                                 SstvImage::new(spec.mode, spec.line_pixels, spec.image_lines);
@@ -131,6 +142,7 @@ impl SstvDecoder {
                                 line_pair_index: 0,
                                 image,
                                 buffer: residual,
+                                hedr_shift_hz: detected.hedr_shift_hz,
                             };
                             continue; // re-enter loop to process leftover audio
                         }
@@ -147,6 +159,7 @@ impl SstvDecoder {
                     line_pair_index,
                     image,
                     buffer,
+                    hedr_shift_hz,
                 } => {
                     buffer.extend_from_slice(remaining);
 
@@ -202,6 +215,7 @@ impl SstvDecoder {
                             &buffer[..needed],
                             image,
                             &mut self.pd_demod,
+                            *hedr_shift_hz,
                         );
 
                         let row0 = *line_pair_index * 2;
@@ -364,16 +378,21 @@ mod tests {
         let mut burst = synth_vis(0x5F, 0.0);
         burst.extend(std::iter::repeat_n(0.0_f32, 512));
         let events = d.process(&burst);
-        let any_vis = events.iter().any(|e| {
-            matches!(
-                e,
+        let hedr = events
+            .iter()
+            .find_map(|e| match e {
                 SstvEvent::VisDetected {
                     mode: SstvMode::Pd120,
+                    hedr_shift_hz,
                     ..
-                }
-            )
-        });
-        assert!(any_vis, "expected VisDetected for PD120, got {events:?}");
+                } => Some(*hedr_shift_hz),
+                _ => None,
+            })
+            .expect("expected VisDetected for PD120");
+        assert!(
+            hedr.abs() < 10.0,
+            "synthetic burst should report ~0 Hz shift, got {hedr}"
+        );
     }
 
     #[test]
@@ -383,13 +402,18 @@ mod tests {
         let mut burst = synth_vis(0x60, 0.0);
         burst.extend(std::iter::repeat_n(0.0_f32, 512));
         let events = d.process(&burst);
-        assert!(events.iter().any(|e| matches!(
-            e,
-            SstvEvent::VisDetected {
-                mode: SstvMode::Pd180,
-                ..
-            }
-        )));
+        let hedr = events
+            .iter()
+            .find_map(|e| match e {
+                SstvEvent::VisDetected {
+                    mode: SstvMode::Pd180,
+                    hedr_shift_hz,
+                    ..
+                } => Some(*hedr_shift_hz),
+                _ => None,
+            })
+            .expect("expected VisDetected for PD180");
+        assert!(hedr.abs() < 10.0);
     }
 
     #[test]

--- a/src/mode_pd.rs
+++ b/src/mode_pd.rs
@@ -14,14 +14,16 @@ use rustfft::{num_complex::Complex, FftPlanner};
 ///
 /// SSTV video lives in 1500–2300 Hz: 1500 Hz = black (0), 2300 Hz = white (255).
 /// Linear scaling: `lum = (freq - 1500) / (2300 - 1500) * 255`.
-/// Out-of-band frequencies are clamped.
+/// Out-of-band frequencies are clamped. `hedr_shift_hz` shifts the band
+/// to compensate for radio mistuning detected at VIS time:
+/// `lum = (freq - 1500 - hedr_shift_hz) / 3.1372549`.
 ///
 /// Translated from slowrx's `video.c:406`:
-/// `StoredLum[SampleNum] = clip((Freq - 1500) / 3.1372549);`
+/// `StoredLum[SampleNum] = clip((Freq - 1500 - HedrShift) / 3.1372549);`
 /// where `3.1372549 = (2300 - 1500) / 255`.
 #[must_use]
-pub(crate) fn freq_to_luminance(freq_hz: f64) -> u8 {
-    let v = (freq_hz - 1500.0) / 3.137_254_9;
+pub(crate) fn freq_to_luminance(freq_hz: f64, hedr_shift_hz: f64) -> u8 {
+    let v = (freq_hz - 1500.0 - hedr_shift_hz) / 3.137_254_9;
     // Truncation-via-`as` matches slowrx's clip() semantics
     // (slowrx uses `(unsigned char)a` which truncates the fractional part).
     #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
@@ -96,6 +98,11 @@ impl PdDemod {
     /// window is `audio[center_sample - FFT_LEN/2 .. center_sample + FFT_LEN/2]`,
     /// clamped at audio boundaries.
     ///
+    /// `hedr_shift_hz` shifts the peak-search range from 1500..2300 Hz to
+    /// `(1500 + hedr_shift) .. (2300 + hedr_shift)` so a mistuned radio's
+    /// pixel band lines up with the search window. Translated from slowrx
+    /// `video.c:382` where the search starts at `GetBin(1500 + HedrShift)`.
+    ///
     /// Returns the estimated frequency in Hz. Uses Gaussian-log peak
     /// interpolation matching slowrx `video.c:391-394`.
     #[allow(
@@ -104,7 +111,7 @@ impl PdDemod {
         clippy::cast_sign_loss,
         clippy::cast_possible_wrap
     )]
-    pub fn pixel_freq(&mut self, audio: &[f32], center_sample: i64) -> f64 {
+    pub fn pixel_freq(&mut self, audio: &[f32], center_sample: i64, hedr_shift_hz: f64) -> f64 {
         // Fill the reusable buffer in-place — avoids a per-call Vec allocation.
         let half = (FFT_LEN as i64) / 2;
         for i in 0..FFT_LEN {
@@ -123,13 +130,15 @@ impl PdDemod {
         self.fft
             .process_with_scratch(&mut self.fft_buf, &mut self.scratch[..]);
 
-        // Search peak in bins corresponding to 1500..2300 Hz.
+        // Search peak in bins corresponding to (1500+HedrShift)..(2300+HedrShift) Hz.
         let bin_for = |hz: f64| -> usize {
             (hz * (FFT_LEN as f64) / f64::from(crate::resample::WORKING_SAMPLE_RATE_HZ)).round()
                 as usize
         };
-        let lo = bin_for(1500.0).saturating_sub(1).max(1);
-        let hi = bin_for(2300.0).saturating_add(1).min(FFT_LEN / 2 - 1);
+        let lo = bin_for(1500.0 + hedr_shift_hz).saturating_sub(1).max(1);
+        let hi = bin_for(2300.0 + hedr_shift_hz)
+            .saturating_add(1)
+            .min(FFT_LEN / 2 - 1);
 
         let power = |c: Complex<f32>| -> f64 {
             let r = f64::from(c.re);
@@ -194,6 +203,7 @@ pub(crate) fn decode_pd_line_pair(
     window: &[f32],
     image: &mut crate::image::SstvImage,
     demod: &mut PdDemod,
+    hedr_shift_hz: f64,
 ) {
     let work_rate = f64::from(crate::resample::WORKING_SAMPLE_RATE_HZ);
     let sync_secs = spec.sync_seconds;
@@ -242,8 +252,8 @@ pub(crate) fn decode_pd_line_pair(
             // Center sample relative to the channel slice.
             let center_sec_rel = (x as f64 + 0.5) * pixel_secs;
             let center_sample_rel = (center_sec_rel * work_rate).round() as i64;
-            let freq = demod.pixel_freq(&chan_samples, center_sample_rel);
-            channel_buf[x] = freq_to_luminance(freq);
+            let freq = demod.pixel_freq(&chan_samples, center_sample_rel, hedr_shift_hz);
+            channel_buf[x] = freq_to_luminance(freq, hedr_shift_hz);
         }
     }
 
@@ -398,32 +408,49 @@ mod tests {
 
     #[test]
     fn freq_1500_is_black() {
-        assert_eq!(freq_to_luminance(1500.0), 0);
+        assert_eq!(freq_to_luminance(1500.0, 0.0), 0);
     }
 
     #[test]
     fn freq_2300_is_white() {
-        assert_eq!(freq_to_luminance(2300.0), 255);
+        assert_eq!(freq_to_luminance(2300.0, 0.0), 255);
     }
 
     #[test]
     fn freq_below_band_clamps_to_zero() {
-        assert_eq!(freq_to_luminance(1000.0), 0);
-        assert_eq!(freq_to_luminance(0.0), 0);
+        assert_eq!(freq_to_luminance(1000.0, 0.0), 0);
+        assert_eq!(freq_to_luminance(0.0, 0.0), 0);
     }
 
     #[test]
     fn freq_above_band_clamps_to_max() {
-        assert_eq!(freq_to_luminance(3000.0), 255);
+        assert_eq!(freq_to_luminance(3000.0, 0.0), 255);
     }
 
     #[test]
     fn freq_midband_is_midgrey() {
         // 1900 Hz is exactly halfway → ~127.5 → 127 after truncation
-        let v = freq_to_luminance(1900.0);
+        let v = freq_to_luminance(1900.0, 0.0);
         assert!(
             (i32::from(v) - 127).abs() <= 1,
             "midband should be ~127, got {v}"
+        );
+    }
+
+    #[test]
+    fn freq_to_luminance_with_hedr_shift_scales_band() {
+        // With +50 Hz HedrShift, the band shifts to 1550..2350.
+        // freq=1550 should be black, freq=2350 should be white.
+        assert_eq!(freq_to_luminance(1550.0, 50.0), 0);
+        assert_eq!(freq_to_luminance(2350.0, 50.0), 255);
+        // 1500 (would be black at zero shift) is now sub-band, still clamps to 0.
+        assert_eq!(freq_to_luminance(1500.0, 50.0), 0);
+        // 1950 with +50 shift is the new midband ≈ same as 1900 with 0 shift.
+        let a = freq_to_luminance(1950.0, 50.0);
+        let b = freq_to_luminance(1900.0, 0.0);
+        assert!(
+            i32::from(a).abs_diff(i32::from(b)) <= 1,
+            "shifted midband {a} vs unshifted {b}"
         );
     }
 
@@ -466,7 +493,7 @@ mod tests {
         // 100 ms of pure tone at 1900 Hz; ample for FFT_LEN=256.
         let audio = synth_tone(1900.0, 0.100);
         let center = (audio.len() / 2) as i64;
-        let est = d.pixel_freq(&audio, center);
+        let est = d.pixel_freq(&audio, center, 0.0);
         assert!((est - 1900.0).abs() < 5.0, "expected ≈1900, got {est}");
     }
 
@@ -476,7 +503,7 @@ mod tests {
         for &f in &[1500.0_f64, 1700.0, 2100.0, 2300.0] {
             let audio = synth_tone(f, 0.100);
             let center = (audio.len() / 2) as i64;
-            let est = d.pixel_freq(&audio, center);
+            let est = d.pixel_freq(&audio, center, 0.0);
             assert!(
                 (est - f).abs() < 8.0,
                 "f={f} estimate={est} (band edge precision)"
@@ -488,11 +515,35 @@ mod tests {
     fn pdfft_returns_finite_for_silence() {
         let mut d = PdDemod::new();
         let audio = vec![0.0_f32; 1024];
-        let est = d.pixel_freq(&audio, 512);
+        let est = d.pixel_freq(&audio, 512, 0.0);
         assert!(est.is_finite(), "got {est}");
         // Silence has no peak; the search expands by ±1 bin around the
         // 1500-2300 band, and bin width is ~43 Hz, so the fallback may
         // land within ~50 Hz of either edge.
         assert!((1450.0..=2350.0).contains(&est), "out of band: {est}");
+    }
+
+    #[test]
+    fn pixel_freq_with_hedr_shift() {
+        // A 1950 Hz tone with hedr_shift=+50 should yield the same luminance
+        // as a 1900 Hz tone with hedr_shift=0, since the search band shifts.
+        let mut d = PdDemod::new();
+        let audio = synth_tone(1950.0, 0.100);
+        let center = (audio.len() / 2) as i64;
+        let est_shifted = d.pixel_freq(&audio, center, 50.0);
+        let est_unshifted_baseline = {
+            let baseline = synth_tone(1900.0, 0.100);
+            d.pixel_freq(&baseline, (baseline.len() / 2) as i64, 0.0)
+        };
+        // Tone-frequency itself is recovered correctly; what matters is that
+        // the shifted estimator finds 1950, the unshifted finds 1900, and
+        // mapping each to luminance gives ≈ same value.
+        assert!((est_shifted - 1950.0).abs() < 5.0, "got {est_shifted}");
+        let lum_shifted = freq_to_luminance(est_shifted, 50.0);
+        let lum_unshifted = freq_to_luminance(est_unshifted_baseline, 0.0);
+        assert!(
+            i32::from(lum_shifted).abs_diff(i32::from(lum_unshifted)) <= 2,
+            "lum_shifted={lum_shifted} lum_unshifted={lum_unshifted}"
+        );
     }
 }

--- a/src/vis.rs
+++ b/src/vis.rs
@@ -1,36 +1,364 @@
 //! VIS (Vertical Interval Signaling) header detection.
 //!
-//! Translated in spirit from slowrx's `vis.c` (Oona Räisänen, ISC License).
-//! See `NOTICE.md` for full attribution. We replace slowrx's 2048-point FFT
-//! plus Gaussian-interpolated peak finder with four Goertzel filters tuned
-//! at the four tone frequencies that actually matter for VIS detection
-//! (1900 / 1200 / 1100 / 1300 Hz). The result is mathematically equivalent
-//! for VIS purposes and dramatically simpler to test in isolation.
+//! Faithful translation of slowrx's `vis.c` (Oona Räisänen, ISC License) —
+//! see `NOTICE.md`. A 10 ms-hop sliding window with 20 ms Hann-weighted
+//! audio feeds a 512-FFT (zero-padded for spectral interpolation),
+//! peak-find in 500-3300 Hz, Gaussian-log peak interpolation. The
+//! resulting frequencies feed a 45-entry sliding history; the matcher
+//! tries 9 alignments (i × j, 3 phases × 3 leader candidates) using
+//! **relative** ±25 Hz tolerance from the observed leader. On match,
+//! `HedrShift = leader_observed - 1900` is plumbed through to the
+//! per-pixel demod for radio-mistuning compensation.
+//!
+//! Sizes scale by 1/4 from slowrx's 44.1 kHz to our 11.025 kHz
+//! ([`HOP_SAMPLES`], [`WINDOW_SAMPLES`], [`FFT_LEN`]); [`HISTORY_LEN`]
+//! stays 45 (450 ms). `FFT_LEN=512` gives 21.5 Hz/bin like slowrx's 2048/44100.
+
+use rustfft::{num_complex::Complex, FftPlanner};
+use std::sync::Arc;
 
 use crate::resample::WORKING_SAMPLE_RATE_HZ;
 
-/// VIS leader / sync tones in Hz.
+// Tone frequencies relative to the observed leader (slowrx vis.c).
 pub(crate) const LEADER_HZ: f64 = 1900.0;
-pub(crate) const BREAK_HZ: f64 = 1200.0;
-pub(crate) const BIT_ZERO_HZ: f64 = 1300.0;
-pub(crate) const BIT_ONE_HZ: f64 = 1100.0;
+pub(crate) const BREAK_HZ_OFFSET: f64 = -700.0; // 1200 - 1900
+pub(crate) const BIT_ZERO_OFFSET: f64 = -600.0; // 1300 - 1900
+pub(crate) const BIT_ONE_OFFSET: f64 = -800.0; // 1100 - 1900
+pub(crate) const TONE_TOLERANCE_HZ: f64 = 25.0; // ±25 Hz
 
-/// Power output of a single Goertzel filter run on an input window.
-///
-/// Returns the bin power (proportional to amplitude squared).
-/// `target_hz` is the frequency to match; `samples` is the input
-/// window at the working sample rate ([`WORKING_SAMPLE_RATE_HZ`]).
+#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+pub(crate) const HOP_SAMPLES: usize = (0.010 * WORKING_SAMPLE_RATE_HZ as f64) as usize;
+#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+pub(crate) const WINDOW_SAMPLES: usize = (0.020 * WORKING_SAMPLE_RATE_HZ as f64) as usize;
+pub(crate) const FFT_LEN: usize = 512;
+pub(crate) const HISTORY_LEN: usize = 45; // slowrx HedrBuf size
+
+const SEARCH_LO_HZ: f64 = 500.0;
+const SEARCH_HI_HZ: f64 = 3300.0;
+
+/// VIS detection state machine at the [`WORKING_SAMPLE_RATE_HZ`] working rate.
+pub(crate) struct VisDetector {
+    fft: Arc<dyn rustfft::Fft<f32>>,
+    hann: Vec<f32>,
+    fft_buf: Vec<Complex<f32>>,
+    scratch: Vec<Complex<f32>>,
+    /// Audio samples since `audio_origin_sample`.
+    audio_buffer: Vec<f32>,
+    /// Working-rate sample index of `audio_buffer[0]`.
+    audio_origin_sample: u64,
+    /// 45-entry circular frequency history (Hz) — slowrx's `HedrBuf`.
+    history: [f64; HISTORY_LEN],
+    /// Ring-buffer write position (slowrx's `HedrPtr`).
+    history_ptr: usize,
+    /// Hops recorded so far, capped at `HISTORY_LEN` — gates pattern matching.
+    history_filled: usize,
+    /// Hops FFT'd; combined with `audio_origin_sample` it locates each window.
+    hops_completed: u64,
+    detected: Option<DetectedVis>,
+}
+
+/// Result of a successful VIS detection.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(crate) struct DetectedVis {
+    /// 7-bit VIS code (LSB-first).
+    pub code: u8,
+    /// Radio mistuning offset in Hz: `observed_leader - 1900`. The caller
+    /// plumbs this through to per-pixel demod for accurate pixel-frequency
+    /// mapping (slowrx vis.c line 106 → video.c line 406).
+    pub hedr_shift_hz: f64,
+    /// Working-rate sample index where the VIS stop-bit window ended.
+    pub end_sample: u64,
+}
+
+impl VisDetector {
+    /// Construct a fresh VIS detector. Allocates the FFT plan + reusable
+    /// buffers; reuse across many `process` calls.
+    pub fn new() -> Self {
+        let mut planner = FftPlanner::<f32>::new();
+        let fft = planner.plan_fft_forward(FFT_LEN);
+        let scratch_len = fft.get_inplace_scratch_len();
+        Self {
+            fft,
+            hann: build_hann_window(WINDOW_SAMPLES),
+            fft_buf: vec![Complex { re: 0.0, im: 0.0 }; FFT_LEN],
+            scratch: vec![Complex { re: 0.0, im: 0.0 }; scratch_len.max(FFT_LEN)],
+            audio_buffer: Vec::with_capacity(WINDOW_SAMPLES * 4),
+            audio_origin_sample: 0,
+            history: [0.0; HISTORY_LEN],
+            history_ptr: 0,
+            history_filled: 0,
+            hops_completed: 0,
+            detected: None,
+        }
+    }
+
+    /// Push working-rate audio into the detector. `total_samples_consumed`
+    /// is the running sample count *after* this chunk was added — used to
+    /// resolve every hop's absolute sample index.
+    pub fn process(&mut self, samples: &[f32], total_samples_consumed: u64) {
+        // Slowrx vis.c line 137: `if (gotvis) break;` — drop further audio
+        // until the caller drains the detection result.
+        if self.detected.is_some() {
+            return;
+        }
+        // Re-anchor `audio_origin_sample` lazily on first sample.
+        if self.audio_buffer.is_empty() {
+            #[allow(clippy::cast_possible_truncation)]
+            let chunk_len = samples.len() as u64;
+            self.audio_origin_sample = total_samples_consumed.saturating_sub(chunk_len);
+        }
+        self.audio_buffer.extend_from_slice(samples);
+
+        // Each loop iteration: process one hop, optionally match, drain.
+        loop {
+            let buf_window_start = self.next_window_start_in_buffer();
+            let buf_window_end = buf_window_start + WINDOW_SAMPLES;
+            if buf_window_end > self.audio_buffer.len() {
+                break;
+            }
+            self.process_hop(buf_window_start);
+            self.hops_completed = self.hops_completed.saturating_add(1);
+
+            if self.history_filled >= HISTORY_LEN {
+                if let Some((code, hedr_shift_hz, i_match)) =
+                    match_vis_pattern(&self.rotated_history())
+                {
+                    // Stop-bit hop = `tone[14*3+i]` = `(2-i)` hops back
+                    // from the latest. The bit is 30 ms = 3 hops long,
+                    // so its absolute end-sample simplifies to:
+                    //   `(hops_completed + i) * HOP_SAMPLES`
+                    // (slowrx vis.c lines 168-170 instead skips a fixed
+                    // 20 ms regardless of `i`; we use the precise i-aware
+                    // boundary so per-pixel image alignment stays tight).
+                    let stop_end_abs =
+                        (self.hops_completed.saturating_add(i_match as u64)) * HOP_SAMPLES as u64;
+                    let drain_to_buf =
+                        usize::try_from(stop_end_abs.saturating_sub(self.audio_origin_sample))
+                            .unwrap_or(usize::MAX)
+                            .min(self.audio_buffer.len());
+                    self.detected = Some(DetectedVis {
+                        code,
+                        hedr_shift_hz,
+                        end_sample: stop_end_abs,
+                    });
+                    self.audio_buffer.drain(..drain_to_buf);
+                    #[allow(clippy::cast_possible_truncation)]
+                    {
+                        self.audio_origin_sample += drain_to_buf as u64;
+                    }
+                    return;
+                }
+            }
+
+            // Drop samples no future window will touch (next hop starts
+            // at buf_window_start + HOP_SAMPLES).
+            let drain_to = buf_window_start + HOP_SAMPLES;
+            self.audio_buffer.drain(..drain_to);
+            #[allow(clippy::cast_possible_truncation)]
+            {
+                self.audio_origin_sample += drain_to as u64;
+            }
+        }
+    }
+
+    /// Take the detected VIS (if any). Audio buffer is preserved so the
+    /// caller can recover post-stop-bit residue via [`Self::take_residual_buffer`].
+    pub fn take_detected(&mut self) -> Option<DetectedVis> {
+        self.detected.take()
+    }
+
+    /// Take any audio still buffered (post-stop-bit residue). The detector
+    /// keeps an empty buffer; the next `process` call re-anchors the origin.
+    pub fn take_residual_buffer(&mut self) -> Vec<f32> {
+        std::mem::take(&mut self.audio_buffer)
+    }
+
+    /// Position in `audio_buffer` where the next 20 ms window starts.
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    fn next_window_start_in_buffer(&self) -> usize {
+        let next_hop_abs = self.hops_completed * HOP_SAMPLES as u64;
+        next_hop_abs.saturating_sub(self.audio_origin_sample) as usize
+    }
+
+    /// Run one 20 ms FFT, append its peak frequency to history. Slowrx
+    /// vis.c line 67 falls back to `HedrBuf[(HedrPtr-1) % 45]` when the
+    /// peak is at the search boundary or has a non-positive neighbour;
+    /// we encode that by returning NaN from `estimate_peak_freq`.
+    fn process_hop(&mut self, buf_window_start: usize) {
+        let window = &self.audio_buffer[buf_window_start..buf_window_start + WINDOW_SAMPLES];
+        for (i, slot) in self.fft_buf.iter_mut().enumerate() {
+            *slot = if i < WINDOW_SAMPLES {
+                Complex {
+                    re: window[i] * self.hann[i],
+                    im: 0.0,
+                }
+            } else {
+                Complex { re: 0.0, im: 0.0 }
+            };
+        }
+        self.fft
+            .process_with_scratch(&mut self.fft_buf, &mut self.scratch[..]);
+
+        let peak_hz = estimate_peak_freq(&self.fft_buf);
+        let prev_idx = (self.history_ptr + HISTORY_LEN - 1) % HISTORY_LEN;
+        self.history[self.history_ptr] = if peak_hz.is_finite() {
+            peak_hz
+        } else {
+            self.history[prev_idx]
+        };
+        self.history_ptr = (self.history_ptr + 1) % HISTORY_LEN;
+        if self.history_filled < HISTORY_LEN {
+            self.history_filled += 1;
+        }
+    }
+
+    /// Rotate the circular history so `[0]` is oldest, `[HISTORY_LEN-1]`
+    /// is newest — slowrx vis.c line 76: `tone[i] = HedrBuf[(HedrPtr + i) % 45]`.
+    fn rotated_history(&self) -> [f64; HISTORY_LEN] {
+        let mut out = [0.0_f64; HISTORY_LEN];
+        for (i, slot) in out.iter_mut().enumerate() {
+            *slot = self.history[(self.history_ptr + i) % HISTORY_LEN];
+        }
+        out
+    }
+}
+
+/// Build a length-`n` symmetric Hann window. Matches slowrx vis.c line 30:
+/// `Hann[i] = 0.5 * (1 - cos(2π i / (n-1)))`.
+#[allow(clippy::cast_precision_loss, clippy::cast_possible_truncation)]
+fn build_hann_window(n: usize) -> Vec<f32> {
+    let m = (n.saturating_sub(1).max(1)) as f64;
+    (0..n)
+        .map(|i| {
+            let v = 0.5 * (1.0 - (2.0 * std::f64::consts::PI * (i as f64) / m).cos());
+            v as f32
+        })
+        .collect()
+}
+
+/// Find the dominant peak in 500..3300 Hz and refine via Gaussian-log
+/// peak interpolation (slowrx vis.c lines 54-70). Returns NaN if the
+/// peak is at the boundary or any of the three sample bins (peak-1,
+/// peak, peak+1) are non-positive — callers then fall back to the
+/// previous history entry.
+#[allow(
+    clippy::cast_precision_loss,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss
+)]
+fn estimate_peak_freq(spectrum: &[Complex<f32>]) -> f64 {
+    let fft_len = spectrum.len();
+    let bin_for = |hz: f64| -> usize {
+        ((hz * fft_len as f64) / f64::from(WORKING_SAMPLE_RATE_HZ)).round() as usize
+    };
+    let lo = bin_for(SEARCH_LO_HZ);
+    let hi = bin_for(SEARCH_HI_HZ);
+    if lo == 0 || hi >= fft_len.saturating_sub(1) || lo >= hi {
+        return f64::NAN;
+    }
+    let power = |c: Complex<f32>| -> f64 {
+        let r = f64::from(c.re);
+        let i = f64::from(c.im);
+        r * r + i * i
+    };
+    let mut max_bin = lo;
+    let mut max_p = power(spectrum[lo]);
+    for (k, &c) in spectrum.iter().enumerate().take(hi).skip(lo + 1) {
+        let p = power(c);
+        if p > max_p {
+            max_p = p;
+            max_bin = k;
+        }
+    }
+    if max_bin <= lo || max_bin >= hi {
+        return f64::NAN;
+    }
+    let p_prev = power(spectrum[max_bin - 1]);
+    let p_curr = max_p;
+    let p_next = power(spectrum[max_bin + 1]);
+    if p_prev <= 0.0 || p_curr <= 0.0 || p_next <= 0.0 {
+        return f64::NAN;
+    }
+    // bin = MaxBin + log(P[+1]/P[-1]) / (2 * log(P[0]^2 / (P[+1]*P[-1])))
+    let num = (p_next / p_prev).ln();
+    let denom = 2.0 * (p_curr * p_curr / (p_next * p_prev)).ln();
+    let bin = if denom.abs() > 1e-12 {
+        max_bin as f64 + num / denom
+    } else {
+        max_bin as f64
+    };
+    bin / fft_len as f64 * f64::from(WORKING_SAMPLE_RATE_HZ)
+}
+
+/// Match the 14-window VIS pattern in a 45-entry frequency history.
+/// Tries 9 alignments (i × j, 3 phases × 3 leader candidates). Returns
+/// `(vis_code, hedr_shift_hz, i)` on detection (`hedr_shift_hz =
+/// observed_leader - 1900`, `i` is the matched phase). Uses relative
+/// ±25 Hz tolerance — slowrx vis.c lines 82-104. (Indices like `3 + i`
+/// spell out slowrx's `tone[1*3+i]` so parity with C is one-to-one.)
+fn match_vis_pattern(tones: &[f64; HISTORY_LEN]) -> Option<(u8, f64, usize)> {
+    let tol = TONE_TOLERANCE_HZ;
+    for i in 0..3 {
+        for j in 0..3 {
+            let leader = tones[j];
+            if !within(tones[3 + i], leader, tol)
+                || !within(tones[6 + i], leader, tol)
+                || !within(tones[9 + i], leader, tol)
+                || !within(tones[12 + i], leader, tol)
+            {
+                continue;
+            }
+            let break_target = leader + BREAK_HZ_OFFSET;
+            if !within(tones[15 + i], break_target, tol)
+                || !within(tones[42 + i], break_target, tol)
+            {
+                continue;
+            }
+            let zero_target = leader + BIT_ZERO_OFFSET;
+            let one_target = leader + BIT_ONE_OFFSET;
+            let mut code = 0u8;
+            let mut parity = 0u8;
+            let mut bit_ok = true;
+            for k in 0..8 {
+                let t = tones[18 + i + 3 * k];
+                let bit = if within(t, zero_target, tol) {
+                    0u8
+                } else if within(t, one_target, tol) {
+                    1u8
+                } else {
+                    bit_ok = false;
+                    break;
+                };
+                if k < 7 {
+                    code |= bit << k;
+                    parity ^= bit;
+                } else if parity != bit {
+                    bit_ok = false;
+                }
+            }
+            if bit_ok {
+                return Some((code, leader - LEADER_HZ, i));
+            }
+        }
+    }
+    None
+}
+
+#[inline]
+fn within(value: f64, target: f64, tol: f64) -> bool {
+    (value - target).abs() < tol
+}
+
+/// Goertzel power on `samples` at `target_hz` (bin power, ~amplitude²).
+/// Used by `decoder::estimate_freq` and the resample-quality tests.
+#[allow(clippy::cast_precision_loss)]
 pub(crate) fn goertzel_power(samples: &[f32], target_hz: f64) -> f64 {
-    // VIS windows are ~330 samples at 11025 Hz, far below f64's 2^53 mantissa.
-    #[allow(clippy::cast_precision_loss)]
     let n = samples.len() as f64;
     if n == 0.0 {
         return 0.0;
     }
     let k = (0.5 + n * target_hz / f64::from(WORKING_SAMPLE_RATE_HZ)).floor();
-    let omega = 2.0 * std::f64::consts::PI * k / n;
-    let coeff = 2.0 * omega.cos();
-
+    let coeff = 2.0 * (2.0 * std::f64::consts::PI * k / n).cos();
     let mut s_prev = 0.0_f64;
     let mut s_prev2 = 0.0_f64;
     for &sample in samples {
@@ -39,162 +367,6 @@ pub(crate) fn goertzel_power(samples: &[f32], target_hz: f64) -> f64 {
         s_prev = s;
     }
     s_prev2.mul_add(s_prev2, s_prev.mul_add(s_prev, -coeff * s_prev * s_prev2))
-}
-
-/// Each VIS bit lasts 30 ms; at 11025 Hz that is `WINDOW_SAMPLES`
-/// audio samples per bit.
-#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-pub(crate) const WINDOW_SAMPLES: usize = (0.030 * WORKING_SAMPLE_RATE_HZ as f64) as usize; // 330
-
-/// VIS detection state machine. Operates on audio at the
-/// [`WORKING_SAMPLE_RATE_HZ`] working rate.
-///
-/// Slides a 30-ms window across input audio. For each window, runs the
-/// four Goertzel filters and records the dominant tone. When the last
-/// 14 windows match the VIS pattern (leader · break · 8 bits · stop),
-/// emits the decoded 7-bit code via [`Self::take_detected`].
-pub(crate) struct VisDetector {
-    buffer: Vec<f32>,
-    tones: Vec<Tone>,
-    detected: Option<DetectedVis>,
-}
-
-/// Categorical tone classification for a single 30 ms window.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum Tone {
-    Leader,  // 1900 Hz
-    Break,   // 1200 Hz
-    BitZero, // 1300 Hz
-    BitOne,  // 1100 Hz
-    Other,
-}
-
-/// Result of a successful VIS detection.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) struct DetectedVis {
-    /// 7-bit VIS code (LSB-first decoded).
-    pub code: u8,
-    /// Decoder-relative sample index where the stop-bit ended.
-    pub end_sample: u64,
-}
-
-impl VisDetector {
-    pub fn new() -> Self {
-        Self {
-            buffer: Vec::with_capacity(WINDOW_SAMPLES * 4),
-            tones: Vec::new(),
-            detected: None,
-        }
-    }
-
-    /// Push working-rate audio samples into the detector.
-    ///
-    /// `total_samples_consumed` is the running sample count from the
-    /// caller's perspective (used to populate `DetectedVis::end_sample`).
-    pub fn process(&mut self, samples: &[f32], total_samples_consumed: u64) {
-        self.buffer.extend_from_slice(samples);
-
-        while self.buffer.len() >= WINDOW_SAMPLES && self.detected.is_none() {
-            let window: Vec<f32> = self.buffer.drain(..WINDOW_SAMPLES).collect();
-            let tone = classify(&window);
-            self.tones.push(tone);
-            if self.tones.len() > 14 {
-                self.tones.remove(0);
-            }
-            if self.tones.len() == 14 {
-                if let Some(code) = match_vis_pattern(&self.tones) {
-                    // The window we just consumed is the stop bit.
-                    // `total_samples_consumed` is the running counter
-                    // AFTER the caller's chunk was appended; subtracting
-                    // the not-yet-consumed remainder of `buffer` gives
-                    // the sample boundary at the end of the just-drained
-                    // (stop-bit) window — the exact end of the burst.
-                    let end_sample =
-                        total_samples_consumed.saturating_sub(self.buffer.len() as u64);
-                    self.detected = Some(DetectedVis { code, end_sample });
-                }
-            }
-        }
-    }
-
-    /// Take the detected VIS (if any). Tone history is cleared so the
-    /// next call to [`Self::process`] starts fresh; the audio buffer is
-    /// NOT cleared so callers can recover post-stop-bit residue via
-    /// [`Self::take_residual_buffer`].
-    pub fn take_detected(&mut self) -> Option<DetectedVis> {
-        let d = self.detected.take();
-        if d.is_some() {
-            self.tones.clear();
-        }
-        d
-    }
-
-    /// Take any audio still buffered by the detector (post-stop-bit residue).
-    /// The caller is expected to hand this audio to the next stage of the
-    /// decoder so no samples are lost across a state transition.
-    pub fn take_residual_buffer(&mut self) -> Vec<f32> {
-        std::mem::take(&mut self.buffer)
-    }
-}
-
-fn classify(window: &[f32]) -> Tone {
-    let p_leader = goertzel_power(window, LEADER_HZ);
-    let p_break = goertzel_power(window, BREAK_HZ);
-    let p0 = goertzel_power(window, BIT_ZERO_HZ);
-    let p1 = goertzel_power(window, BIT_ONE_HZ);
-    // Pick the maximum; require at least 5× margin over the second-place
-    // tone to avoid mis-classifying noise. The 5× threshold is empirical;
-    // slowrx uses ±25 Hz frequency tolerance which translates to a similar
-    // power ratio in tone-classifier terms.
-    let mut ranked = [
-        (Tone::Leader, p_leader),
-        (Tone::Break, p_break),
-        (Tone::BitZero, p0),
-        (Tone::BitOne, p1),
-    ];
-    ranked.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
-    if ranked[0].1 > 5.0 * ranked[1].1 {
-        ranked[0].0
-    } else {
-        Tone::Other
-    }
-}
-
-/// Match the 14-window VIS pattern: 4 leader + 1 break + 8 bits + 1 stop.
-/// Returns the recovered 7-bit code on parity-OK, otherwise `None`.
-fn match_vis_pattern(tones: &[Tone]) -> Option<u8> {
-    debug_assert_eq!(tones.len(), 14);
-    // Windows [0..4] = leader, [4] = break, [5..13] = bits, [13] = stop.
-    if !(tones[0] == Tone::Leader
-        && tones[1] == Tone::Leader
-        && tones[2] == Tone::Leader
-        && tones[3] == Tone::Leader)
-    {
-        return None;
-    }
-    if tones[4] != Tone::Break || tones[13] != Tone::Break {
-        return None;
-    }
-    let mut code = 0u8;
-    let mut parity = 0u8;
-    for (i, tone) in tones[5..12].iter().enumerate() {
-        let bit = match tone {
-            Tone::BitOne => 1,
-            Tone::BitZero => 0,
-            _ => return None,
-        };
-        code |= bit << i;
-        parity ^= bit;
-    }
-    let parity_bit = match tones[12] {
-        Tone::BitOne => 1,
-        Tone::BitZero => 0,
-        _ => return None,
-    };
-    if parity != parity_bit {
-        return None;
-    }
-    Some(code)
 }
 
 #[cfg(any(test, feature = "test-support"))]
@@ -217,6 +389,11 @@ pub mod tests {
     /// Generate `secs` of pure tone at `freq_hz` at the working sample rate.
     pub fn synth_tone(freq_hz: f64, secs: f64) -> Vec<f32> {
         let n = (secs * f64::from(WORKING_SAMPLE_RATE_HZ)).round() as usize;
+        synth_tone_n(freq_hz, n)
+    }
+
+    /// Generate `n` samples of pure tone at `freq_hz` at the working sample rate.
+    pub fn synth_tone_n(freq_hz: f64, n: usize) -> Vec<f32> {
         (0..n)
             .map(|i| {
                 let t = (i as f64) / f64::from(WORKING_SAMPLE_RATE_HZ);
@@ -225,82 +402,66 @@ pub mod tests {
             .collect()
     }
 
-    /// Build a synthetic VIS burst encoding the given 7-bit `code`
-    /// with even parity. Pads `pre_silence_secs` of zeros before the
-    /// leader so the detector has to find the burst inside a longer
-    /// audio buffer.
-    pub fn synth_vis(code: u8, pre_silence_secs: f64) -> Vec<f32> {
+    /// Build a synthetic VIS burst encoding `code` with even parity.
+    /// `freq_offset_hz` shifts every tone (mistuned-radio test fixture).
+    /// Continuous-phase: avoids bit-boundary discontinuities that would
+    /// pull FFT peaks off-tone.
+    pub fn synth_vis_with_offset(code: u8, pre_silence_secs: f64, freq_offset_hz: f64) -> Vec<f32> {
         assert!(code < 0x80, "VIS codes are 7 bits");
-
-        let mut out: Vec<f32> = Vec::new();
-        // Pre-silence
-        let n_pre = (pre_silence_secs * f64::from(WORKING_SAMPLE_RATE_HZ)).round() as usize;
-        out.resize(n_pre, 0.0);
-
-        // 300 ms leader (10 × 30 ms windows of 1900 Hz)
-        out.extend(synth_tone(LEADER_HZ, 0.300));
-        // 30 ms break at 1200 Hz
-        out.extend(synth_tone(BREAK_HZ, 0.030));
-
-        // 7 data bits (LSB-first per slowrx convention)
+        let sr = f64::from(WORKING_SAMPLE_RATE_HZ);
+        let mut out: Vec<f32> = vec![0.0; (pre_silence_secs * sr).round() as usize];
+        let mut phase = 0.0_f64;
+        let mut emit = |freq: f64, secs: f64, out: &mut Vec<f32>| {
+            let dphi = 2.0 * PI * freq / sr;
+            for _ in 0..(secs * sr).round() as usize {
+                out.push(phase.sin() as f32);
+                phase += dphi;
+                if phase > 2.0 * PI {
+                    phase -= 2.0 * PI;
+                }
+            }
+        };
+        let leader = LEADER_HZ + freq_offset_hz;
+        let break_f = leader + BREAK_HZ_OFFSET;
+        let bit_freq = |bit: u8| -> f64 {
+            leader
+                + if bit == 1 {
+                    BIT_ONE_OFFSET
+                } else {
+                    BIT_ZERO_OFFSET
+                }
+        };
+        emit(leader, 0.300, &mut out);
+        emit(break_f, 0.030, &mut out);
         let mut parity = 0u8;
         for b in 0..7 {
             let bit = (code >> b) & 1;
             parity ^= bit;
-            let f = if bit == 1 { BIT_ONE_HZ } else { BIT_ZERO_HZ };
-            out.extend(synth_tone(f, 0.030));
+            emit(bit_freq(bit), 0.030, &mut out);
         }
-        // 8th bit = even parity
-        let parity_freq = if parity == 1 { BIT_ONE_HZ } else { BIT_ZERO_HZ };
-        out.extend(synth_tone(parity_freq, 0.030));
-
-        // 30 ms stop at 1200 Hz
-        out.extend(synth_tone(BREAK_HZ, 0.030));
+        emit(bit_freq(parity), 0.030, &mut out);
+        emit(break_f, 0.030, &mut out);
         out
     }
 
-    #[test]
-    fn synth_vis_for_pd120_has_expected_length() {
-        // 0.3 s leader + 0.03 s break + 8 × 0.03 s bits + 0.03 s stop = 0.6 s nominal.
-        // (with no pre-silence)
-        // synth_vis calls synth_tone 11 times (1 leader + 10 data/stop windows), each
-        // independently rounding to the nearest sample, so the actual total may differ
-        // from round(0.6 × sr) by up to ±11 samples.  We use a tolerance of ±11.
-        let samples = synth_vis(0x5F, 0.0);
-        let expected_len = (0.6 * f64::from(WORKING_SAMPLE_RATE_HZ)).round() as usize;
-        assert!(
-            (samples.len() as isize - expected_len as isize).abs() <= 11,
-            "len={} expected≈{expected_len}",
-            samples.len()
-        );
+    /// Convenience wrapper: zero-offset VIS burst.
+    pub fn synth_vis(code: u8, pre_silence_secs: f64) -> Vec<f32> {
+        synth_vis_with_offset(code, pre_silence_secs, 0.0)
     }
 
-    #[test]
-    fn goertzel_finds_leader_tone() {
-        let samples = synth_tone(1900.0, 0.030);
-        let p_leader = goertzel_power(&samples, LEADER_HZ);
-        let p_break = goertzel_power(&samples, BREAK_HZ);
-        // Leader bin has dramatically more power than the break bin.
-        assert!(
-            p_leader > 50.0 * p_break,
-            "leader={p_leader} break={p_break}"
-        );
+    /// Helper: feed `audio` into a fresh detector and return the result.
+    fn run(audio: &[f32]) -> Option<DetectedVis> {
+        let mut det = VisDetector::new();
+        det.process(audio, audio.len() as u64);
+        det.take_detected()
     }
 
-    #[test]
-    fn goertzel_finds_bit_zero() {
-        let samples = synth_tone(1300.0, 0.030);
-        let p0 = goertzel_power(&samples, BIT_ZERO_HZ);
-        let p1 = goertzel_power(&samples, BIT_ONE_HZ);
-        assert!(p0 > 50.0 * p1, "bit0={p0} bit1={p1}");
-    }
-
-    #[test]
-    fn goertzel_finds_bit_one() {
-        let samples = synth_tone(1100.0, 0.030);
-        let p0 = goertzel_power(&samples, BIT_ZERO_HZ);
-        let p1 = goertzel_power(&samples, BIT_ONE_HZ);
-        assert!(p1 > 50.0 * p0, "bit0={p0} bit1={p1}");
+    /// Helper: build a VIS burst with a trailing zero pad so the sliding
+    /// window has clean post-stop-bit hops to consume.
+    fn vis_padded(code: u8, pre_silence_secs: f64, freq_offset_hz: f64) -> Vec<f32> {
+        let mut audio = synth_vis_with_offset(code, pre_silence_secs, freq_offset_hz);
+        audio.extend(std::iter::repeat_n(0.0_f32, 256));
+        audio
     }
 
     #[test]
@@ -310,7 +471,6 @@ pub mod tests {
 
     #[test]
     fn goertzel_handcomputed_quarter_cycle() {
-        // x = [1, 0, -1, 0], target = sample_rate/4 → expected power = 4.0
         let samples = [1.0_f32, 0.0, -1.0, 0.0];
         let target = f64::from(WORKING_SAMPLE_RATE_HZ) / 4.0;
         let p = goertzel_power(&samples, target);
@@ -318,68 +478,90 @@ pub mod tests {
     }
 
     #[test]
-    fn detects_pd120_vis_clean_signal() {
-        let mut det = VisDetector::new();
-        let audio = synth_vis(0x5F, 0.0);
-        let n = audio.len();
-        det.process(&audio, n as u64);
-        let d = det.take_detected().expect("PD120 detected");
-        assert_eq!(d.code, 0x5F);
+    fn hann_window_endpoints_are_zero() {
+        let h = build_hann_window(WINDOW_SAMPLES);
+        assert!(h[0].abs() < 1e-6);
+        assert!(h[h.len() - 1].abs() < 1e-6);
+        let mid = h.len() / 2;
+        assert!((h[mid] - 1.0).abs() < 1e-2, "middle ≈ 1, got {}", h[mid]);
     }
 
     #[test]
-    fn detects_pd180_vis_clean_signal() {
-        let mut det = VisDetector::new();
-        let audio = synth_vis(0x60, 0.0);
-        let n = audio.len();
-        det.process(&audio, n as u64);
-        let d = det.take_detected().expect("PD180 detected");
+    fn detects_clean_pd120_and_pd180() {
+        for &code in &[0x5F_u8, 0x60] {
+            let d = run(&vis_padded(code, 0.0, 0.0)).expect("clean detect");
+            assert_eq!(d.code, code);
+            assert!(d.hedr_shift_hz.abs() < 10.0);
+        }
+    }
+
+    #[test]
+    fn detects_pd120_with_50hz_offset() {
+        let d = run(&vis_padded(0x5F, 0.050, 50.0)).expect("offset PD120");
+        assert_eq!(d.code, 0x5F);
+        assert!(
+            (d.hedr_shift_hz - 50.0).abs() < 10.0,
+            "got {}",
+            d.hedr_shift_hz
+        );
+    }
+
+    #[test]
+    fn detects_pd180_with_minus_70hz_offset() {
+        let d = run(&vis_padded(0x60, 0.080, -70.0)).expect("offset PD180");
         assert_eq!(d.code, 0x60);
+        assert!(
+            (d.hedr_shift_hz + 70.0).abs() < 10.0,
+            "got {}",
+            d.hedr_shift_hz
+        );
     }
 
     #[test]
-    fn detects_vis_after_pre_silence() {
-        // Pre-silence is a whole multiple of WINDOW_SAMPLES so the burst
-        // aligns with detector window boundaries. Sub-window alignment is
-        // a follow-up task (FrameSync realigns at 10 ms granularity).
-        let mut det = VisDetector::new();
-        let pre_secs = (WINDOW_SAMPLES as f64 * 7.0) / f64::from(WORKING_SAMPLE_RATE_HZ);
-        let audio = synth_vis(0x5F, pre_secs);
-        let n = audio.len();
-        det.process(&audio, n as u64);
-        let d = det.take_detected().expect("PD120 detected after silence");
-        assert_eq!(d.code, 0x5F);
+    fn detects_with_pre_silence_aligned_or_misaligned() {
+        // Aligned: 7×HOP samples; misaligned: 37 samples (not a hop boundary).
+        for pre_samples in [(7 * HOP_SAMPLES) as f64, 37.0] {
+            let pre_secs = pre_samples / f64::from(WORKING_SAMPLE_RATE_HZ);
+            let d = run(&vis_padded(0x5F, pre_secs, 0.0)).expect("detect after silence");
+            assert_eq!(d.code, 0x5F);
+        }
     }
 
     #[test]
-    fn rejects_random_noise() {
-        let mut det = VisDetector::new();
-        // 1 second of mid-band noise that doesn't match VIS.
+    fn rejects_isolated_noise() {
+        let mut x: u64 = 0xdead_beef_cafe_babe;
         let n = WORKING_SAMPLE_RATE_HZ as usize;
         let audio: Vec<f32> = (0..n)
-            .map(|i| {
-                let t = i as f64 / f64::from(WORKING_SAMPLE_RATE_HZ);
-                (0.3 * (2.0 * PI * 1750.0 * t).sin()) as f32
+            .map(|_| {
+                x ^= x << 13;
+                x ^= x >> 7;
+                x ^= x << 17;
+                (((x as i64) as f64) / (i64::MAX as f64)) as f32 * 0.3
             })
             .collect();
-        det.process(&audio, n as u64);
-        assert!(det.take_detected().is_none());
+        assert!(run(&audio).is_none());
+    }
+
+    #[test]
+    fn rejects_constant_off_band_tone() {
+        // A pure 1750 Hz tone has no break/leader pattern; must reject.
+        let n = WORKING_SAMPLE_RATE_HZ as usize;
+        let audio = synth_tone_n(1750.0, n);
+        assert!(run(&audio).is_none());
     }
 
     #[test]
     fn parity_failure_is_rejected() {
-        let mut det = VisDetector::new();
-        // Build a clean burst, then overwrite bit-0's detector window
-        // with the break tone so the bit decoder rejects the slot.
-        // synth_vis emits 300 ms of leader (10 detector windows) + 30 ms
-        // break (1 window), so bit-0 lives at detector window 11.
+        // Zero out one of the bit windows so the bit classifier rejects.
         let mut audio = synth_vis(0x5F, 0.0);
-        let start = WINDOW_SAMPLES * 11;
-        let end = start + WINDOW_SAMPLES;
-        let break_window = synth_tone(BREAK_HZ, 0.030);
-        audio[start..end].copy_from_slice(&break_window[..WINDOW_SAMPLES]);
-        det.process(&audio, audio.len() as u64);
-        assert!(det.take_detected().is_none());
+        let sr = f64::from(WORKING_SAMPLE_RATE_HZ);
+        let bit5_start = ((0.300 + 0.030 + 5.0 * 0.030) * sr) as usize;
+        let bit5_end = bit5_start + (0.030 * sr) as usize;
+        for s in &mut audio[bit5_start..bit5_end] {
+            *s = 0.0;
+        }
+        audio.extend(std::iter::repeat_n(0.0_f32, 256));
+        assert!(run(&audio).is_none());
     }
 
     #[cfg(test)]
@@ -395,29 +577,22 @@ pub mod tests {
                 len in 0usize..32_000,
                 seed in 0u64..u64::MAX,
             ) {
-                // Deterministic pseudo-random audio in [-1, 1].
-                let mut x = seed;
+                let mut x = seed.max(1);
                 let mut audio = Vec::with_capacity(len);
                 for _ in 0..len {
-                    // xorshift
                     x ^= x << 13;
                     x ^= x >> 7;
                     x ^= x << 17;
                     let v = ((x as i64) as f64) / (i64::MAX as f64);
                     audio.push(v as f32);
                 }
-                let mut det = VisDetector::new();
-                det.process(&audio, audio.len() as u64);
-                // Whatever it returns is fine; it just must not panic.
-                let _ = det.take_detected();
+                let _ = run(&audio);
             }
 
             #[test]
             fn every_valid_vis_code_decodes_correctly(code in 0u8..0x80) {
-                let mut det = VisDetector::new();
-                let audio = synth_vis(code, 0.0);
-                det.process(&audio, audio.len() as u64);
-                let d = det.take_detected().expect("clean VIS always decodes");
+                let audio = vis_padded(code, 0.0, 0.0);
+                let d = run(&audio).expect("clean VIS always decodes");
                 prop_assert_eq!(d.code, code);
             }
         }

--- a/src/vis.rs
+++ b/src/vis.rs
@@ -11,7 +11,7 @@
 //! per-pixel demod for radio-mistuning compensation.
 //!
 //! Sizes scale by 1/4 from slowrx's 44.1 kHz to our 11.025 kHz
-//! ([`HOP_SAMPLES`], [`WINDOW_SAMPLES`], [`FFT_LEN`]); [`HISTORY_LEN`]
+//! (`HOP_SAMPLES`, `WINDOW_SAMPLES`, `FFT_LEN`); `HISTORY_LEN`
 //! stays 45 (450 ms). `FFT_LEN=512` gives 21.5 Hz/bin like slowrx's 2048/44100.
 
 use rustfft::{num_complex::Complex, FftPlanner};


### PR DESCRIPTION
**Closes #13, #14, #15, #17, #30, #36, #37, #38** (8 of 26 audit issues).
**Part of #12** (parity audit epic).

## Summary

Phase 1 of the slowrx parity recovery plan — full rewrite of the VIS detector to mirror slowrx's vis.c algorithm. Replaces our 4-Goertzel-bank approach with a real FFT-based scanner that handles real-radio audio's frequency offsets, sub-30ms phase misalignment, and noisy classification.

## Algorithm changes

| Before (PR-1) | After (this PR) |
|---|---|
| 4 Goertzel filters at fixed 1900/1200/1100/1300 Hz | rustfft 512-point FFT scan over 500-3300 Hz |
| 30 ms boundary-aligned non-overlapping windows | 10 ms hop with 50% overlap (220-sample Hann window) |
| 5× power-margin classifier (uniquely ours) | Peak-frequency detection (no power threshold) — matches slowrx |
| Single alignment per detection attempt | 9 alignments per attempt: 3×3 (i × j) loop matching \`vis.c:82-92\` |
| Absolute frequency tolerance | **Relative ±25 Hz** from observed leader (slowrx convention) |
| No HedrShift | **HedrShift extracted** at detection (\`base_freq - 1900\`) and plumbed through \`SstvEvent::VisDetected\` → \`decode_pd_line_pair\` → \`pixel_freq\` + \`freq_to_luminance\` |
| No Hann window | Hann-weighted analysis windows |
| No spectral interpolation | Gaussian-log peak interpolation matching slowrx \`vis.c:62-66\` |

The 512-point FFT at 11025 Hz gives 21.5 Hz/bin — exactly matching slowrx's 2048-point FFT at 44100 Hz. Bin geometry is identical to the C reference.

## Stats

- 53 unit tests + 2 integration + 1 doctest = **56 passing** (+3 net; some Goertzel-specific tests removed since the primitive is gone)
- Coverage **97.50% lines / 97.80% regions** aggregate. \`vis.rs\` 97.37% / 97.66%.
- \`vis.rs\` 600 LOC (at the per-file cap; rewrite is substantial).
- All gates clean: fmt, clippy --all-targets --all-features -D warnings, build --all-features --locked, test --all-features --locked, doc with -D warnings, check --workspace --locked.

## Synthetic regression confirmed

Both PD round-trip integration tests still pass with same-or-better margins:
- PD120: max_diff **19** / mean **1.26** (unchanged)
- PD180: max_diff **17** / mean **0.78** (unchanged)

No synthetic regression introduced.

## Real-audio gate deferred to Phase 4

This PR does not validate against real ARISS audio yet — Phase 2 (FindSync slant + Skip + Rate) and Phase 3 (per-pixel demod robustness) are still missing. Even if VIS detection works on real audio after this PR, post-VIS line decoder may still drift sample rate and run out of audio mid-PD180. **Real-data validation is the Phase 4 ship gate**, after all 3 fix phases land.

## New findings surfaced during Phase 1

Two minor/cosmetic findings the implementer caught while rewriting (filed as separate issues):

- **#39** — Intentional deviation from slowrx's ±20 ms stop-bit slop (we compute exact i-aware boundary)
- **#40** — \`take_residual_buffer\` doesn't reset history; latent if mid-image VIS reactivates

## Test plan

- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\`
- [x] \`cargo test --all-features\` (56 passing)
- [x] \`cargo llvm-cov --fail-under-lines 92 --fail-under-regions 92\` (97.50% / 97.80%)
- [x] \`cargo doc --no-deps --all-features\` with \`-D warnings\` (no warnings)
- [x] \`cargo check --workspace --locked\` (Cargo.lock consistent)

## Attribution

\`vis.rs\`'s top-of-file rustdoc credits slowrx's vis.c verbatim. Algorithm is a faithful translation; constants (±25 Hz tolerance, frequency offsets -700/-600/-800, 9-iteration loop bounds) match the C source line-for-line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved VIS detection with FFT-based frequency estimation and automatic radio-mistuning (hedr) compensation surfaced in detection events for more accurate decoding.

* **Tests**
  * Added extensive VIS tests covering frequency offsets, misalignment, parity/rejection cases, and luminance/peak recovery under mistuning.

* **Documentation**
  * Added a detailed parity audit and updated changelog documenting detection algorithm changes and test results.

* **Chores**
  * Updated ignore rules to exclude local fixture WAV files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->