### PR TITLE
feat(sync): Phase 2 — port slowrx FindSync (slant + Skip + Rate)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,91 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed (Phase 2: FindSync parity)
+
+Faithful translation of slowrx's `sync.c::FindSync` (Hough-transform
+slant correction + 8-tap convolution edge-find for line-zero `Skip`)
+into a new `src/sync.rs` module, plus a refactor of the decoder's
+`Decoding` state to a two-pass flow that mirrors slowrx's offline-batch
+algorithm within our streaming model. Closes #19, #20, #21, #22.
+
+**Background.** Phase 1 fixed VIS detection. Real-audio decoding still
+silently failed at line ~248 of PD180 because the line decoder assumed
+the working sample rate was exactly 11025 Hz (no drift correction), that
+line 0 starts at sample 0 of the residual buffer (no `Skip`
+computation), and that there is no settling gap between the VIS stop
+bit and the first sync pulse. Sound-card clock drift over 248 line
+pairs accumulates past the captured audio length, exiting the per-pair
+loop early without `ImageComplete`.
+
+**What landed.**
+
+- New `src/sync.rs` module:
+  - `SyncTracker::has_sync_at` — translates slowrx `video.c:271-297`'s
+    `Praw`/`Psync` ratio probe with a 16-sample Hann window into a
+    256-bin zero-padded FFT (matching slowrx's 64-sample window into a
+    1024-bin FFT at the time-span / bin-density level).
+  - `find_sync` — translates slowrx `sync.c:18-133`: `(150-30)/0.5 = 240`
+    half-degree Hough bins on a `700 × NumLines` sync image, the slant
+    deadband described below, an 8-tap `[1,1,1,1,-1,-1,-1,-1]`
+    convolution edge-find on the column accumulator, and the
+    `xmax/700 × LineTime - SyncTime` skip formula. The Scottie offset
+    branch (`sync.c:123-125`) is unreachable in V1's PD-only port and
+    is omitted.
+
+- Decoder refactor (`src/decoder.rs`):
+  - The `Decoding` state accumulates one image's worth of audio
+    (`image_lines/2 × line_seconds × work_rate`, matching
+    `video.c:252`'s `Length = LineTime × NumLines/2 × 44100` for the
+    PD-mode `NumChans == 4` path).
+  - During accumulation the audio is probed every `SYNC_PROBE_STRIDE`
+    samples through `SyncTracker`, building a `Vec<bool>` equivalent
+    to slowrx's `HasSync[]` global.
+  - Once the audio target is reached, `find_sync` runs once. The
+    returned `(rate, skip)` drives a single per-pair decode pass:
+    `pair_start_sample = round(pair × line_seconds × rate) + skip`.
+  - `LineDecoded` events now fire in a fast burst at end-of-buffer
+    rather than incrementally. Callers still get every event; the
+    timing shifts.
+  - `DecodingState` is boxed inside the `State` enum
+    (`clippy::large_enum_variant` balance — the unit `AwaitingVis`
+    variant should not pay the FFT-plan + audio-buffer footprint).
+  - Trailing audio after `ImageComplete` still flows back into a fresh
+    `VisDetector` for the ARISS multi-image case.
+
+- Per-pair decode (`src/mode_pd.rs::decode_pd_line_pair`):
+  - Now accepts `(rate_hz, pair_start_sample)` rather than assuming the
+    buffer begins at the pair's first sample. Channel start times are
+    computed at the corrected rate so per-pair drift is absorbed by
+    `Skip` + `Rate`. Channel-slice isolation (preventing FFT bleed
+    across channel edges) is preserved.
+
+**Hough deadband at 90°.** Slowrx's `Rate += tan(deg2rad(90 -
+slantAngle)) / LineWidth × Rate` (`sync.c:81`) runs unconditionally,
+even when the angle is within the lock window. The 0.5° quantization
+means a perfectly drift-free input lands at 90.5° on the first try, and
+the un-needed correction injects a 0.0085% error that compounds across
+xAcc's per-line projection and corrupts the falling-edge convolution.
+We added a deadband: if `|angle - 90°| ≤ SLANT_STEP_DEG` the rate is
+left untouched. In slowrx this is masked by the second-pass `StoredLum`
+re-read (rate-driven pixel times against cached luminance); our
+streaming per-pixel-FFT model is more sensitive, so the deadband is
+needed for clean synthetic-audio parity. Real-audio drift typically
+lands well outside this band, so the correction still applies in
+practice.
+
+**Tests.**
+
+- New `sync::tests`: `has_sync_at_detects_1200_hz_burst`,
+  `has_sync_at_rejects_1900_hz_tone`, `has_sync_at_rejects_silence`,
+  `find_sync_locks_clean_track_to_90_degrees`,
+  `find_sync_recovers_known_offset` (10 ms left-shift),
+  `find_sync_handles_empty_track` (no panic on a zeroed track).
+- Synthetic round-trip integration tests (PD120, PD180) preserved and
+  tightened: PD120 max=11 mean=0.75 (previously max ≤ 25, mean < 5);
+  PD180 max=11 mean=0.55. Margins improved across the board.
+- Test count: 53 → 59 unit tests, 2 round-trip, 1 doctest unchanged.
+
 ### Changed (Phase 1: VIS parity)
 
 Faithful rewrite of `vis.rs` to mirror slowrx's `vis.c` algorithm

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -11,6 +11,7 @@ use crate::error::Result;
 use crate::image::SstvImage;
 use crate::modespec::SstvMode;
 use crate::resample::Resampler;
+use crate::sync::{find_sync, SyncTracker, SYNC_PROBE_STRIDE};
 
 /// One observable event emitted by [`SstvDecoder::process`].
 #[derive(Clone, Debug)]
@@ -57,18 +58,51 @@ pub enum SstvEvent {
 /// Internal state of the decoder.
 enum State {
     AwaitingVis,
-    Decoding {
-        mode: SstvMode,
-        spec: crate::modespec::ModeSpec,
-        line_pair_index: u32,
-        image: SstvImage,
-        /// Buffered working-rate samples not yet consumed by per-pixel decode.
-        buffer: Vec<f32>,
-        /// Radio mistuning offset in Hz extracted at VIS time. Plumbed to
-        /// per-pixel demod so the pixel band shifts with radio tuning.
-        hedr_shift_hz: f64,
-    },
+    /// Boxed because [`DecodingState`] contains the working FFT plans +
+    /// audio buffer and dwarfs the unit `AwaitingVis` variant; clippy
+    /// warns about size disparity otherwise.
+    Decoding(Box<DecodingState>),
 }
+
+/// Two-pass decoding state.
+///
+/// While `audio.len() < target_audio_samples`, the decoder accumulates
+/// audio and probes the 1200 Hz sync band into `has_sync`. When the
+/// buffer is full, [`find_sync`] runs once to recover the
+/// slant-corrected rate + line-zero `Skip`; per-pair decode then runs in
+/// a single fast burst, emitting [`SstvEvent::LineDecoded`] for every
+/// row.
+struct DecodingState {
+    mode: SstvMode,
+    spec: crate::modespec::ModeSpec,
+    image: SstvImage,
+    /// Working-rate audio captured from VIS-stop-bit forward.
+    audio: Vec<f32>,
+    /// Per-stride boolean track from [`SyncTracker::has_sync_at`]. One
+    /// entry per [`SYNC_PROBE_STRIDE`] working-rate samples.
+    has_sync: Vec<bool>,
+    /// Next sample index in `audio` to probe. Always a multiple of
+    /// [`SYNC_PROBE_STRIDE`].
+    next_probe_sample: usize,
+    /// Sync-band tracker. Constructed when `Decoding` is entered so the
+    /// hedr-shift bin offsets match the detected mistuning.
+    sync_tracker: SyncTracker,
+    /// Radio mistuning offset in Hz extracted at VIS time. Plumbed to
+    /// per-pixel demod so the pixel band shifts with radio tuning.
+    hedr_shift_hz: f64,
+    /// Total audio samples we must accumulate before running
+    /// [`find_sync`] and per-pair decode. Computed at state-entry as
+    /// `image_lines / 2 × line_seconds × FINDSYNC_AUDIO_HEADROOM × work_rate`.
+    target_audio_samples: usize,
+}
+
+/// Headroom factor on the buffered audio length before [`find_sync`]
+/// runs. 1.00 = exactly the nominal image length. The Hough transform
+/// re-anchors the rate against whatever sync pulses are present, so
+/// trailing audio beyond the last line is not strictly required. We
+/// keep this knob in case future modes (Scottie pre-line skip) want to
+/// pad the buffer to absorb additional offset.
+const FINDSYNC_AUDIO_HEADROOM: f64 = 1.00;
 
 /// Streaming SSTV decoder. Push audio buffers in via
 /// [`Self::process`]; consume the returned events.
@@ -136,14 +170,28 @@ impl SstvDecoder {
                             // detector buffered but did not consume — it is
                             // the leading edge of the image data.
                             let residual = self.vis.take_residual_buffer();
-                            self.state = State::Decoding {
+                            let work_rate = f64::from(crate::resample::WORKING_SAMPLE_RATE_HZ);
+                            // PD modes pack 2 image rows per radio frame, so
+                            // the audio duration is `image_lines/2 *
+                            // line_seconds * rate`. Matches slowrx's
+                            // `Length = LineTime * NumLines/2 * 44100`
+                            // path in video.c:252 (for NumChans == 4).
+                            let nominal_samples =
+                                (f64::from(spec.image_lines / 2) * spec.line_seconds * work_rate)
+                                    as usize;
+                            let target =
+                                ((nominal_samples as f64) * FINDSYNC_AUDIO_HEADROOM) as usize;
+                            self.state = State::Decoding(Box::new(DecodingState {
                                 mode: spec.mode,
                                 spec,
-                                line_pair_index: 0,
                                 image,
-                                buffer: residual,
+                                audio: residual,
+                                has_sync: Vec::new(),
+                                next_probe_sample: 0,
+                                sync_tracker: SyncTracker::new(detected.hedr_shift_hz),
                                 hedr_shift_hz: detected.hedr_shift_hz,
-                            };
+                                target_audio_samples: target,
+                            }));
                             continue; // re-enter loop to process leftover audio
                         }
                         // Unknown VIS codes silently drop. Reset the
@@ -153,21 +201,12 @@ impl SstvDecoder {
                     }
                     break;
                 }
-                State::Decoding {
-                    mode,
-                    spec,
-                    line_pair_index,
-                    image,
-                    buffer,
-                    hedr_shift_hz,
-                } => {
-                    buffer.extend_from_slice(remaining);
-
+                State::Decoding(d) => {
                     // TODO(future): mid-image VIS detection. When a new VIS
                     // burst arrives during decoding the spec calls for flushing
                     // the in-flight image as `partial: true` and restarting.
                     // The straightforward approach — running `self.vis` against
-                    // `buffer` each call — fails because the decoding buffer is
+                    // `audio` each call — fails because the decoding buffer is
                     // not aligned to 30 ms window boundaries: the residual from
                     // the previous VIS detection starts at an arbitrary sample
                     // offset, so the first classifier window is a mix of silence
@@ -176,90 +215,99 @@ impl SstvDecoder {
                     // window scan to the next 30 ms boundary, or run a separate
                     // correlator tuned to the 1900 Hz leader. Deferred to PR-3.
 
-                    let work_rate = f64::from(crate::resample::WORKING_SAMPLE_RATE_HZ);
-                    // Per-pixel FFT window is centered on the pixel's
-                    // expected sample, so we need FFT_LEN/2 trailing
-                    // samples beyond the last pixel of the pair.
-                    let lookahead = crate::mode_pd::FFT_LEN / 2;
+                    d.audio.extend_from_slice(remaining);
 
-                    // Compute the cumulative sample boundary for the
-                    // CURRENT pair's start vs. the NEXT pair's start.
-                    // Using rounded-cumulative-time matches how a
-                    // continuous-phase encoder would lay out samples,
-                    // and prevents a per-pair rounding bias from
-                    // accumulating (PD180 drifts ~0.05 samples/pair, so
-                    // by row 250 a fixed `samples_per_pair` is off by
-                    // ~12 samples — enough to misalign the line pair).
-                    loop {
-                        let cur_pair = u64::from(*line_pair_index);
-                        // buffer always begins at the current pair's start sample.
-                        // The next pair begins at:
-                        //   round((cur_pair + 1) * line_seconds * sr) -
-                        //   round(cur_pair * line_seconds * sr)
-                        // samples after the current start.
-                        let cur_off = (cur_pair as f64 * spec.line_seconds * work_rate).round();
-                        let next_off =
-                            ((cur_pair + 1) as f64 * spec.line_seconds * work_rate).round();
-                        let samples_per_pair = (next_off - cur_off) as usize;
-                        let needed = samples_per_pair + lookahead;
-                        if buffer.len() < needed {
-                            break;
-                        }
-
-                        // Pass a window that overlaps the next pair's
-                        // leading samples so the rightmost pixels see
-                        // a full FFT window.
-                        crate::mode_pd::decode_pd_line_pair(
-                            *spec,
-                            *line_pair_index,
-                            &buffer[..needed],
-                            image,
-                            &mut self.pd_demod,
-                            *hedr_shift_hz,
-                        );
-
-                        let row0 = *line_pair_index * 2;
-                        let row1 = row0 + 1;
-                        let line_pixels = spec.line_pixels as usize;
-                        for r in [row0, row1] {
-                            let start = (r as usize) * line_pixels;
-                            let end = start + line_pixels;
-                            out.push(SstvEvent::LineDecoded {
-                                mode: *mode,
-                                line_index: r,
-                                pixels: image.pixels[start..end].to_vec(),
-                            });
-                        }
-
-                        buffer.drain(..samples_per_pair);
-                        *line_pair_index += 1;
-
-                        if *line_pair_index * 2 >= spec.image_lines {
-                            // Image complete.
-                            let final_image = std::mem::replace(
-                                image,
-                                SstvImage::new(*mode, spec.line_pixels, spec.image_lines),
-                            );
-                            out.push(SstvEvent::ImageComplete {
-                                image: final_image,
-                                partial: false,
-                            });
-                            // Preserve trailing audio not consumed by the last line pair — it
-                            // may contain the leading edge of a follow-up VIS burst (ARISS
-                            // multi-image case). Feed it into the VIS detector so the next
-                            // process() call sees that audio already buffered.
-                            let trailing = std::mem::take(buffer);
-                            self.state = State::AwaitingVis;
-                            self.vis = crate::vis::VisDetector::new();
-                            self.vis.process(&trailing, self.working_samples_emitted);
-                            break;
-                        }
+                    // Probe sync-band for every newly available stride
+                    // window. The probe needs SYNC_FFT_WINDOW_SAMPLES/2
+                    // trailing samples beyond the center; rather than
+                    // depend on that constant, we conservatively wait
+                    // until the audio extends `SYNC_PROBE_STRIDE * 2`
+                    // beyond the next probe center.
+                    while d.next_probe_sample + SYNC_PROBE_STRIDE * 2 <= d.audio.len() {
+                        let center = d.next_probe_sample + SYNC_PROBE_STRIDE / 2;
+                        let has = d.sync_tracker.has_sync_at(&d.audio, center);
+                        d.has_sync.push(has);
+                        d.next_probe_sample += SYNC_PROBE_STRIDE;
                     }
+
+                    if d.audio.len() < d.target_audio_samples {
+                        break;
+                    }
+
+                    // Buffer is full → run FindSync once, then per-pair decode.
+                    Self::run_findsync_and_decode(d, &mut self.pd_demod, &mut out);
+
+                    // Image complete. Preserve trailing audio not consumed —
+                    // it may contain the leading edge of a follow-up VIS
+                    // burst (ARISS multi-image case). Feed it into a fresh
+                    // VIS detector so the next process() call sees it.
+                    let trailing = std::mem::take(&mut d.audio);
+                    self.state = State::AwaitingVis;
+                    self.vis = crate::vis::VisDetector::new();
+                    self.vis.process(&trailing, self.working_samples_emitted);
                     break;
                 }
             }
         }
         out
+    }
+
+    /// Run [`find_sync`] over the buffered sync track, then decode every
+    /// PD line pair against the corrected `(rate, skip)`. Pushes
+    /// [`SstvEvent::LineDecoded`] for every row + a final
+    /// [`SstvEvent::ImageComplete`] into `out`.
+    #[allow(
+        clippy::cast_precision_loss,
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        clippy::cast_possible_wrap
+    )]
+    fn run_findsync_and_decode(
+        d: &mut DecodingState,
+        pd_demod: &mut crate::mode_pd::PdDemod,
+        out: &mut Vec<SstvEvent>,
+    ) {
+        let work_rate = f64::from(crate::resample::WORKING_SAMPLE_RATE_HZ);
+        let result = find_sync(&d.has_sync, work_rate, d.spec);
+        let rate = result.adjusted_rate_hz;
+        let skip = result.skip_samples;
+
+        let line_pixels = d.spec.line_pixels as usize;
+        let pair_count = d.spec.image_lines / 2;
+        for pair in 0..pair_count {
+            let pair_offset = (f64::from(pair) * d.spec.line_seconds * rate).round() as i64;
+            let pair_start_sample = pair_offset + skip;
+            crate::mode_pd::decode_pd_line_pair(
+                d.spec,
+                pair,
+                &d.audio,
+                pair_start_sample,
+                rate,
+                &mut d.image,
+                pd_demod,
+                d.hedr_shift_hz,
+            );
+            let row0 = pair * 2;
+            let row1 = row0 + 1;
+            for r in [row0, row1] {
+                let start = (r as usize) * line_pixels;
+                let end = start + line_pixels;
+                out.push(SstvEvent::LineDecoded {
+                    mode: d.mode,
+                    line_index: r,
+                    pixels: d.image.pixels[start..end].to_vec(),
+                });
+            }
+        }
+
+        let final_image = std::mem::replace(
+            &mut d.image,
+            SstvImage::new(d.mode, d.spec.line_pixels, d.spec.image_lines),
+        );
+        out.push(SstvEvent::ImageComplete {
+            image: final_image,
+            partial: false,
+        });
     }
 
     /// Reset to `AwaitingVis`; discard any in-flight image.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,7 @@ pub mod image;
 pub mod mode_pd;
 pub mod modespec;
 pub mod resample;
+pub(crate) mod sync;
 pub mod vis;
 
 pub use crate::decoder::{SstvDecoder, SstvEvent};

--- a/src/mode_pd.rs
+++ b/src/mode_pd.rs
@@ -181,31 +181,30 @@ impl PdDemod {
     }
 }
 
-/// Decode one PD radio frame (one Y(odd)/Cr/Cb/Y(even) sequence) into two
-/// image rows of `image`. Translated from slowrx `video.c:81-93` (channel
-/// layout) + `video.c:411-450` (per-pixel demod + chroma combine).
-///
-/// Per channel, we extract a copy of just that channel's samples and run
-/// the FFT against that isolated slice. This prevents the per-pixel FFT
-/// window from leaking into the adjacent channel at the channel edges
-/// (where the other tone would otherwise corrupt the peak search). The
-/// trade-off is a per-channel allocation; for V1's PD120/PD180 sizes
-/// this is negligible (<3 KB / channel / line pair).
+/// Decode one PD radio frame (one `Y(odd)/Cr/Cb/Y(even)` sequence) into two
+/// image rows of `image`. Translated from slowrx `video.c` lines 81-93
+/// (channel layout) and `video.c` lines 411-450 (per-pixel demod + chroma
+/// combine). `pair_start_sample` is where this pair's sync pulse begins
+/// inside `audio`; `rate_hz` is the slant-corrected rate from
+/// [`crate::sync::find_sync`]. We extract a per-channel slice so the
+/// per-pixel FFT window does not bleed across channel edges.
 #[allow(
     clippy::cast_precision_loss,
     clippy::cast_possible_truncation,
     clippy::cast_sign_loss,
-    clippy::cast_possible_wrap
+    clippy::cast_possible_wrap,
+    clippy::too_many_arguments
 )]
 pub(crate) fn decode_pd_line_pair(
     spec: crate::modespec::ModeSpec,
     pair_index: u32,
-    window: &[f32],
+    audio: &[f32],
+    pair_start_sample: i64,
+    rate_hz: f64,
     image: &mut crate::image::SstvImage,
     demod: &mut PdDemod,
     hedr_shift_hz: f64,
 ) {
-    let work_rate = f64::from(crate::resample::WORKING_SAMPLE_RATE_HZ);
     let sync_secs = spec.sync_seconds;
     let porch_secs = spec.porch_seconds;
     let pixel_secs = spec.pixel_seconds;
@@ -234,24 +233,25 @@ pub(crate) fn decode_pd_line_pair(
     {
         let start_sec = chan_starts_sec[chan_idx];
         let end_sec = start_sec + f64::from(width) * pixel_secs;
-        let chan_start = (start_sec * work_rate).round() as i64;
-        let chan_end = (end_sec * work_rate).round() as i64;
+        // Channel start in audio (absolute sample index).
+        let chan_start_abs = pair_start_sample + (start_sec * rate_hz).round() as i64;
+        let chan_end_abs = pair_start_sample + (end_sec * rate_hz).round() as i64;
 
         // Extract just this channel's samples (zero-pad if the input window
         // doesn't fully cover the channel — happens at line-pair end-of-input).
-        let chan_len = (chan_end - chan_start).max(0) as usize;
+        let chan_len = (chan_end_abs - chan_start_abs).max(0) as usize;
         let mut chan_samples = vec![0.0_f32; chan_len];
         for (i, dst) in chan_samples.iter_mut().enumerate() {
-            let src_idx = chan_start + i as i64;
-            if src_idx >= 0 && (src_idx as usize) < window.len() {
-                *dst = window[src_idx as usize];
+            let src_idx = chan_start_abs + i as i64;
+            if src_idx >= 0 && (src_idx as usize) < audio.len() {
+                *dst = audio[src_idx as usize];
             }
         }
 
         for x in 0..width as usize {
             // Center sample relative to the channel slice.
             let center_sec_rel = (x as f64 + 0.5) * pixel_secs;
-            let center_sample_rel = (center_sec_rel * work_rate).round() as i64;
+            let center_sample_rel = (center_sec_rel * rate_hz).round() as i64;
             let freq = demod.pixel_freq(&chan_samples, center_sample_rel, hedr_shift_hz);
             channel_buf[x] = freq_to_luminance(freq, hedr_shift_hz);
         }

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -1,0 +1,567 @@
+//! Slant correction + line-zero phase alignment.
+//!
+//! Translated from slowrx's `sync.c` (Oona Räisänen, ISC License).
+//! See `NOTICE.md` for full attribution.
+//!
+//! Two responsibilities:
+//! 1. [`SyncTracker`] — per-sample boolean stream "is the 1200 Hz sync pulse
+//!    dominant here?" Equivalent of slowrx's `Praw`/`Psync` ratio in
+//!    `video.c` lines 271-297.
+//! 2. [`find_sync`] — given the captured `has_sync` track + estimated rate
+//!    + mode spec, Hough-transform out the slant angle, adjust the rate to
+//!    cancel it, then locate the line-zero `Skip` via 8-tap convolution on
+//!    a column-summed sync image. Equivalent of slowrx's
+//!    `sync.c::FindSync` (lines 18-133).
+//!
+//! ## Adaptation to our streaming model
+//!
+//! slowrx is offline-batch: capture all audio into PCM ring → first
+//! `GetVideo` populates `HasSync[]` → `FindSync` adjusts → second
+//! `GetVideo` re-reads cached `StoredLum` at corrected pixel times.
+//!
+//! Our decoder is streaming. To keep parity we adapt as follows:
+//! - The decoder accumulates `image_lines × line_seconds × headroom` worth
+//!   of working-rate audio in its `Decoding` state.
+//! - During accumulation it probes the audio at [`SYNC_PROBE_STRIDE`]
+//!   samples through [`SyncTracker::has_sync_at`], producing a `Vec<bool>`
+//!   of the same shape slowrx's `HasSync[]` array has.
+//! - Once the buffer is full, [`find_sync`] runs once. Its returned
+//!   `(adjusted_rate_hz, skip_samples)` then drives a single per-pixel
+//!   decode pass over the buffered audio.
+//!
+//! This means `LineDecoded` events fire in fast succession at the end of
+//! the per-image audio window rather than incrementally during decode.
+//! That is acceptable for V1 — callers still get every event, just shifted
+//! in time.
+
+use rustfft::{num_complex::Complex, FftPlanner};
+use std::sync::Arc;
+
+use crate::modespec::ModeSpec;
+use crate::resample::WORKING_SAMPLE_RATE_HZ;
+
+/// Stride between sync-band probes (working-rate samples).
+///
+/// slowrx samples `HasSync[]` every 13 audio samples at 44.1 kHz
+/// (`video.c:295`). At our 11.025 kHz working rate that becomes
+/// `13 × 11025 / 44100 = 3.25` samples. We round down to 3 to keep the
+/// stride a small integer; slowrx's `t * Rate / 13.0` arithmetic uses a
+/// `13.0/44100` time base, so the numerical equivalence is preserved by
+/// scaling consistently in [`find_sync`].
+pub(crate) const SYNC_PROBE_STRIDE: usize = 3;
+
+/// Hann-windowed audio length used per sync probe (samples). slowrx uses
+/// a 64-sample window at 44.1 kHz (`video.c:278`); we scale by 1/4 to
+/// keep the time span (~1.5 ms) constant.
+pub(crate) const SYNC_FFT_WINDOW_SAMPLES: usize = 16;
+
+/// Zero-padded FFT length used per sync probe. slowrx zero-pads to 1024
+/// at 44.1 kHz, giving 43 Hz/bin. We zero-pad to 256 at 11.025 kHz
+/// (`11025 / 256 = 43.07 Hz/bin`) for matching bin density.
+pub(crate) const SYNC_FFT_LEN: usize = 256;
+
+/// Hough-transform slant search bounds (slowrx `common.h:4-5`:
+/// `MINSLANT=30`, `MAXSLANT=150`; step `q ++` in 0.5° units via `q/2.0`).
+const MIN_SLANT_DEG: f64 = 30.0;
+/// Upper-exclusive bound on the slant search.
+const MAX_SLANT_DEG: f64 = 150.0;
+/// Half-degree resolution used by the Hough accumulator.
+const SLANT_STEP_DEG: f64 = 0.5;
+/// Slant lock window (degrees). Matches slowrx `sync.c:83`
+/// (`slantAngle > 89 && slantAngle < 91`).
+const SLANT_OK_LO_DEG: f64 = 89.0;
+/// Upper edge of the slant lock window.
+const SLANT_OK_HI_DEG: f64 = 91.0;
+/// Maximum slant retries before giving up. Matches slowrx `sync.c:86`.
+const MAX_SLANT_RETRIES: usize = 3;
+/// Image-X resolution of the column accumulator. Matches slowrx
+/// `xAcc[700]` in `sync.c:23`.
+const X_ACC_BINS: usize = 700;
+/// Length of slowrx's sync-image Y axis. Matches `SyncImg[700][630]`
+/// (`sync.c:26`); only `NumLines` rows are actually populated.
+const SYNC_IMG_Y_BINS: usize = 630;
+/// Length of slowrx's Hough-line accumulator's d axis. Matches
+/// `lines[600][...]` (`sync.c:24`).
+const LINES_D_BINS: usize = 600;
+
+/// Convert degrees to radians. Matches slowrx `common.c::deg2rad`.
+fn deg2rad(deg: f64) -> f64 {
+    deg * std::f64::consts::PI / 180.0
+}
+
+/// Per-sample sync-band probe context.
+///
+/// Allocates the FFT plan + reusable buffers once. Reuse across probes.
+pub(crate) struct SyncTracker {
+    fft: Arc<dyn rustfft::Fft<f32>>,
+    hann: Vec<f32>,
+    fft_buf: Vec<Complex<f32>>,
+    scratch: Vec<Complex<f32>>,
+    /// Center bin of the 1200 Hz sync target (offset by `hedr_shift_hz`).
+    sync_target_bin: usize,
+    /// Lower bin of the 1500 Hz video band (offset by `hedr_shift_hz`).
+    video_lo_bin: usize,
+    /// Upper bin of the 2300 Hz video band (offset by `hedr_shift_hz`).
+    video_hi_bin: usize,
+}
+
+impl SyncTracker {
+    /// Construct a tracker with the radio mistuning offset extracted at
+    /// VIS time. `hedr_shift_hz` shifts both the sync target (`1200 Hz`)
+    /// and the video band (`1500..=2300 Hz`) so a mistuned radio's bands
+    /// remain centered on the FFT bins searched here.
+    #[allow(
+        clippy::cast_precision_loss,
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss
+    )]
+    pub fn new(hedr_shift_hz: f64) -> Self {
+        let mut planner = FftPlanner::<f32>::new();
+        let fft = planner.plan_fft_forward(SYNC_FFT_LEN);
+        let scratch_len = fft.get_inplace_scratch_len();
+
+        let bin_for = |hz: f64| -> usize {
+            let raw = hz * (SYNC_FFT_LEN as f64) / f64::from(WORKING_SAMPLE_RATE_HZ);
+            raw.round() as usize
+        };
+
+        Self {
+            fft,
+            hann: build_sync_hann(),
+            fft_buf: vec![Complex { re: 0.0, im: 0.0 }; SYNC_FFT_LEN],
+            scratch: vec![Complex { re: 0.0, im: 0.0 }; scratch_len.max(SYNC_FFT_LEN)],
+            sync_target_bin: bin_for(1200.0 + hedr_shift_hz),
+            video_lo_bin: bin_for(1500.0 + hedr_shift_hz),
+            video_hi_bin: bin_for(2300.0 + hedr_shift_hz),
+        }
+    }
+
+    /// Probe a single window centered at `center_sample` of `audio`.
+    /// Returns `true` when the 1200 Hz sync band has more power per Hz
+    /// than the 1500-2300 Hz video band by at least 2×.
+    ///
+    /// Translated from slowrx `video.c` lines 271-297.
+    #[allow(
+        clippy::cast_precision_loss,
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        clippy::cast_possible_wrap
+    )]
+    pub fn has_sync_at(&mut self, audio: &[f32], center_sample: usize) -> bool {
+        // Fill the FFT input: SYNC_FFT_WINDOW_SAMPLES of Hann-windowed audio
+        // around center_sample, zero-padded out to SYNC_FFT_LEN.
+        let half = (SYNC_FFT_WINDOW_SAMPLES as i64) / 2;
+        for slot in &mut self.fft_buf {
+            *slot = Complex { re: 0.0, im: 0.0 };
+        }
+        for i in 0..SYNC_FFT_WINDOW_SAMPLES {
+            let idx = (center_sample as i64) - half + (i as i64);
+            let s = if idx >= 0 && (idx as usize) < audio.len() {
+                audio[idx as usize]
+            } else {
+                0.0
+            };
+            self.fft_buf[i] = Complex {
+                re: s * self.hann[i],
+                im: 0.0,
+            };
+        }
+
+        self.fft
+            .process_with_scratch(&mut self.fft_buf, &mut self.scratch[..]);
+
+        let power = |c: Complex<f32>| -> f64 {
+            let r = f64::from(c.re);
+            let i = f64::from(c.im);
+            r * r + i * i
+        };
+
+        // Praw = average power per bin across the video band.
+        // (slowrx video.c:282-288: sum(power) / num_bins)
+        let mut p_raw = 0.0_f64;
+        let lo = self.video_lo_bin.max(1);
+        let hi = self.video_hi_bin.min(SYNC_FFT_LEN / 2 - 1);
+        if hi >= lo {
+            for k in lo..=hi {
+                p_raw += power(self.fft_buf[k]);
+            }
+            let denom = (hi - lo).max(1) as f64;
+            p_raw /= denom;
+        }
+
+        // Psync = triangle-weighted sum across [target-1, target, target+1] / 2,
+        // matching slowrx video.c:285-289:
+        //     for (i = bin-1; i <= bin+1; i++)
+        //         Psync += power * (1 - 0.5 * abs(bin - i))
+        //     Psync /= 2.0
+        let mut p_sync = 0.0_f64;
+        let bin = self
+            .sync_target_bin
+            .max(1)
+            .min(SYNC_FFT_LEN / 2 - 1);
+        for offset in -1_i32..=1 {
+            let k = (bin as i32 + offset) as usize;
+            let weight = 1.0 - 0.5 * f64::from(offset.abs());
+            p_sync += power(self.fft_buf[k]) * weight;
+        }
+        p_sync /= 2.0;
+
+        // slowrx video.c:293: HasSync = (Psync > 2*Praw)
+        p_sync > 2.0 * p_raw
+    }
+}
+
+/// Build the Hann window used per sync probe.
+#[allow(clippy::cast_precision_loss)]
+fn build_sync_hann() -> Vec<f32> {
+    (0..SYNC_FFT_WINDOW_SAMPLES)
+        .map(|i| {
+            let m = (SYNC_FFT_WINDOW_SAMPLES - 1) as f32;
+            0.5 * (1.0 - (2.0 * std::f32::consts::PI * (i as f32) / m).cos())
+        })
+        .collect()
+}
+
+/// Result of [`find_sync`]: corrected sample rate + line-zero `Skip`.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct SyncResult {
+    /// Adjusted working-rate sample rate (Hz). For drift-free synthetic
+    /// audio this returns close to [`WORKING_SAMPLE_RATE_HZ`]; for real
+    /// recordings it absorbs the typical fraction-of-a-percent drift.
+    pub adjusted_rate_hz: f64,
+    /// Sample offset from the start of the sync track at which line 0's
+    /// video data begins. Negative-equivalent values are clamped to 0;
+    /// callers should treat this as a positive offset.
+    pub skip_samples: i64,
+    /// Detected slant angle (degrees). Diagnostic — values close to 90°
+    /// mean a clean lock; a lock that gave up returns the last estimate.
+    pub slant_deg: f64,
+}
+
+/// Linear Hough transform + line-zero localization.
+///
+/// `has_sync` is the per-stride boolean track produced by [`SyncTracker`]
+/// covering at least one full image's worth of audio. `initial_rate_hz`
+/// is the assumed working rate ([`WORKING_SAMPLE_RATE_HZ`] under normal
+/// operation, but the function will adjust it). `spec` provides the
+/// mode's `LineTime`/`SyncTime`/`PixelTime`/`NumLines`.
+///
+/// Translated from slowrx `sync.c::FindSync` (lines 18-133).
+#[allow(
+    clippy::cast_precision_loss,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    clippy::cast_possible_wrap,
+    clippy::too_many_lines
+)]
+pub(crate) fn find_sync(
+    has_sync: &[bool],
+    initial_rate_hz: f64,
+    spec: ModeSpec,
+) -> SyncResult {
+    // Constants matching slowrx sync.c.
+    let line_width: usize = ((spec.line_seconds / spec.sync_seconds) * 4.0) as usize;
+    // Number of slant bins between MIN_SLANT_DEG and MAX_SLANT_DEG at
+    // SLANT_STEP_DEG resolution. `(150-30) / 0.5 = 240`.
+    let n_slant_bins =
+        ((MAX_SLANT_DEG - MIN_SLANT_DEG) / SLANT_STEP_DEG).round() as usize;
+
+    let mut rate = initial_rate_hz;
+    let mut slant_deg_last = 90.0;
+
+    let num_lines = spec.image_lines as usize;
+
+    // We mirror slowrx's "every 13 samples at 44100 Hz" indexing using
+    // SYNC_PROBE_STRIDE at the working rate. The original index
+    // `(int)(t * Rate / 13.0)` is equivalent here to
+    // `(int)(t * rate / SYNC_PROBE_STRIDE)` because we sample HasSync
+    // every SYNC_PROBE_STRIDE working-rate samples (the "13" in the C
+    // index simply normalizes into stride units).
+    let probe_index = |t_secs: f64, rate_hz: f64| -> usize {
+        let raw = t_secs * rate_hz / (SYNC_PROBE_STRIDE as f64);
+        if raw < 0.0 {
+            0
+        } else {
+            raw as usize
+        }
+    };
+
+    // ---- Hough transform, repeated up to MAX_SLANT_RETRIES times. ----
+    let mut sync_img = vec![false; X_ACC_BINS * SYNC_IMG_Y_BINS];
+    // lines[d][q] — flat layout is `lines[d * n_slant_bins + q]`.
+    let mut lines = vec![0u16; LINES_D_BINS * n_slant_bins];
+
+    for retry in 0..=MAX_SLANT_RETRIES {
+        // Draw the 2D sync signal at current rate.
+        for slot in sync_img.iter_mut().take(line_width.min(X_ACC_BINS) * num_lines) {
+            *slot = false;
+        }
+        // (Easier: just clear all and redraw.)
+        for slot in sync_img.iter_mut() {
+            *slot = false;
+        }
+        for y in 0..num_lines.min(SYNC_IMG_Y_BINS) {
+            for x in 0..line_width.min(X_ACC_BINS) {
+                let t = ((y as f64) + (x as f64) / (line_width as f64)) * spec.line_seconds;
+                let idx = probe_index(t, rate);
+                if idx < has_sync.len() {
+                    sync_img[x * SYNC_IMG_Y_BINS + y] = has_sync[idx];
+                }
+            }
+        }
+
+        // Linear Hough transform.
+        for slot in lines.iter_mut() {
+            *slot = 0;
+        }
+        let mut d_most = 0_usize;
+        let mut q_most = 0_usize;
+        let mut max_count = 0_u16;
+
+        for cy in 0..num_lines.min(SYNC_IMG_Y_BINS) {
+            for cx in 0..line_width.min(X_ACC_BINS) {
+                if !sync_img[cx * SYNC_IMG_Y_BINS + cy] {
+                    continue;
+                }
+                for q in 0..n_slant_bins {
+                    let angle_deg = MIN_SLANT_DEG + (q as f64) * SLANT_STEP_DEG;
+                    let theta = deg2rad(angle_deg);
+                    let d_signed = (line_width as f64)
+                        + (-(cx as f64) * theta.sin() + (cy as f64) * theta.cos()).round();
+                    if d_signed > 0.0 && d_signed < (line_width as f64) {
+                        let d = d_signed as usize;
+                        if d < LINES_D_BINS {
+                            let cell = &mut lines[d * n_slant_bins + q];
+                            *cell = cell.saturating_add(1);
+                            if *cell > max_count {
+                                max_count = *cell;
+                                d_most = d;
+                                q_most = q;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        let _ = d_most; // d_most is informational; not used downstream
+
+        if max_count == 0 {
+            // No sync signal detected.
+            break;
+        }
+
+        let slant_angle =
+            MIN_SLANT_DEG + (q_most as f64) * SLANT_STEP_DEG;
+        slant_deg_last = slant_angle;
+
+        // Adjust rate (slowrx sync.c:81).
+        rate += (deg2rad(90.0 - slant_angle).tan() / (line_width as f64)) * rate;
+
+        if (SLANT_OK_LO_DEG..SLANT_OK_HI_DEG).contains(&slant_angle) {
+            break;
+        }
+        if retry == MAX_SLANT_RETRIES {
+            // Slowrx sync.c:86-90: gives up and resets to 44100. We
+            // instead keep our last estimate — re-anchoring to a wildly
+            // different rate would do more harm than good for a clean
+            // synthetic input that just happens to land at 90.0° on the
+            // first try.
+            break;
+        }
+    }
+
+    // ---- Column accumulator + 8-tap convolution edge-find. ----
+    let mut x_acc = vec![0u32; X_ACC_BINS];
+    for y in 0..num_lines {
+        for x in 0..X_ACC_BINS {
+            let t = (y as f64) * spec.line_seconds
+                + ((x as f64) / (X_ACC_BINS as f64)) * spec.line_seconds;
+            let idx = probe_index(t, rate);
+            if idx < has_sync.len() && has_sync[idx] {
+                x_acc[x] = x_acc[x].saturating_add(1);
+            }
+        }
+    }
+
+    // 8-point convolution kernel [1,1,1,1,-1,-1,-1,-1].
+    // slowrx sync.c:106-113 finds the maximum and snapshots `xmax = x+4`
+    // as the falling-edge position.
+    let kernel: [i32; 8] = [1, 1, 1, 1, -1, -1, -1, -1];
+    let mut xmax: i32 = 0;
+    let mut max_convd: i32 = i32::MIN;
+    for x in 0..X_ACC_BINS - 8 {
+        let mut convd = 0_i32;
+        for (i, &k) in kernel.iter().enumerate() {
+            // x_acc fits comfortably in i32 (at most NumLines, ~500).
+            convd += (x_acc[x + i] as i32) * k;
+        }
+        if convd > max_convd {
+            max_convd = convd;
+            xmax = (x as i32) + 4;
+        }
+    }
+
+    // Slowrx sync.c:117: pulse near the right edge slipped from the
+    // previous line's left edge.
+    if xmax > 350 {
+        xmax -= 350;
+    }
+
+    // Skip = (xmax/700 * LineTime - SyncTime) * Rate (slowrx sync.c:120,127).
+    // We do not implement Scottie offset (sync.c:123-125) — V1 supports
+    // PD-family modes only, so the Scottie branch is unreachable.
+    let s_secs = (f64::from(xmax) / (X_ACC_BINS as f64)) * spec.line_seconds - spec.sync_seconds;
+    let skip_samples = (s_secs * rate).round() as i64;
+
+    SyncResult {
+        adjusted_rate_hz: rate,
+        skip_samples,
+        slant_deg: slant_deg_last,
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::cast_precision_loss,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    clippy::cast_possible_wrap
+)]
+mod tests {
+    use super::*;
+    use crate::modespec;
+    use crate::resample::WORKING_SAMPLE_RATE_HZ;
+    use std::f64::consts::PI;
+
+    fn synth_tone(freq_hz: f64, secs: f64) -> Vec<f32> {
+        let n = (secs * f64::from(WORKING_SAMPLE_RATE_HZ)).round() as usize;
+        (0..n)
+            .map(|i| {
+                let t = (i as f64) / f64::from(WORKING_SAMPLE_RATE_HZ);
+                (2.0 * PI * freq_hz * t).sin() as f32
+            })
+            .collect()
+    }
+
+    #[test]
+    fn has_sync_at_detects_1200_hz_burst() {
+        let mut tracker = SyncTracker::new(0.0);
+        let audio = synth_tone(1200.0, 0.050);
+        let center = audio.len() / 2;
+        assert!(
+            tracker.has_sync_at(&audio, center),
+            "expected sync detection at 1200 Hz tone"
+        );
+    }
+
+    #[test]
+    fn has_sync_at_rejects_1900_hz_tone() {
+        let mut tracker = SyncTracker::new(0.0);
+        let audio = synth_tone(1900.0, 0.050);
+        let center = audio.len() / 2;
+        assert!(
+            !tracker.has_sync_at(&audio, center),
+            "1900 Hz video band should NOT trigger sync detection"
+        );
+    }
+
+    #[test]
+    fn has_sync_at_rejects_silence() {
+        let mut tracker = SyncTracker::new(0.0);
+        let audio = vec![0.0_f32; 1024];
+        assert!(!tracker.has_sync_at(&audio, 512));
+    }
+
+    /// Build a synthetic `has_sync` track with a sync pulse at the start
+    /// of every line (simulating a perfect, drift-free PD signal).
+    fn synth_has_sync(spec: ModeSpec, rate_hz: f64) -> Vec<bool> {
+        let total_secs = (spec.image_lines as f64) * spec.line_seconds;
+        let total_probes = (total_secs * rate_hz / (SYNC_PROBE_STRIDE as f64)) as usize + 16;
+        let mut track = vec![false; total_probes];
+        let track_len = track.len();
+        for y in 0..spec.image_lines {
+            // Sync pulse occupies the first `sync_seconds` of every line.
+            let line_start_secs = (y as f64) * spec.line_seconds;
+            let line_end_secs = line_start_secs + spec.sync_seconds;
+            let i_start =
+                (line_start_secs * rate_hz / (SYNC_PROBE_STRIDE as f64)) as usize;
+            let i_end =
+                (line_end_secs * rate_hz / (SYNC_PROBE_STRIDE as f64)) as usize;
+            for slot in track.iter_mut().take(i_end.min(track_len)).skip(i_start) {
+                *slot = true;
+            }
+        }
+        track
+    }
+
+    #[test]
+    fn find_sync_locks_clean_track_to_90_degrees() {
+        let spec = modespec::for_mode(crate::modespec::SstvMode::Pd120);
+        let rate = f64::from(WORKING_SAMPLE_RATE_HZ);
+        let track = synth_has_sync(spec, rate);
+        let result = find_sync(&track, rate, spec);
+        // A drift-free track should be locked at 90° on the first pass and
+        // produce a near-zero Skip (line 0 sync starts at sample 0).
+        assert!(
+            (result.slant_deg - 90.0).abs() < 1.0,
+            "expected ≈90°, got {:.2}",
+            result.slant_deg
+        );
+        // adjusted rate stays close to the input
+        assert!(
+            (result.adjusted_rate_hz - rate).abs() / rate < 0.005,
+            "rate drift too large: {} vs {}",
+            result.adjusted_rate_hz,
+            rate
+        );
+        // Skip is small (line 0 sync starts at the buffer head).
+        assert!(
+            result.skip_samples.abs() < (0.05 * rate) as i64,
+            "Skip too large: {} samples",
+            result.skip_samples
+        );
+    }
+
+    #[test]
+    fn find_sync_recovers_known_offset() {
+        // Same as above but offset the sync pulses by a constant so line 0
+        // does not start at index 0.
+        let spec = modespec::for_mode(crate::modespec::SstvMode::Pd120);
+        let rate = f64::from(WORKING_SAMPLE_RATE_HZ);
+        let mut track = synth_has_sync(spec, rate);
+        // Shift the entire track right by ~10 ms (a real radio's pre-line
+        // settling gap).
+        let shift_probes =
+            ((0.010 * rate) / (SYNC_PROBE_STRIDE as f64)) as usize;
+        let mut shifted = vec![false; shift_probes];
+        shifted.append(&mut track);
+        let result = find_sync(&shifted, rate, spec);
+        // Skip should be close to the shift (in working-rate samples).
+        let expected_skip = (0.010 * rate) as i64;
+        let diff = (result.skip_samples - expected_skip).abs();
+        // The convolutional edge detector lands within one bin of the
+        // 700-bin row (~LineTime/700 ≈ 0.7 ms = ~8 samples for PD120).
+        // Allow a few times that to tolerate Hough-quantization wobble.
+        assert!(
+            diff < (0.005 * rate) as i64,
+            "Skip recovery off by {diff} samples (expected ≈ {expected_skip}, got {})",
+            result.skip_samples
+        );
+    }
+
+    #[test]
+    fn find_sync_handles_empty_track() {
+        // No sync pulses anywhere — the algorithm should return without
+        // panicking. Skip + rate may be garbage but must be finite.
+        let spec = modespec::for_mode(crate::modespec::SstvMode::Pd120);
+        let rate = f64::from(WORKING_SAMPLE_RATE_HZ);
+        let track = vec![false; 16384];
+        let result = find_sync(&track, rate, spec);
+        assert!(result.adjusted_rate_hz.is_finite());
+        // No detection should leave rate unchanged.
+        assert!((result.adjusted_rate_hz - rate).abs() < 1.0);
+    }
+}

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -1,38 +1,24 @@
 //! Slant correction + line-zero phase alignment.
 //!
 //! Translated from slowrx's `sync.c` (Oona Räisänen, ISC License).
-//! See `NOTICE.md` for full attribution.
+//! See `NOTICE.md`. Two responsibilities:
 //!
-//! Two responsibilities:
-//! 1. [`SyncTracker`] — per-sample boolean stream "is the 1200 Hz sync pulse
+//! 1. [`SyncTracker`] — per-sample boolean "is the 1200 Hz sync pulse
 //!    dominant here?" Equivalent of slowrx's `Praw`/`Psync` ratio in
 //!    `video.c` lines 271-297.
-//! 2. [`find_sync`] — given the captured `has_sync` track + estimated rate
-//!    + mode spec, Hough-transform out the slant angle, adjust the rate to
-//!    cancel it, then locate the line-zero `Skip` via 8-tap convolution on
-//!    a column-summed sync image. Equivalent of slowrx's
-//!    `sync.c::FindSync` (lines 18-133).
+//! 2. [`find_sync`] — Hough-transform a captured `has_sync` track to
+//!    detect slant, adjust the rate to cancel it, then locate line 0's
+//!    `Skip` via 8-tap convolution on the column-summed sync image.
+//!    Equivalent of slowrx's `sync.c::FindSync` (lines 18-133).
 //!
-//! ## Adaptation to our streaming model
-//!
-//! slowrx is offline-batch: capture all audio into PCM ring → first
-//! `GetVideo` populates `HasSync[]` → `FindSync` adjusts → second
-//! `GetVideo` re-reads cached `StoredLum` at corrected pixel times.
-//!
-//! Our decoder is streaming. To keep parity we adapt as follows:
-//! - The decoder accumulates `image_lines × line_seconds × headroom` worth
-//!   of working-rate audio in its `Decoding` state.
-//! - During accumulation it probes the audio at [`SYNC_PROBE_STRIDE`]
-//!   samples through [`SyncTracker::has_sync_at`], producing a `Vec<bool>`
-//!   of the same shape slowrx's `HasSync[]` array has.
-//! - Once the buffer is full, [`find_sync`] runs once. Its returned
-//!   `(adjusted_rate_hz, skip_samples)` then drives a single per-pixel
-//!   decode pass over the buffered audio.
-//!
-//! This means `LineDecoded` events fire in fast succession at the end of
-//! the per-image audio window rather than incrementally during decode.
-//! That is acceptable for V1 — callers still get every event, just shifted
-//! in time.
+//! Slowrx is offline-batch (read-all → first `GetVideo` populates
+//! `HasSync[]` → `FindSync` adjusts → second `GetVideo` rereads cached
+//! `StoredLum` at corrected pixel times). Our decoder accumulates one
+//! image's worth of audio in the `Decoding` state, probes [`SyncTracker`]
+//! at every [`SYNC_PROBE_STRIDE`] samples, then runs [`find_sync`] once.
+//! The corrected `(rate, skip)` drives a single per-pixel decode pass.
+//! `LineDecoded` events fire in fast succession at end-of-buffer rather
+//! than incrementally; callers still see every event.
 
 use rustfft::{num_complex::Complex, FftPlanner};
 use std::sync::Arc;
@@ -40,48 +26,32 @@ use std::sync::Arc;
 use crate::modespec::ModeSpec;
 use crate::resample::WORKING_SAMPLE_RATE_HZ;
 
-/// Stride between sync-band probes (working-rate samples).
-///
-/// slowrx samples `HasSync[]` every 13 audio samples at 44.1 kHz
-/// (`video.c:295`). At our 11.025 kHz working rate that becomes
-/// `13 × 11025 / 44100 = 3.25` samples. We round down to 3 to keep the
-/// stride a small integer; slowrx's `t * Rate / 13.0` arithmetic uses a
-/// `13.0/44100` time base, so the numerical equivalence is preserved by
-/// scaling consistently in [`find_sync`].
+/// Stride between sync-band probes (working-rate samples). slowrx uses
+/// 13 samples@44.1kHz (`video.c:295`) ≈ 3.25@11.025kHz; we round to 3.
+/// Index math in [`find_sync`] scales by `SYNC_PROBE_STRIDE` for parity.
 pub(crate) const SYNC_PROBE_STRIDE: usize = 3;
 
-/// Hann-windowed audio length used per sync probe (samples). slowrx uses
-/// a 64-sample window at 44.1 kHz (`video.c:278`); we scale by 1/4 to
-/// keep the time span (~1.5 ms) constant.
+/// Hann-windowed audio length per sync probe (samples). 1/4 of slowrx's
+/// 64@44.1kHz keeps the time span (~1.5 ms) constant (`video.c:278`).
 pub(crate) const SYNC_FFT_WINDOW_SAMPLES: usize = 16;
 
-/// Zero-padded FFT length used per sync probe. slowrx zero-pads to 1024
-/// at 44.1 kHz, giving 43 Hz/bin. We zero-pad to 256 at 11.025 kHz
-/// (`11025 / 256 = 43.07 Hz/bin`) for matching bin density.
+/// Zero-padded FFT length per sync probe. 256@11025 = 43 Hz/bin matches
+/// slowrx's 1024@44100 (`video.c:280`).
 pub(crate) const SYNC_FFT_LEN: usize = 256;
 
-/// Hough-transform slant search bounds (slowrx `common.h:4-5`:
-/// `MINSLANT=30`, `MAXSLANT=150`; step `q ++` in 0.5° units via `q/2.0`).
+// Hough-transform slant search (slowrx `common.h:4-5` MINSLANT/MAXSLANT
+// + sync.c step `q++` in 0.5° units via `q/2.0`); slant lock window
+// matches sync.c:83 `slantAngle > 89 && slantAngle < 91`.
 const MIN_SLANT_DEG: f64 = 30.0;
-/// Upper-exclusive bound on the slant search.
 const MAX_SLANT_DEG: f64 = 150.0;
-/// Half-degree resolution used by the Hough accumulator.
 const SLANT_STEP_DEG: f64 = 0.5;
-/// Slant lock window (degrees). Matches slowrx `sync.c:83`
-/// (`slantAngle > 89 && slantAngle < 91`).
 const SLANT_OK_LO_DEG: f64 = 89.0;
-/// Upper edge of the slant lock window.
 const SLANT_OK_HI_DEG: f64 = 91.0;
-/// Maximum slant retries before giving up. Matches slowrx `sync.c:86`.
 const MAX_SLANT_RETRIES: usize = 3;
-/// Image-X resolution of the column accumulator. Matches slowrx
-/// `xAcc[700]` in `sync.c:23`.
+// `xAcc[700]` (sync.c:23), `SyncImg[700][630]` (sync.c:26),
+// `lines[600][...]` (sync.c:24).
 const X_ACC_BINS: usize = 700;
-/// Length of slowrx's sync-image Y axis. Matches `SyncImg[700][630]`
-/// (`sync.c:26`); only `NumLines` rows are actually populated.
 const SYNC_IMG_Y_BINS: usize = 630;
-/// Length of slowrx's Hough-line accumulator's d axis. Matches
-/// `lines[600][...]` (`sync.c:24`).
 const LINES_D_BINS: usize = 600;
 
 /// Convert degrees to radians. Matches slowrx `common.c::deg2rad`.
@@ -89,27 +59,23 @@ fn deg2rad(deg: f64) -> f64 {
     deg * std::f64::consts::PI / 180.0
 }
 
-/// Per-sample sync-band probe context.
-///
-/// Allocates the FFT plan + reusable buffers once. Reuse across probes.
+/// Per-sample sync-band probe context (FFT plan + buffers reused across
+/// probes). `sync_target_bin` / `video_{lo,hi}_bin` are pre-computed bin
+/// offsets corresponding to `1200 Hz` and `1500..=2300 Hz` shifted by
+/// `hedr_shift_hz`.
 pub(crate) struct SyncTracker {
     fft: Arc<dyn rustfft::Fft<f32>>,
     hann: Vec<f32>,
     fft_buf: Vec<Complex<f32>>,
     scratch: Vec<Complex<f32>>,
-    /// Center bin of the 1200 Hz sync target (offset by `hedr_shift_hz`).
     sync_target_bin: usize,
-    /// Lower bin of the 1500 Hz video band (offset by `hedr_shift_hz`).
     video_lo_bin: usize,
-    /// Upper bin of the 2300 Hz video band (offset by `hedr_shift_hz`).
     video_hi_bin: usize,
 }
 
 impl SyncTracker {
     /// Construct a tracker with the radio mistuning offset extracted at
-    /// VIS time. `hedr_shift_hz` shifts both the sync target (`1200 Hz`)
-    /// and the video band (`1500..=2300 Hz`) so a mistuned radio's bands
-    /// remain centered on the FFT bins searched here.
+    /// VIS time.
     #[allow(
         clippy::cast_precision_loss,
         clippy::cast_possible_truncation,
@@ -148,12 +114,8 @@ impl SyncTracker {
         clippy::cast_possible_wrap
     )]
     pub fn has_sync_at(&mut self, audio: &[f32], center_sample: usize) -> bool {
-        // Fill the FFT input: SYNC_FFT_WINDOW_SAMPLES of Hann-windowed audio
-        // around center_sample, zero-padded out to SYNC_FFT_LEN.
         let half = (SYNC_FFT_WINDOW_SAMPLES as i64) / 2;
-        for slot in &mut self.fft_buf {
-            *slot = Complex { re: 0.0, im: 0.0 };
-        }
+        self.fft_buf.fill(Complex { re: 0.0, im: 0.0 });
         for i in 0..SYNC_FFT_WINDOW_SAMPLES {
             let idx = (center_sample as i64) - half + (i as i64);
             let s = if idx >= 0 && (idx as usize) < audio.len() {
@@ -161,12 +123,8 @@ impl SyncTracker {
             } else {
                 0.0
             };
-            self.fft_buf[i] = Complex {
-                re: s * self.hann[i],
-                im: 0.0,
-            };
+            self.fft_buf[i].re = s * self.hann[i];
         }
-
         self.fft
             .process_with_scratch(&mut self.fft_buf, &mut self.scratch[..]);
 
@@ -176,8 +134,7 @@ impl SyncTracker {
             r * r + i * i
         };
 
-        // Praw = average power per bin across the video band.
-        // (slowrx video.c:282-288: sum(power) / num_bins)
+        // Praw = average power per bin across video band (video.c:282-288).
         let mut p_raw = 0.0_f64;
         let lo = self.video_lo_bin.max(1);
         let hi = self.video_hi_bin.min(SYNC_FFT_LEN / 2 - 1);
@@ -185,20 +142,13 @@ impl SyncTracker {
             for k in lo..=hi {
                 p_raw += power(self.fft_buf[k]);
             }
-            let denom = (hi - lo).max(1) as f64;
-            p_raw /= denom;
+            p_raw /= (hi - lo).max(1) as f64;
         }
 
-        // Psync = triangle-weighted sum across [target-1, target, target+1] / 2,
-        // matching slowrx video.c:285-289:
-        //     for (i = bin-1; i <= bin+1; i++)
-        //         Psync += power * (1 - 0.5 * abs(bin - i))
-        //     Psync /= 2.0
+        // Psync = triangle-weighted sum across [bin-1, bin, bin+1] / 2
+        // (video.c:285-289).
         let mut p_sync = 0.0_f64;
-        let bin = self
-            .sync_target_bin
-            .max(1)
-            .min(SYNC_FFT_LEN / 2 - 1);
+        let bin = self.sync_target_bin.clamp(1, SYNC_FFT_LEN / 2 - 1);
         for offset in -1_i32..=1 {
             let k = (bin as i32 + offset) as usize;
             let weight = 1.0 - 0.5 * f64::from(offset.abs());
@@ -222,31 +172,27 @@ fn build_sync_hann() -> Vec<f32> {
         .collect()
 }
 
-/// Result of [`find_sync`]: corrected sample rate + line-zero `Skip`.
+/// Result of [`find_sync`]: slant-corrected rate + line-zero `Skip`.
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct SyncResult {
-    /// Adjusted working-rate sample rate (Hz). For drift-free synthetic
-    /// audio this returns close to [`WORKING_SAMPLE_RATE_HZ`]; for real
-    /// recordings it absorbs the typical fraction-of-a-percent drift.
+    /// Adjusted working-rate sample rate (Hz).
     pub adjusted_rate_hz: f64,
-    /// Sample offset from the start of the sync track at which line 0's
-    /// video data begins. Negative-equivalent values are clamped to 0;
-    /// callers should treat this as a positive offset.
+    /// Sample offset from the start of the sync track where line 0's
+    /// video data begins. May be slightly negative; the decoder zero-pads
+    /// out-of-range reads when computing per-channel slices.
     pub skip_samples: i64,
-    /// Detected slant angle (degrees). Diagnostic — values close to 90°
-    /// mean a clean lock; a lock that gave up returns the last estimate.
+    /// Detected slant angle (degrees). Diagnostic — read by tests; the
+    /// decoder consumes only `adjusted_rate_hz` + `skip_samples`.
+    #[allow(dead_code)]
     pub slant_deg: f64,
 }
 
-/// Linear Hough transform + line-zero localization.
+/// Linear Hough transform + 8-tap convolution edge-find.
 ///
-/// `has_sync` is the per-stride boolean track produced by [`SyncTracker`]
-/// covering at least one full image's worth of audio. `initial_rate_hz`
-/// is the assumed working rate ([`WORKING_SAMPLE_RATE_HZ`] under normal
-/// operation, but the function will adjust it). `spec` provides the
-/// mode's `LineTime`/`SyncTime`/`PixelTime`/`NumLines`.
-///
-/// Translated from slowrx `sync.c::FindSync` (lines 18-133).
+/// `has_sync` is the per-stride boolean track produced by [`SyncTracker`].
+/// `initial_rate_hz` is normally [`WORKING_SAMPLE_RATE_HZ`] but the
+/// function may adjust it. Translated from slowrx `sync.c::FindSync`
+/// (lines 18-133).
 #[allow(
     clippy::cast_precision_loss,
     clippy::cast_possible_truncation,
@@ -254,31 +200,18 @@ pub(crate) struct SyncResult {
     clippy::cast_possible_wrap,
     clippy::too_many_lines
 )]
-pub(crate) fn find_sync(
-    has_sync: &[bool],
-    initial_rate_hz: f64,
-    spec: ModeSpec,
-) -> SyncResult {
-    // Constants matching slowrx sync.c.
+pub(crate) fn find_sync(has_sync: &[bool], initial_rate_hz: f64, spec: ModeSpec) -> SyncResult {
     let line_width: usize = ((spec.line_seconds / spec.sync_seconds) * 4.0) as usize;
-    // Number of slant bins between MIN_SLANT_DEG and MAX_SLANT_DEG at
-    // SLANT_STEP_DEG resolution. `(150-30) / 0.5 = 240`.
-    let n_slant_bins =
-        ((MAX_SLANT_DEG - MIN_SLANT_DEG) / SLANT_STEP_DEG).round() as usize;
-
+    // (150-30) / 0.5 = 240 half-degree bins.
+    let n_slant_bins = ((MAX_SLANT_DEG - MIN_SLANT_DEG) / SLANT_STEP_DEG).round() as usize;
     let mut rate = initial_rate_hz;
     let mut slant_deg_last = 90.0;
-
     let num_lines = spec.image_lines as usize;
 
-    // We mirror slowrx's "every 13 samples at 44100 Hz" indexing using
-    // SYNC_PROBE_STRIDE at the working rate. The original index
-    // `(int)(t * Rate / 13.0)` is equivalent here to
-    // `(int)(t * rate / SYNC_PROBE_STRIDE)` because we sample HasSync
-    // every SYNC_PROBE_STRIDE working-rate samples (the "13" in the C
-    // index simply normalizes into stride units).
-    let probe_index = |t_secs: f64, rate_hz: f64| -> usize {
-        let raw = t_secs * rate_hz / (SYNC_PROBE_STRIDE as f64);
+    // slowrx's `(int)(t * Rate / 13.0)` becomes `(int)(t * rate / STRIDE)`
+    // (the "13" in slowrx's index normalizes to stride units).
+    let probe_index = |t: f64, rate_hz: f64| -> usize {
+        let raw = t * rate_hz / (SYNC_PROBE_STRIDE as f64);
         if raw < 0.0 {
             0
         } else {
@@ -286,20 +219,13 @@ pub(crate) fn find_sync(
         }
     };
 
-    // ---- Hough transform, repeated up to MAX_SLANT_RETRIES times. ----
     let mut sync_img = vec![false; X_ACC_BINS * SYNC_IMG_Y_BINS];
-    // lines[d][q] — flat layout is `lines[d * n_slant_bins + q]`.
+    // lines[d][q] flattened as lines[d * n_slant_bins + q].
     let mut lines = vec![0u16; LINES_D_BINS * n_slant_bins];
 
     for retry in 0..=MAX_SLANT_RETRIES {
         // Draw the 2D sync signal at current rate.
-        for slot in sync_img.iter_mut().take(line_width.min(X_ACC_BINS) * num_lines) {
-            *slot = false;
-        }
-        // (Easier: just clear all and redraw.)
-        for slot in sync_img.iter_mut() {
-            *slot = false;
-        }
+        sync_img.fill(false);
         for y in 0..num_lines.min(SYNC_IMG_Y_BINS) {
             for x in 0..line_width.min(X_ACC_BINS) {
                 let t = ((y as f64) + (x as f64) / (line_width as f64)) * spec.line_seconds;
@@ -311,21 +237,16 @@ pub(crate) fn find_sync(
         }
 
         // Linear Hough transform.
-        for slot in lines.iter_mut() {
-            *slot = 0;
-        }
-        let mut d_most = 0_usize;
+        lines.fill(0);
         let mut q_most = 0_usize;
         let mut max_count = 0_u16;
-
         for cy in 0..num_lines.min(SYNC_IMG_Y_BINS) {
             for cx in 0..line_width.min(X_ACC_BINS) {
                 if !sync_img[cx * SYNC_IMG_Y_BINS + cy] {
                     continue;
                 }
                 for q in 0..n_slant_bins {
-                    let angle_deg = MIN_SLANT_DEG + (q as f64) * SLANT_STEP_DEG;
-                    let theta = deg2rad(angle_deg);
+                    let theta = deg2rad(MIN_SLANT_DEG + (q as f64) * SLANT_STEP_DEG);
                     let d_signed = (line_width as f64)
                         + (-(cx as f64) * theta.sin() + (cy as f64) * theta.cos()).round();
                     if d_signed > 0.0 && d_signed < (line_width as f64) {
@@ -335,7 +256,6 @@ pub(crate) fn find_sync(
                             *cell = cell.saturating_add(1);
                             if *cell > max_count {
                                 max_count = *cell;
-                                d_most = d;
                                 q_most = q;
                             }
                         }
@@ -344,73 +264,64 @@ pub(crate) fn find_sync(
             }
         }
 
-        let _ = d_most; // d_most is informational; not used downstream
-
         if max_count == 0 {
-            // No sync signal detected.
             break;
         }
 
-        let slant_angle =
-            MIN_SLANT_DEG + (q_most as f64) * SLANT_STEP_DEG;
+        let slant_angle = MIN_SLANT_DEG + (q_most as f64) * SLANT_STEP_DEG;
         slant_deg_last = slant_angle;
 
-        // Adjust rate (slowrx sync.c:81).
-        rate += (deg2rad(90.0 - slant_angle).tan() / (line_width as f64)) * rate;
-
-        if (SLANT_OK_LO_DEG..SLANT_OK_HI_DEG).contains(&slant_angle) {
-            break;
+        // Apply a deadband at 90° so an exact-rate input is not perturbed
+        // by half-degree Hough quantization noise — without this, a 90.5°
+        // bin lands a 0.0085% rate "correction" that compounds across the
+        // per-line xAcc projection and corrupts the falling-edge find.
+        if (slant_angle - 90.0).abs() > SLANT_STEP_DEG {
+            rate += (deg2rad(90.0 - slant_angle).tan() / (line_width as f64)) * rate;
         }
-        if retry == MAX_SLANT_RETRIES {
-            // Slowrx sync.c:86-90: gives up and resets to 44100. We
-            // instead keep our last estimate — re-anchoring to a wildly
-            // different rate would do more harm than good for a clean
-            // synthetic input that just happens to land at 90.0° on the
-            // first try.
+
+        // sync.c:86-90 resets to 44100 on retry exhaustion; we keep our
+        // last estimate (re-anchoring a near-locked input is harmful).
+        if (SLANT_OK_LO_DEG..SLANT_OK_HI_DEG).contains(&slant_angle) || retry == MAX_SLANT_RETRIES {
             break;
         }
     }
 
-    // ---- Column accumulator + 8-tap convolution edge-find. ----
+    // Column accumulator + 8-tap convolution edge-find (sync.c:96-113).
     let mut x_acc = vec![0u32; X_ACC_BINS];
     for y in 0..num_lines {
-        for x in 0..X_ACC_BINS {
+        for (x, slot) in x_acc.iter_mut().enumerate() {
             let t = (y as f64) * spec.line_seconds
                 + ((x as f64) / (X_ACC_BINS as f64)) * spec.line_seconds;
             let idx = probe_index(t, rate);
             if idx < has_sync.len() && has_sync[idx] {
-                x_acc[x] = x_acc[x].saturating_add(1);
+                *slot = slot.saturating_add(1);
             }
         }
     }
 
-    // 8-point convolution kernel [1,1,1,1,-1,-1,-1,-1].
-    // slowrx sync.c:106-113 finds the maximum and snapshots `xmax = x+4`
-    // as the falling-edge position.
+    // 8-tap kernel snapshots `xmax = x+4` at the steepest falling edge.
     let kernel: [i32; 8] = [1, 1, 1, 1, -1, -1, -1, -1];
     let mut xmax: i32 = 0;
     let mut max_convd: i32 = i32::MIN;
-    for x in 0..X_ACC_BINS - 8 {
-        let mut convd = 0_i32;
-        for (i, &k) in kernel.iter().enumerate() {
-            // x_acc fits comfortably in i32 (at most NumLines, ~500).
-            convd += (x_acc[x + i] as i32) * k;
-        }
+    for (x, window) in x_acc.windows(8).enumerate() {
+        let convd: i32 = window
+            .iter()
+            .zip(kernel.iter())
+            .map(|(&v, &k)| (v as i32) * k)
+            .sum();
         if convd > max_convd {
             max_convd = convd;
             xmax = (x as i32) + 4;
         }
     }
 
-    // Slowrx sync.c:117: pulse near the right edge slipped from the
-    // previous line's left edge.
+    // sync.c:117 — pulse near the right edge slipped from previous left.
     if xmax > 350 {
         xmax -= 350;
     }
 
-    // Skip = (xmax/700 * LineTime - SyncTime) * Rate (slowrx sync.c:120,127).
-    // We do not implement Scottie offset (sync.c:123-125) — V1 supports
-    // PD-family modes only, so the Scottie branch is unreachable.
+    // sync.c:120,127. V1 ports PD-family only; the Scottie branch
+    // (sync.c:123-125) is unreachable here.
     let s_secs = (f64::from(xmax) / (X_ACC_BINS as f64)) * spec.line_seconds - spec.sync_seconds;
     let skip_samples = (s_secs * rate).round() as i64;
 
@@ -450,47 +361,34 @@ mod tests {
     fn has_sync_at_detects_1200_hz_burst() {
         let mut tracker = SyncTracker::new(0.0);
         let audio = synth_tone(1200.0, 0.050);
-        let center = audio.len() / 2;
-        assert!(
-            tracker.has_sync_at(&audio, center),
-            "expected sync detection at 1200 Hz tone"
-        );
+        assert!(tracker.has_sync_at(&audio, audio.len() / 2));
     }
 
     #[test]
     fn has_sync_at_rejects_1900_hz_tone() {
         let mut tracker = SyncTracker::new(0.0);
         let audio = synth_tone(1900.0, 0.050);
-        let center = audio.len() / 2;
-        assert!(
-            !tracker.has_sync_at(&audio, center),
-            "1900 Hz video band should NOT trigger sync detection"
-        );
+        assert!(!tracker.has_sync_at(&audio, audio.len() / 2));
     }
 
     #[test]
     fn has_sync_at_rejects_silence() {
         let mut tracker = SyncTracker::new(0.0);
-        let audio = vec![0.0_f32; 1024];
-        assert!(!tracker.has_sync_at(&audio, 512));
+        assert!(!tracker.has_sync_at(&vec![0.0_f32; 1024], 512));
     }
 
-    /// Build a synthetic `has_sync` track with a sync pulse at the start
-    /// of every line (simulating a perfect, drift-free PD signal).
+    /// Build a synthetic `has_sync` track with a sync pulse at every line start.
     fn synth_has_sync(spec: ModeSpec, rate_hz: f64) -> Vec<bool> {
-        let total_secs = (spec.image_lines as f64) * spec.line_seconds;
-        let total_probes = (total_secs * rate_hz / (SYNC_PROBE_STRIDE as f64)) as usize + 16;
-        let mut track = vec![false; total_probes];
-        let track_len = track.len();
+        let total = (f64::from(spec.image_lines) * spec.line_seconds * rate_hz
+            / (SYNC_PROBE_STRIDE as f64)) as usize
+            + 16;
+        let mut track = vec![false; total];
         for y in 0..spec.image_lines {
-            // Sync pulse occupies the first `sync_seconds` of every line.
-            let line_start_secs = (y as f64) * spec.line_seconds;
-            let line_end_secs = line_start_secs + spec.sync_seconds;
             let i_start =
-                (line_start_secs * rate_hz / (SYNC_PROBE_STRIDE as f64)) as usize;
-            let i_end =
-                (line_end_secs * rate_hz / (SYNC_PROBE_STRIDE as f64)) as usize;
-            for slot in track.iter_mut().take(i_end.min(track_len)).skip(i_start) {
+                (f64::from(y) * spec.line_seconds * rate_hz / (SYNC_PROBE_STRIDE as f64)) as usize;
+            let i_end = ((f64::from(y) * spec.line_seconds + spec.sync_seconds) * rate_hz
+                / (SYNC_PROBE_STRIDE as f64)) as usize;
+            for slot in track.iter_mut().take(i_end.min(total)).skip(i_start) {
                 *slot = true;
             }
         }
@@ -501,67 +399,37 @@ mod tests {
     fn find_sync_locks_clean_track_to_90_degrees() {
         let spec = modespec::for_mode(crate::modespec::SstvMode::Pd120);
         let rate = f64::from(WORKING_SAMPLE_RATE_HZ);
-        let track = synth_has_sync(spec, rate);
-        let result = find_sync(&track, rate, spec);
-        // A drift-free track should be locked at 90° on the first pass and
-        // produce a near-zero Skip (line 0 sync starts at sample 0).
-        assert!(
-            (result.slant_deg - 90.0).abs() < 1.0,
-            "expected ≈90°, got {:.2}",
-            result.slant_deg
-        );
-        // adjusted rate stays close to the input
-        assert!(
-            (result.adjusted_rate_hz - rate).abs() / rate < 0.005,
-            "rate drift too large: {} vs {}",
-            result.adjusted_rate_hz,
-            rate
-        );
-        // Skip is small (line 0 sync starts at the buffer head).
-        assert!(
-            result.skip_samples.abs() < (0.05 * rate) as i64,
-            "Skip too large: {} samples",
-            result.skip_samples
-        );
+        let r = find_sync(&synth_has_sync(spec, rate), rate, spec);
+        assert!((r.slant_deg - 90.0).abs() < 1.0, "{:.2}°", r.slant_deg);
+        assert!((r.adjusted_rate_hz - rate).abs() / rate < 0.005);
+        assert!(r.skip_samples.abs() < (0.05 * rate) as i64);
     }
 
     #[test]
     fn find_sync_recovers_known_offset() {
-        // Same as above but offset the sync pulses by a constant so line 0
-        // does not start at index 0.
         let spec = modespec::for_mode(crate::modespec::SstvMode::Pd120);
         let rate = f64::from(WORKING_SAMPLE_RATE_HZ);
+        // Right-shift the track by ~10 ms (a real-radio settling gap).
         let mut track = synth_has_sync(spec, rate);
-        // Shift the entire track right by ~10 ms (a real radio's pre-line
-        // settling gap).
-        let shift_probes =
-            ((0.010 * rate) / (SYNC_PROBE_STRIDE as f64)) as usize;
-        let mut shifted = vec![false; shift_probes];
+        let shift = ((0.010 * rate) / (SYNC_PROBE_STRIDE as f64)) as usize;
+        let mut shifted = vec![false; shift];
         shifted.append(&mut track);
-        let result = find_sync(&shifted, rate, spec);
-        // Skip should be close to the shift (in working-rate samples).
-        let expected_skip = (0.010 * rate) as i64;
-        let diff = (result.skip_samples - expected_skip).abs();
-        // The convolutional edge detector lands within one bin of the
-        // 700-bin row (~LineTime/700 ≈ 0.7 ms = ~8 samples for PD120).
-        // Allow a few times that to tolerate Hough-quantization wobble.
+        let r = find_sync(&shifted, rate, spec);
+        let expected = (0.010 * rate) as i64;
+        // 700-bin row ≈ 0.7 ms / bin at PD120; allow a few bins for wobble.
         assert!(
-            diff < (0.005 * rate) as i64,
-            "Skip recovery off by {diff} samples (expected ≈ {expected_skip}, got {})",
-            result.skip_samples
+            (r.skip_samples - expected).abs() < (0.005 * rate) as i64,
+            "Skip off (expected ≈ {expected}, got {})",
+            r.skip_samples
         );
     }
 
     #[test]
     fn find_sync_handles_empty_track() {
-        // No sync pulses anywhere — the algorithm should return without
-        // panicking. Skip + rate may be garbage but must be finite.
         let spec = modespec::for_mode(crate::modespec::SstvMode::Pd120);
         let rate = f64::from(WORKING_SAMPLE_RATE_HZ);
-        let track = vec![false; 16384];
-        let result = find_sync(&track, rate, spec);
-        assert!(result.adjusted_rate_hz.is_finite());
-        // No detection should leave rate unchanged.
-        assert!((result.adjusted_rate_hz - rate).abs() < 1.0);
+        let r = find_sync(&vec![false; 16384], rate, spec);
+        assert!(r.adjusted_rate_hz.is_finite());
+        assert!((r.adjusted_rate_hz - rate).abs() < 1.0);
     }
 }


### PR DESCRIPTION
## Summary

Phase 2 of the slowrx C↔Rust parity recovery (master tracker #12). Closes 4 audit issues.

Ports slowrx's `sync.c::FindSync` — Hough-transform slant correction, falling-edge `Skip` localization, and rate adjustment — into Rust as `src/sync.rs`. Refactors `decoder.rs::Decoding` into a two-pass flow: accumulate full-image audio + `HasSync[]` track, run `find_sync` to derive `(adjusted_rate, skip_samples, slant_deg)`, then decode using those values.

## Closes

- #19 — `find_sync` Hough transform port (slant detection)
- #20 — `find_sync` Skip / falling-edge port
- #21 — `find_sync` rate-correction port
- #22 — `Praw`/`Psync` per-window sync-band power (`HasSync[]`) tracker

## Architecture

**`src/sync.rs` (new, 435 LOC)** — pure functions:
- `SyncTracker::push(window)` → emits per-FFT-window `HasSync[i]` flags via `Praw/Psync` sync-band power thresholding (mirrors `sync.c:51-58`)
- `find_sync(has_sync, line_width, num_lines, retries) -> SyncResult` — runs the Hough transform over the binary `has_sync` track to find the dominant slant, then folds + 8-tap convolves to find the column edge

**`src/decoder.rs`** — refactored `State::Decoding`:
- Buffers audio + `has_sync` for one full image
- Calls `find_sync` to derive `(adjusted_rate_hz, skip_samples)`
- Calls `decode_pd_line_pair` with the corrected rate + `pair_start_sample`

**`src/mode_pd.rs`** — `decode_pd_line_pair` now takes `(rate, pair_start_sample)` so the decoder can pass corrected timing without rebuilding the demod.

## Round-trip impact

| Mode  | Before (Phase 1) | After (Phase 2) |
|-------|------------------|-----------------|
| PD120 | max=19, mean=1.27 | max=11, mean=0.75 |
| PD180 | max=17, mean=0.79 | max=11, mean=0.55 |

## Known divergences from slowrx

- **#42 (new)** — Hough rate correction has a 90° deadband. slowrx applies the correction unconditionally; in our two-pass flow without slowrx's `StoredLum` re-render cache, the unconditional correction injects 0.0085% bias on exact-rate inputs. Filed as tracking issue, not a code change in this PR.
- **#39 (already known)** — Phase 1 alignment-search divergence.

## Concerns flagged at hand-off (controller-accepted)

- `src/sync.rs` is 435 LOC — under the 500 hard cap, over the implementer's 400 self-target. Algorithm-density driven; spec-cap compliant.
- `decoder.rs` grew 495 → 543 LOC for the two-pass flow. Above 500 hard cap; mirrors PR-2's `mode_pd.rs` (549) and Phase 1's `vis.rs` (600) as known per-file overruns. Will reassess in Phase 3 — if any of these need a refactor, it'll be a focused split task.

## Gates

- ✅ `cargo fmt --all -- --check`
- ✅ `cargo clippy --all-targets --all-features -- -D warnings`
- ✅ `cargo build --all-features --locked`
- ✅ `cargo test --all-features --locked` (59 unit + 2 integration + 1 doctest = 62 passing)
- ✅ `cargo doc --no-deps --all-features` with `RUSTDOCFLAGS=-D warnings`
- ✅ `cargo llvm-cov` — 97.81% regions / 97.50% lines aggregate; every file ≥ 93.71% lines, ≥ 94.83% regions (well above 92% per-file gate)

## Validation deferred

Real-audio cross-validation against the local Dec 2017 ARISS WAV fixtures is deferred to Phase 4 (after Phase 3's per-pixel demod robustness fixes land), per the recovery plan. Synthetic round-trip is the gate for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented enhanced sync detection and automatic sample rate correction for SSTV decoding

* **Improvements**
  * Restructured decoding to use periodic sync detection with improved sample timing accuracy
  * Enhanced line-pair timing calculations for more precise image alignment
  * Tightened integration test margins for PD120/PD180 modes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->