### PR TITLE
chore(release): prepare 0.1.0 — version bump, badges, publish-dryrun CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,3 +79,20 @@ jobs:
             --ignore-filename-regex 'src/bin/.*' \
             --fail-under-lines 92 \
             --fail-under-regions 92
+
+  publish-dryrun:
+    name: Publish dry-run
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7
+      - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2
+      - name: cargo publish --dry-run
+        run: cargo publish --dry-run --locked
+      - name: cargo package --list (visibility check)
+        # Surfaces the exact file list that would be uploaded to crates.io.
+        # CI doesn't gate on this — it's diagnostic for reviewers — but
+        # any unexpected file (e.g. fixtures, test corpora) should be
+        # caught here before we publish.
+        run: cargo package --list --locked --allow-dirty

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0] - 2026-05-02
+
+First public release on crates.io. PD120 + PD180 SSTV decoding, validated
+end-to-end against Dec-2017 ARISS captures (6 of 7 fixtures decode to
+images visually matching reference JPGs; the 7th is a truncated capture
+missing the VIS leader). The path here was a 7-phase recovery effort
+spanning two parity audits against slowrx C — see closed [epic #12] and
+[`docs/audits/`] for the full archaeology. The [`docs/intentional-deviations.md`]
+file catalogs every deliberate divergence from slowrx so future audits
+have somewhere to point first.
+
+[epic #12]: https://github.com/jasonherald/slowrx.rs/issues/12
+[`docs/audits/`]: ./docs/audits/
+[`docs/intentional-deviations.md`]: ./docs/intentional-deviations.md
+
 ### Added (CLI binary + R12BW parity + deviations doc — issues #7, #26, #39)
 
 - **`slowrx-cli` binary** (#7) — `cargo install slowrx --features cli` builds

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -707,7 +707,7 @@ checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "slowrx"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slowrx"
-version = "0.0.0"
+version = "0.1.0"
 edition = "2021"
 rust-version = "1.85"
 description = "Pure-Rust SSTV (Slow-Scan TV) decoder library — a port of slowrx by Oona Räisänen"

--- a/README.md
+++ b/README.md
@@ -6,16 +6,54 @@
 > ecosystem with a library-first API while preserving the algorithmic
 > work that made slowrx great.
 
+[![Crates.io](https://img.shields.io/crates/v/slowrx.svg)](https://crates.io/crates/slowrx)
+[![Docs.rs](https://docs.rs/slowrx/badge.svg)](https://docs.rs/slowrx)
 [![CI](https://github.com/jasonherald/slowrx.rs/actions/workflows/ci.yml/badge.svg)](https://github.com/jasonherald/slowrx.rs/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](./LICENSE)
 
 ## Status
 
-🚧 **Pre-0.1 — under active development.**
+🛰️ **0.1.0 — V1 published.** PD120 and PD180 decoding from raw audio.
 
-The implementation roadmap is tracked in [GitHub Issues](https://github.com/jasonherald/slowrx.rs/issues).
-The first published release on [crates.io](https://crates.io/) will land
-once V1 (PD120 + PD180) decodes ARISS reception audio cleanly end-to-end.
+Validated end-to-end against ARISS Dec-2017 captures: 6 of 7 fixtures
+decode to images visually matching the reference JPGs (the 7th is a
+truncated capture missing the VIS leader). V2 mode coverage (Robot,
+Scottie, Martin, PD240) is on the [roadmap](https://github.com/jasonherald/slowrx.rs/issues/9).
+
+## Install
+
+```bash
+# library
+cargo add slowrx
+
+# CLI tool (decodes WAV → PNG)
+cargo install slowrx --features cli
+```
+
+## Quick start
+
+```rust
+use slowrx::{SstvDecoder, SstvEvent};
+
+// Construct a decoder at the caller's audio sample rate.
+let mut decoder = SstvDecoder::new(44_100).expect("valid sample rate");
+
+// Feed audio chunks; consume events as images complete.
+let audio: Vec<f32> = vec![0.0; 1024]; // mono samples in [-1.0, 1.0]
+for event in decoder.process(&audio) {
+    if let SstvEvent::ImageComplete { image, .. } = event {
+        println!("decoded {}×{} {:?} image",
+                 image.width, image.height, image.mode);
+    }
+}
+```
+
+CLI:
+
+```bash
+slowrx-cli --input recording.wav --output ./out
+# → out/img-001-pd120.png, out/img-002-pd180.png, ...
+```
 
 ## What it does
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,8 @@
 //!
 //! [NOTICE file]: https://github.com/jasonherald/slowrx.rs/blob/main/NOTICE.md
 
+#![warn(missing_docs)]
+
 pub mod decoder;
 pub mod error;
 pub mod image;


### PR DESCRIPTION
Closes **#8** (PR-5: pre-publish polish + cargo publish 0.1.0).

After merge, the manual `cargo publish 0.1.0` is the last step in the V1 plan.

## Changes

- **Version**: 0.0.0 → 0.1.0 in `Cargo.toml` + `Cargo.lock`.
- **README**: added crates.io and docs.rs badges (populate once published), refreshed status to "V1 published", added an Install section (both library + CLI) and a working library quick-start.
- **CHANGELOG**: flipped `[Unreleased]` → `[0.1.0] - 2026-05-02` with a release preamble linking epic #12 / audits / deviations doc.
- **lib.rs**: added `#![warn(missing_docs)]` (no new lint hits — every public item already documented; CI's `RUSTDOCFLAGS=-D warnings` promotes warnings to deny).
- **CI**: new `publish-dryrun` job runs `cargo publish --dry-run --locked` + `cargo package --list` for visibility.

## Package contents verified

```
.cargo_vcs_info.json
CHANGELOG.md
Cargo.lock
Cargo.toml
Cargo.toml.orig
LICENSE
NOTICE.md
README.md
docs/intentional-deviations.md
src/bin/slowrx_cli.rs
src/decoder.rs
src/error.rs
src/image.rs
src/lib.rs
src/mode_pd.rs
src/modespec.rs
src/pd_test_encoder.rs
src/resample.rs
src/snr.rs
src/sync.rs
src/vis.rs
```

21 files, 232.7 KiB packaged (73.1 KiB compressed). No `tests/`, no `examples/`, no `docs/audits/`, no `docs/wav_files/`, no `target/`.

`cargo publish --dry-run --locked` clean.

## Manual user action after merge

```bash
cargo login   # paste crates.io token
cargo publish
git tag v0.1.0
git push origin v0.1.0
```

Then verify https://crates.io/crates/slowrx and https://docs.rs/slowrx/0.1.0 are live; the README badges will start rendering.

## Gates

- ✅ `cargo fmt --all -- --check`
- ✅ `cargo clippy --all-targets --all-features -- -D warnings`
- ✅ `cargo build --all-features --locked`
- ✅ `cargo test --all-features --locked`
- ✅ `cargo doc --no-deps --all-features` with `RUSTDOCFLAGS=-D warnings` (effectively `-D missing-docs` via the new `warn`)
- ✅ `cargo publish --dry-run --locked --allow-dirty`
- ✅ `cargo package --list` shows only intended files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README with release badges, installation instructions, and quick start guide for both the Rust API and CLI tool.
  * Added version 0.1.0 release notes in CHANGELOG.

* **Chores**
  * Released version 0.1.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->