### PR TITLE
feat(pd240): V2.1 — PD240 decoding (closes #63)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-05-02
+
+V2.1 — PD240 mode coverage. First V2 release. Adds the third PD-family
+mode and the V2 ModeSpec carve-out (`sync_position` field on `ModeSpec`,
+`SyncPosition` enum) that lets later mode-family epics declare their
+sync placement explicitly.
+
+Closes V2.1 epic ([#63]). Tracks the V2 umbrella ([#9]).
+
+[#9]: https://github.com/jasonherald/slowrx.rs/issues/9
+[#63]: https://github.com/jasonherald/slowrx.rs/issues/63
+
+### Added
+
+- **PD240 mode** (`SstvMode::Pd240`, VIS code `0x61`). 640×496, ~240s
+  per image. Same `ChannelLayout::PdYcbcr` as PD120/PD180 — reuses
+  `mode_pd::decode_pd_line_pair` unchanged. Timing constants from
+  slowrx `modespec.c:299-310`.
+- **`SyncPosition` enum + `ModeSpec::sync_position` field.** V2 carve-out
+  per [V2 epic-split design](docs/superpowers/specs/2026-05-02-v2-epic-split-design.md).
+  PD120/PD180/PD240 all use `SyncPosition::LineStart`. The
+  `#[non_exhaustive]` enum will gain a Scottie variant in V2.3.
+
+### Tests
+
+- `tests/roundtrip.rs::pd240_roundtrip` — synthetic encode/decode round-
+  trip with mean per-pixel-diff threshold < 5.0.
+
 ## [0.1.0] - 2026-05-02
 
 First public release on crates.io. PD120 + PD180 SSTV decoding, validated

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -707,7 +707,7 @@ checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "slowrx"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slowrx"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 rust-version = "1.85"
 description = "Pure-Rust SSTV (Slow-Scan TV) decoder library — a port of slowrx by Oona Räisänen"

--- a/README.md
+++ b/README.md
@@ -13,12 +13,14 @@
 
 ## Status
 
-🛰️ **0.1.0 — V1 published.** PD120 and PD180 decoding from raw audio.
+🛰️ **0.2.0 — V2.1 published.** PD120, PD180, and PD240 decoding from raw audio.
 
-Validated end-to-end against ARISS Dec-2017 captures: 6 of 7 fixtures
-decode to images visually matching the reference JPGs (the 7th is a
-truncated capture missing the VIS leader). V2 mode coverage (Robot,
-Scottie, Martin, PD240) is on the [roadmap](https://github.com/jasonherald/slowrx.rs/issues/9).
+PD120 and PD180 are validated end-to-end against ARISS Dec-2017 captures:
+6 of 7 fixtures decode to images visually matching the reference JPGs
+(the 7th is a truncated capture missing the VIS leader). PD240 currently
+ships with synthetic encode/decode round-trip coverage only — a real-radio
+fixture is pending. Remaining V2 mode coverage (Robot, Scottie, Martin)
+is on the [roadmap](https://github.com/jasonherald/slowrx.rs/issues/9).
 
 ## Install
 
@@ -60,9 +62,9 @@ slowrx-cli --input recording.wav --output ./out
 `slowrx.rs` decodes Slow-Scan Television images from a stream of audio
 samples. Mode coverage roadmap:
 
-| Mode family | V1 | V2 |
+| Mode family | Shipped | Roadmap |
 |---|---|---|
-| **PD** | PD120, PD180 | PD240 |
+| **PD** | PD120, PD180, PD240 | — |
 | **Robot** | — | Robot 36, Robot 72 |
 | **Scottie** | — | Scottie 1, Scottie 2, Scottie DX |
 | **Martin** | — | Martin 1, Martin 2 |

--- a/docs/superpowers/plans/2026-05-02-v2.1-pd240.md
+++ b/docs/superpowers/plans/2026-05-02-v2.1-pd240.md
@@ -1,0 +1,1111 @@
+# V2.1 — PD240 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land PD240 SSTV decode support as the first V2 release (`slowrx 0.2.0`), and stand up the GitHub epic structure (umbrella #9 + 5 child epics) that the rest of V2 will execute against.
+
+**Architecture:** PD240 is the lowest-risk V2 mode — same `PdYcbcr` channel layout as PD120/PD180, only timing differs. Nearly all changes are additive to existing files; the only V1 file *modifications* are: (1) one new variant on the `SstvMode` enum, (2) one new field on `ModeSpec` (`sync_position`) added now to force later mode families to make their sync-placement assumption explicit, (3) two new lookup arms. No new module file. Synthetic round-trip in `tests/roundtrip.rs` is the merge gate; real-radio fixtures land asynchronously per the V2 spec.
+
+**Tech Stack:** Rust 2021 (MSRV 1.85), `rustfft`, `thiserror`, `proptest`. CI runs `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --all-features --locked`, `cargo doc -D warnings`. Release tooling: `cargo publish --dry-run`. GitHub epic management via `gh` CLI.
+
+**Spec reference:** `docs/superpowers/specs/2026-05-02-v2-epic-split-design.md`.
+**slowrx C reference (locally):** `original/slowrx/modespec.c:299-310` (PD240 timing), `original/slowrx/modespec.c:382` (VIS code 0x61), `original/slowrx/video.c:81-93` (PD channel layout).
+
+---
+
+## Phase 0 — GitHub epic structure
+
+This phase satisfies the spec's first two acceptance criteria (umbrella #9 has Children section; 5 child epics exist) and produces the issue numbers V2.1's commits will reference. Run once, before any code changes.
+
+> **Convention:** save each child-issue body to `/tmp/v2-epic-bodies/<id>.md` before filing so the `gh issue create` invocation reads from a file rather than a long inline `--body`. Saves quoting headaches.
+
+### Task 0.1: Create the V2.1 (PD240) child epic body file
+
+**Files:**
+- Create: `/tmp/v2-epic-bodies/v2.1-pd240.md`
+
+- [ ] **Step 1: Write the body file**
+
+```bash
+mkdir -p /tmp/v2-epic-bodies
+cat > /tmp/v2-epic-bodies/v2.1-pd240.md <<'EOF'
+**Parent:** #9
+**Release:** 0.2.0
+
+## Mode family
+PD240 (single mode). VIS code `0x61`. slowrx C reference: `modespec.c:299-310` (timing), `modespec.c:382` (VIS map row 6 col 1).
+
+## DSP delta from V1
+None. PD240 reuses `mode_pd::decode_pd_line_pair` unchanged. Only the timing constants differ from PD120/PD180.
+
+## File plan
+- Modify `src/modespec.rs`: add `Pd240` enum variant, `PD240` const, lookup + for_mode arms. Add `SyncPosition` enum and `sync_position: SyncPosition` field on `ModeSpec` (V2 carve-out — forces V2.3 Scottie to be explicit; PD/Robot/Martin all use `LineStart`).
+- Modify `src/pd_test_encoder.rs`: extend the `assert!(matches!(mode, Pd120 | Pd180))` to include `Pd240`.
+- Modify `tests/roundtrip.rs`: add `Pd240 => 0x61` arm to the VIS code match; add `pd240_roundtrip` test.
+- No new module file. No `decoder.rs` change (dispatch is a no-op for same-layout modes).
+
+## Test corpus
+Synthetic encode → decode round-trip via `tests/roundtrip.rs::pd240_roundtrip`. Mean per-pixel RGB diff threshold `< 5.0` (matches PD120/PD180 gate).
+
+## Coverage gate
+`cargo llvm-cov` ≥ 92 % per-file maintained. (PD240 adds <50 LOC across two existing files; gate expected to remain green.)
+
+## Acceptance checklist
+- [ ] Synthetic round-trip passes locally and in CI
+- [ ] Per-file coverage ≥ 92 %
+- [ ] `CHANGELOG.md` entry under `[0.2.0]`
+- [ ] `Cargo.toml` version bumped to `0.2.0`
+- [ ] README mode-coverage table updated (move PD240 from V2 to V1 column)
+- [ ] `cargo publish --dry-run` clean
+- [ ] PR merged, crate published
+
+## Out of scope
+Real-radio PD240 fixtures (those land asynchronously, not as a merge gate).
+EOF
+```
+
+- [ ] **Step 2: Verify the file**
+
+Run: `wc -l /tmp/v2-epic-bodies/v2.1-pd240.md && head -3 /tmp/v2-epic-bodies/v2.1-pd240.md`
+Expected: ~30 lines, first line is `**Parent:** #9`.
+
+### Task 0.2: Create the V2.2 (Robot) child epic body file
+
+**Files:**
+- Create: `/tmp/v2-epic-bodies/v2.2-robot.md`
+
+- [ ] **Step 1: Write the body file**
+
+```bash
+cat > /tmp/v2-epic-bodies/v2.2-robot.md <<'EOF'
+**Parent:** #9
+**Release:** 0.3.0
+
+## Mode family
+Robot 36, Robot 72. VIS codes: Robot 36 = `0x08`, Robot 72 = `0x0C`. slowrx C reference: `modespec.c` Robot rows + `video.c` Robot decoder. Verify exact constants from `original/slowrx/modespec.c` before implementing.
+
+## DSP delta from V1
+- New chroma layout: Robot uses YCrCb where Robot 36 alternates Cr/Cb between consecutive lines (each line carries Y + half the chroma pair); Robot 72 carries full Y/Cr/Cb per line.
+- New `ChannelLayout::RobotYuv` variant on `ModeSpec`.
+- New `decoder.rs` dispatch arm: `RobotYuv => mode_robot::decode_line(...)`.
+
+## File plan
+- New `src/mode_robot.rs` (≤ 500 LOC). Decoder + per-line state for Cr/Cb alternation.
+- New `src/robot_test_encoder.rs` (test-support only).
+- Modify `src/modespec.rs`: 2 new `SstvMode` variants, `ChannelLayout::RobotYuv`, 2 new `ModeSpec` consts + lookup/for_mode arms.
+- Modify `src/decoder.rs`: dispatch on `ChannelLayout`. Reuse PD path for `PdYcbcr`; add `RobotYuv` arm calling `mode_robot::decode_line`.
+- Modify `src/lib.rs`: `pub mod mode_robot;`.
+- Modify `tests/roundtrip.rs`: 2 new round-trip tests.
+
+## Test corpus
+Synthetic encode → decode round-trip per mode. **Critical:** Robot 36 round-trip must cover both line phases (odd/even chroma) — single-image test with mixed chroma content.
+
+## Coverage gate
+≥ 92 % per-file. New `mode_robot.rs` ships with ≥ 92 % coverage on its own.
+
+## Acceptance checklist
+Same shape as V2.1 (synthetic round-trip green, coverage gate, CHANGELOG, version bump to 0.3.0, dry-run, PR).
+
+## Out of scope
+Real-radio fixtures (async).
+EOF
+```
+
+- [ ] **Step 2: Verify**
+
+Run: `wc -l /tmp/v2-epic-bodies/v2.2-robot.md`
+Expected: ~30 lines.
+
+### Task 0.3: Create the V2.3 (Scottie) child epic body file
+
+**Files:**
+- Create: `/tmp/v2-epic-bodies/v2.3-scottie.md`
+
+- [ ] **Step 1: Write the body file**
+
+```bash
+cat > /tmp/v2-epic-bodies/v2.3-scottie.md <<'EOF'
+**Parent:** #9
+**Release:** 0.4.0
+
+## Mode family
+Scottie 1, Scottie 2, Scottie DX. VIS codes: S1 = `0x3C`, S2 = `0x38`, SDX = `0x4C`. Verify against `original/slowrx/modespec.c`.
+
+## DSP delta from V1
+- New chroma layout: RGB sequential per line (G, B, R per slowrx convention).
+- **Sync placement is mid-line** (between channels), not line-start. This is the V2 risk flagged in the spec — V2.1 will have already added the `sync_position` field to `ModeSpec`; this epic uses `SyncPosition::Scottie` (or similar) to make the mid-line placement explicit.
+- New `ChannelLayout::RgbSequential` variant (shared with Martin).
+- New dispatch arm in `decoder.rs`: `RgbSequential => mode_scottie::decode_line(...)`. The handler dispatches further based on `sync_position`.
+- May require changes to `sync.rs` or the line-clock advance in `decoder.rs` if hidden line-start assumptions surface. Spec authorizes those changes in this epic's scope.
+
+## File plan
+- New `src/mode_scottie.rs` (≤ 500 LOC) — also called by Martin via shared entry point.
+- New `src/scottie_test_encoder.rs`.
+- Modify `src/modespec.rs`: 3 new `SstvMode` variants, `ChannelLayout::RgbSequential`, `SyncPosition` variants, 3 new `ModeSpec` consts + lookup/for_mode arms.
+- Modify `src/decoder.rs`: add `RgbSequential` dispatch arm.
+- Modify `src/lib.rs`: `pub mod mode_scottie;`.
+- Modify `tests/roundtrip.rs`: 3 new round-trip tests.
+
+## Test corpus
+Synthetic encode → decode round-trip per mode.
+
+## Coverage gate
+≥ 92 % per-file.
+
+## Acceptance checklist
+Same shape (synthetic green, coverage, CHANGELOG, version 0.4.0, dry-run, PR).
+
+## Out of scope
+Real-radio fixtures (async).
+EOF
+```
+
+- [ ] **Step 2: Verify**
+
+Run: `wc -l /tmp/v2-epic-bodies/v2.3-scottie.md`
+
+### Task 0.4: Create the V2.4 (Martin) child epic body file
+
+**Files:**
+- Create: `/tmp/v2-epic-bodies/v2.4-martin.md`
+
+- [ ] **Step 1: Write the body file**
+
+```bash
+cat > /tmp/v2-epic-bodies/v2.4-martin.md <<'EOF'
+**Parent:** #9
+**Release:** 0.5.0
+
+## Mode family
+Martin 1, Martin 2. VIS codes: M1 = `0x2C`, M2 = `0x28`. Verify against `original/slowrx/modespec.c`.
+
+## DSP delta from V1
+- Same RGB-sequential layout as Scottie (`ChannelLayout::RgbSequential`).
+- `sync_position: LineStart` (unlike Scottie). The shared `mode_scottie::decode_line` entry point dispatches Martin via the `sync_position` field.
+- Re-uses `mode_scottie.rs` if duplication is small. Per spec: only extract a shared helper if duplication pain is clear.
+
+## File plan
+- Likely no new `mode_martin.rs` — handled inside `mode_scottie.rs`. Decision finalized during this epic's writing-plans pass when Scottie's shape is concrete.
+- Modify `src/modespec.rs`: 2 new `SstvMode` variants, 2 new `ModeSpec` consts + lookup/for_mode arms.
+- Modify `tests/roundtrip.rs`: 2 new round-trip tests.
+
+## Test corpus
+Synthetic encode → decode round-trip per mode.
+
+## Coverage gate
+≥ 92 % per-file.
+
+## Acceptance checklist
+Same shape (synthetic green, coverage, CHANGELOG, version 0.5.0, dry-run, PR).
+
+## Out of scope
+Real-radio fixtures (async). Cross-mode shared-helper refactoring beyond what naturally falls out of Scottie reuse.
+EOF
+```
+
+- [ ] **Step 2: Verify**
+
+Run: `wc -l /tmp/v2-epic-bodies/v2.4-martin.md`
+
+### Task 0.5: Create the V2.5 (Zarya) child epic body file
+
+**Files:**
+- Create: `/tmp/v2-epic-bodies/v2.5-zarya.md`
+
+- [ ] **Step 1: Write the body file**
+
+```bash
+cat > /tmp/v2-epic-bodies/v2.5-zarya.md <<'EOF'
+**Parent:** #9
+**Release:** patch (no API change)
+**Status:** Open-ended capture tracker. Runs in parallel with V2.1–V2.4. Does not gate any decoder release.
+
+## Capture goals
+Acquire at least one ISS Russian-side / RSØISS SSTV pass (commonly called "Zarya" because the Zarya module hosts the Russian amateur radio gear). Frequency: 145.800 MHz FM. Recent ARISS-SSTV events from the Russian side have been PD120 almost exclusively — already supported by V1. So this epic is **fixture/observability work, not a new decoder.**
+
+Document for each capture:
+- Date and pass time (UTC)
+- Receiver / antenna / SDR
+- Audio chain (sample rate, bit depth, mono/stereo)
+- Result of `slowrx-cli` decode — which VIS code(s) detected, which mode(s)
+
+## Mode identification
+1. Run `slowrx-cli --input <recording.wav> --output /tmp/zarya/`
+2. Read the `VIS: mode=...` line. Expected: `Pd120` (possibly `Pd180`).
+3. If decode fails or VIS mode is something else, capture the diagnostics and open a separate decoder issue.
+
+## Fixture acceptance
+- Drop the WAV under `tests/fixtures/iss-zarya/` (gitignored, like `docs/wav_files/201712-ISS_SSTV/`).
+- Add a `tests/fixtures/iss-zarya/README.md` documenting which captures are present and what each decodes to.
+- Add a regression case in `tests/cli.rs` (or equivalent) following the V1 pattern: skip silently if the fixture isn't present.
+
+## Acceptance for closeout (if ever)
+At least one Zarya capture decoded to a recognizable image, fixture path committed (the WAV itself stays out of git). Likely stays open indefinitely as a capture tracker.
+
+## Out of scope
+- New decoder work (Zarya uses already-supported PD120/PD180).
+- CI gate on real-WAV decoding (V1 convention preserved).
+EOF
+```
+
+- [ ] **Step 2: Verify**
+
+Run: `wc -l /tmp/v2-epic-bodies/v2.5-zarya.md`
+
+### Task 0.6: File the 5 child epics on GitHub
+
+**Files:** None (GitHub-side change).
+
+- [ ] **Step 1: File V2.1**
+
+```bash
+gh issue create --repo jasonherald/slowrx.rs \
+  --title "EPIC V2.1: PD240 — single-mode, lowest-risk V2 release (0.2.0)" \
+  --label "epic,v2" \
+  --body-file /tmp/v2-epic-bodies/v2.1-pd240.md
+```
+
+Capture the returned issue URL. Extract the issue number (the trailing integer in the URL) and **record it as `V2_1=`** for use in Task 0.7.
+
+- [ ] **Step 2: File V2.2**
+
+```bash
+gh issue create --repo jasonherald/slowrx.rs \
+  --title "EPIC V2.2: Robot family (Robot 36, Robot 72) — 0.3.0" \
+  --label "epic,v2" \
+  --body-file /tmp/v2-epic-bodies/v2.2-robot.md
+```
+
+Record issue number as `V2_2=`.
+
+- [ ] **Step 3: File V2.3**
+
+```bash
+gh issue create --repo jasonherald/slowrx.rs \
+  --title "EPIC V2.3: Scottie family (S1, S2, DX) — 0.4.0" \
+  --label "epic,v2" \
+  --body-file /tmp/v2-epic-bodies/v2.3-scottie.md
+```
+
+Record as `V2_3=`.
+
+- [ ] **Step 4: File V2.4**
+
+```bash
+gh issue create --repo jasonherald/slowrx.rs \
+  --title "EPIC V2.4: Martin family (M1, M2) — 0.5.0" \
+  --label "epic,v2" \
+  --body-file /tmp/v2-epic-bodies/v2.4-martin.md
+```
+
+Record as `V2_4=`.
+
+- [ ] **Step 5: File V2.5**
+
+```bash
+gh issue create --repo jasonherald/slowrx.rs \
+  --title "EPIC V2.5: ISS / Zarya real-capture validation (parallel, open-ended)" \
+  --label "epic,v2" \
+  --body-file /tmp/v2-epic-bodies/v2.5-zarya.md
+```
+
+Record as `V2_5=`.
+
+- [ ] **Step 6: Verify all 5 are filed**
+
+```bash
+gh issue list --repo jasonherald/slowrx.rs --label epic --state open
+```
+
+Expected: at least 5 open epic issues — the 4 V2.x (PD240/Robot/Scottie/Martin) and V2.5 (Zarya). The umbrella #9 also remains open.
+
+### Task 0.7: Update umbrella #9 with the Children section
+
+**Files:**
+- Modify: GitHub issue #9 body.
+
+- [ ] **Step 1: Fetch the current body**
+
+```bash
+gh issue view 9 --repo jasonherald/slowrx.rs --json body --jq .body > /tmp/issue-9-current.md
+cat /tmp/issue-9-current.md | tail -5
+```
+
+- [ ] **Step 2: Build the Children section**
+
+Substitute the actual `V2_1`…`V2_5` issue numbers captured in Task 0.6 into the placeholders below.
+
+```bash
+# Replace V2_1..V2_5 with real numbers before running
+cat > /tmp/issue-9-children.md <<EOF
+
+## Children
+
+V2 is decomposed into 5 child epics (per [V2 epic-split design](https://github.com/jasonherald/slowrx.rs/blob/main/docs/superpowers/specs/2026-05-02-v2-epic-split-design.md)). Sequential delivery for V2.1–V2.4; V2.5 runs in parallel.
+
+| # | Epic | Modes | Release | Issue |
+|---|------|-------|---------|-------|
+| V2.1 | PD-extended | PD240 | 0.2.0 | #${V2_1} |
+| V2.2 | Robot family | Robot 36, Robot 72 | 0.3.0 | #${V2_2} |
+| V2.3 | Scottie family | Scottie 1, Scottie 2, Scottie DX | 0.4.0 | #${V2_3} |
+| V2.4 | Martin family | Martin 1, Martin 2 | 0.5.0 | #${V2_4} |
+| V2.5 | ISS / Zarya capture validation | (no decoder) | patch | #${V2_5} |
+
+This umbrella closes when V2.1–V2.4 close. V2.5 outlives V2 as an open-ended capture tracker.
+EOF
+```
+
+- [ ] **Step 3: Concatenate current body + Children section**
+
+```bash
+cat /tmp/issue-9-current.md /tmp/issue-9-children.md > /tmp/issue-9-new.md
+```
+
+- [ ] **Step 4: Push the updated body**
+
+```bash
+gh issue edit 9 --repo jasonherald/slowrx.rs --body-file /tmp/issue-9-new.md
+```
+
+- [ ] **Step 5: Verify**
+
+```bash
+gh issue view 9 --repo jasonherald/slowrx.rs --json body --jq .body | tail -20
+```
+
+Expected: the Children table appears at the bottom of #9 with all 5 issue numbers populated.
+
+### Task 0.8: Create the V2.1 worktree + feature branch
+
+**Files:** None (git-side change).
+
+This isolates V2.1's code work from `main` so other tasks can land independently.
+
+- [ ] **Step 1: Create worktree**
+
+```bash
+git -C /data/source/slowrx.rs worktree add ../slowrx.rs-v2.1-pd240 -b feat/v2.1-pd240
+```
+
+- [ ] **Step 2: Verify**
+
+```bash
+git -C /data/source/slowrx.rs worktree list
+cd /data/source/slowrx.rs-v2.1-pd240 && git status
+```
+
+Expected: new worktree at `/data/source/slowrx.rs-v2.1-pd240` on branch `feat/v2.1-pd240`, working tree clean.
+
+**From this point on, all paths are relative to `/data/source/slowrx.rs-v2.1-pd240/` — the V2.1 worktree.**
+
+---
+
+## Phase 1 — `SyncPosition` field on `ModeSpec`
+
+This phase adds the V2 carve-out for sync placement. PD120/PD180 keep behavior identical (both use `SyncPosition::LineStart`); the field exists so V2.3 (Scottie) is forced to make its mid-line sync explicit at dispatch time. TDD-style: write a test that asserts the new field is `LineStart` for PD modes, then add the field.
+
+### Task 1.1: Add the failing test for `SyncPosition`
+
+**Files:**
+- Modify: `src/modespec.rs:128-177` (add a test inside the existing `#[cfg(test)] mod tests` block).
+
+- [ ] **Step 1: Add the test**
+
+Append inside the existing `mod tests { ... }` block in `src/modespec.rs`, just before the closing brace at line 177:
+
+```rust
+    #[test]
+    fn pd_modes_have_line_start_sync_position() {
+        // V2 carve-out: ModeSpec.sync_position lets V2.3 Scottie declare
+        // mid-line sync without retrofitting V1. PD120/PD180/PD240 all use
+        // line-start sync (slowrx video.c:88-92 places sync at the start of
+        // each line for PD modes).
+        for mode in [SstvMode::Pd120, SstvMode::Pd180] {
+            let spec = for_mode(mode);
+            assert_eq!(spec.sync_position, SyncPosition::LineStart);
+        }
+    }
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cargo test --features test-support --lib pd_modes_have_line_start_sync_position 2>&1 | tail -20`
+
+Expected: compilation FAIL — `cannot find type 'SyncPosition' in this scope` and/or `no field 'sync_position' on type 'ModeSpec'`.
+
+### Task 1.2: Add `SyncPosition` enum and `sync_position` field
+
+**Files:**
+- Modify: `src/modespec.rs:50-126` (`ChannelLayout` enum area + `ModeSpec` struct + PD120/PD180 const initializers).
+
+- [ ] **Step 1: Add the `SyncPosition` enum**
+
+Insert just after the `ChannelLayout` enum definition (after line 60 in the current file — the `}` that closes `ChannelLayout`):
+
+```rust
+/// Where the sync pulse sits within a radio line.
+///
+/// PD/Robot/Martin all place sync at line start (the standard SSTV
+/// convention). Scottie modes are the exception — sync sits between G
+/// and B channels, not at line start. Stored here so future mode
+/// decoders are forced to make their sync placement explicit at dispatch
+/// time, surfacing the V1 line-clock-advance assumption that sync ==
+/// line start.
+///
+/// V1 + V2.1 only emit [`SyncPosition::LineStart`]; [`SyncPosition::Scottie`]
+/// lands with the V2.3 Scottie family epic.
+#[non_exhaustive]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum SyncPosition {
+    /// Sync pulse at the start of each radio line. PD, Robot, Martin.
+    LineStart,
+}
+```
+
+- [ ] **Step 2: Add the `sync_position` field on `ModeSpec`**
+
+Modify the `ModeSpec` struct at line 23-50. Append a new field after `channel_layout`:
+
+```rust
+    /// Channel layout used by per-mode decoders.
+    pub channel_layout: ChannelLayout,
+    /// Where the sync pulse sits within a radio line. See [`SyncPosition`]
+    /// for the rationale (V2 carve-out forcing mid-line sync to be
+    /// explicit when V2.3 Scottie lands).
+    pub sync_position: SyncPosition,
+}
+```
+
+- [ ] **Step 3: Update PD120 const**
+
+Modify `const PD120` at line 102 to include the new field:
+
+```rust
+const PD120: ModeSpec = ModeSpec {
+    mode: SstvMode::Pd120,
+    vis_code: 0x5F,
+    line_pixels: 640,
+    image_lines: 496,
+    line_seconds: 0.508_48,
+    sync_seconds: 0.020,
+    porch_seconds: 0.002_08,
+    pixel_seconds: 0.000_19,
+    septr_seconds: 0.0, // modespec.c: SeptrTime = 0e-3 for PD-family
+    channel_layout: ChannelLayout::PdYcbcr,
+    sync_position: SyncPosition::LineStart,
+};
+```
+
+- [ ] **Step 4: Update PD180 const**
+
+Same shape — append `sync_position: SyncPosition::LineStart,` to `const PD180` at line 115.
+
+- [ ] **Step 5: Run all `modespec` tests**
+
+Run: `cargo test --features test-support --lib modespec:: 2>&1 | tail -20`
+
+Expected: all tests in `modespec::tests` pass, including the new `pd_modes_have_line_start_sync_position`.
+
+- [ ] **Step 6: Run the full test suite to catch any regression**
+
+Run: `cargo test --all-features --locked 2>&1 | tail -10`
+
+Expected: all tests pass. (No code outside `modespec.rs` touches `ModeSpec` literally — the field addition is binary-compatible for downstream construction sites because all `ModeSpec` values are built inside `modespec.rs` consts.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/modespec.rs
+git commit -m "feat(modespec): add SyncPosition enum + ModeSpec.sync_position field
+
+V2 carve-out per V2 epic-split spec. PD120/PD180 use LineStart; the
+non-exhaustive SyncPosition enum will gain a Scottie variant in V2.3.
+Forces future mode decoders to make their sync placement explicit at
+dispatch time, surfacing the V1 line-clock-advance assumption that
+sync == line start.
+
+Refs: docs/superpowers/specs/2026-05-02-v2-epic-split-design.md"
+```
+
+---
+
+## Phase 2 — `SstvMode::Pd240` enum variant
+
+### Task 2.1: Add the failing test for `Pd240` enum variant
+
+**Files:**
+- Modify: `src/modespec.rs` `mod tests` block.
+
+- [ ] **Step 1: Add the test**
+
+Append inside the existing `mod tests` block:
+
+```rust
+    #[test]
+    fn pd240_vis_code_resolves() {
+        let spec = lookup(0x61).expect("PD240 VIS resolves");
+        assert_eq!(spec.mode, SstvMode::Pd240);
+        assert_eq!(spec.vis_code, 0x61);
+        assert_eq!(spec.line_pixels, 640);
+        assert_eq!(spec.image_lines, 496);
+        assert_eq!(spec.channel_layout, ChannelLayout::PdYcbcr);
+        assert_eq!(spec.sync_position, SyncPosition::LineStart);
+        assert_eq!(spec.line_seconds, 1.000);
+        assert_eq!(spec.sync_seconds, 0.020);
+        assert_eq!(spec.porch_seconds, 0.002_08);
+        assert_eq!(spec.pixel_seconds, 0.000_382);
+        assert_eq!(spec.septr_seconds, 0.0);
+    }
+
+    #[test]
+    fn for_mode_returns_pd240_spec() {
+        assert_eq!(for_mode(SstvMode::Pd240).vis_code, 0x61);
+    }
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cargo test --features test-support --lib pd240_ 2>&1 | tail -20`
+
+Expected: compilation FAIL — `no variant or associated item named 'Pd240' found for enum 'SstvMode'`.
+
+### Task 2.2: Add `Pd240` variant + `PD240` const + lookup arm + `for_mode` arm
+
+**Files:**
+- Modify: `src/modespec.rs:14-19` (enum), `src/modespec.rs:78-97` (lookup + for_mode), `src/modespec.rs:99-126` (consts).
+
+- [ ] **Step 1: Add the enum variant**
+
+Modify the `SstvMode` enum at line 14-19:
+
+```rust
+#[non_exhaustive]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum SstvMode {
+    /// PD-120 (640×496, ~120s per image)
+    Pd120,
+    /// PD-180 (640×496, ~180s per image)
+    Pd180,
+    /// PD-240 (640×496, ~240s per image)
+    Pd240,
+}
+```
+
+- [ ] **Step 2: Add the `PD240` const**
+
+Append after `const PD180` (around line 126):
+
+```rust
+const PD240: ModeSpec = ModeSpec {
+    mode: SstvMode::Pd240,
+    vis_code: 0x61,
+    line_pixels: 640,
+    image_lines: 496,
+    // slowrx modespec.c:299-310 — PD240 LineTime = 1000e-3,
+    // PixelTime = 0.382e-3, SyncTime = 20e-3, PorchTime = 2.08e-3.
+    line_seconds: 1.000,
+    sync_seconds: 0.020,
+    porch_seconds: 0.002_08,
+    pixel_seconds: 0.000_382,
+    septr_seconds: 0.0, // modespec.c: SeptrTime = 0e-3 for PD-family
+    channel_layout: ChannelLayout::PdYcbcr,
+    sync_position: SyncPosition::LineStart,
+};
+```
+
+- [ ] **Step 3: Add lookup arm**
+
+Modify the `lookup` function:
+
+```rust
+pub fn lookup(vis_code: u8) -> Option<ModeSpec> {
+    match vis_code {
+        0x5F => Some(PD120),
+        0x60 => Some(PD180),
+        0x61 => Some(PD240),
+        _ => None,
+    }
+}
+```
+
+- [ ] **Step 4: Add `for_mode` arm**
+
+Modify the `for_mode` function:
+
+```rust
+pub fn for_mode(mode: SstvMode) -> ModeSpec {
+    match mode {
+        SstvMode::Pd120 => PD120,
+        SstvMode::Pd180 => PD180,
+        SstvMode::Pd240 => PD240,
+    }
+}
+```
+
+- [ ] **Step 5: Run the new tests**
+
+Run: `cargo test --features test-support --lib pd240_ 2>&1 | tail -10`
+
+Expected: PASS for `pd240_vis_code_resolves` and `for_mode_returns_pd240_spec`.
+
+- [ ] **Step 6: Run the whole modespec suite**
+
+Run: `cargo test --features test-support --lib modespec:: 2>&1 | tail -15`
+
+Expected: all `modespec::tests` pass, including pre-existing `chan_starts_sec_septr_zero_is_numerically_equivalent_to_old_formula` (that test loops over PD120/PD180 — not changed by adding PD240, but worth confirming).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/modespec.rs
+git commit -m "feat(modespec): add SstvMode::Pd240 + 0x61 lookup + PD240 const
+
+PD240 timing from slowrx modespec.c:299-310. VIS code 0x61 from
+modespec.c:382 (VISmap row 6 col 1). Same channel layout as PD120/PD180
+(PdYcbcr) so no decoder.rs change needed — for_mode delivers the
+PD240-specific timing constants and decode_pd_line_pair handles the
+rest.
+
+Refs: V2.1 epic"
+```
+
+---
+
+## Phase 3 — PD240 round-trip test
+
+### Task 3.1: Allow `Pd240` in the test encoder
+
+**Files:**
+- Modify: `src/pd_test_encoder.rs:51-57`.
+
+- [ ] **Step 1: Update the assert**
+
+Change line 52 of `src/pd_test_encoder.rs` from:
+
+```rust
+    assert!(matches!(mode, SstvMode::Pd120 | SstvMode::Pd180));
+```
+
+to:
+
+```rust
+    assert!(matches!(
+        mode,
+        SstvMode::Pd120 | SstvMode::Pd180 | SstvMode::Pd240
+    ));
+```
+
+(No other change needed — `encode_pd` already reads `pixel_seconds`/`line_seconds` from the spec, so it works for any PD-family mode automatically.)
+
+- [ ] **Step 2: Build to confirm no other breakage**
+
+Run: `cargo build --features test-support 2>&1 | tail -5`
+
+Expected: compiles cleanly.
+
+### Task 3.2: Add the failing PD240 round-trip test
+
+**Files:**
+- Modify: `tests/roundtrip.rs:41-50` (`vis_code` match) and end of file.
+
+- [ ] **Step 1: Add `Pd240` arm to the VIS code match**
+
+Change `tests/roundtrip.rs:41-45` from:
+
+```rust
+    let vis_code = match mode {
+        SstvMode::Pd120 => 0x5F,
+        SstvMode::Pd180 => 0x60,
+        _ => unreachable!(),
+    };
+```
+
+to:
+
+```rust
+    let vis_code = match mode {
+        SstvMode::Pd120 => 0x5F,
+        SstvMode::Pd180 => 0x60,
+        SstvMode::Pd240 => 0x61,
+        _ => unreachable!(),
+    };
+```
+
+- [ ] **Step 2: Add the `pd240_roundtrip` test**
+
+Append at the end of `tests/roundtrip.rs`:
+
+```rust
+#[test]
+fn pd240_roundtrip() {
+    run_roundtrip(SstvMode::Pd240);
+}
+```
+
+- [ ] **Step 3: Run the new test**
+
+Run: `cargo test --test roundtrip --features test-support pd240_roundtrip -- --nocapture 2>&1 | tail -15`
+
+Expected: PASS, with assertion `mean < 5.0`. PD240 is 4× the audio length of PD120 so this test will take longer than `pd120_roundtrip` (rough estimate: 4-15 seconds depending on machine).
+
+If the test fails with `mean >= 5.0`, the rounding-error compounding flagged in `pd_test_encoder.rs` may have broken at the longer time horizon — investigate before patching the threshold.
+
+- [ ] **Step 4: Run all 3 PD round-trips together**
+
+Run: `cargo test --test roundtrip --features test-support 2>&1 | tail -10`
+
+Expected: 3 tests pass — `pd120_roundtrip`, `pd180_roundtrip`, `pd240_roundtrip`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/pd_test_encoder.rs tests/roundtrip.rs
+git commit -m "test(pd240): synthetic encode/decode round-trip
+
+PD240 reuses the existing PD encoder/decoder paths (same PdYcbcr layout,
+PixelTime is the only material difference). Test follows the
+pd120/pd180 round-trip pattern: gradient luma + smooth chroma stripes,
+mean per-pixel diff threshold < 5.0.
+
+Refs: V2.1 epic"
+```
+
+---
+
+## Phase 4 — Release (0.2.0)
+
+### Task 4.1: Update README mode-coverage table
+
+**Files:**
+- Modify: `README.md:35-44` (the V1/V2 mode-coverage table).
+
+- [ ] **Step 1: Update the table**
+
+In `README.md`, find the "What it does" section's mode coverage table:
+
+```markdown
+| Mode family | V1 | V2 |
+|---|---|---|
+| **PD** | PD120, PD180 | PD240 |
+```
+
+Change to:
+
+```markdown
+| Mode family | Shipped | Roadmap |
+|---|---|---|
+| **PD** | PD120, PD180, PD240 | — |
+```
+
+(Update the column headers from `V1`/`V2` to `Shipped`/`Roadmap` so the table stays accurate as future V2 modes land. Robot/Scottie/Martin remain in `Roadmap`.)
+
+- [ ] **Step 2: Update the Status section header line**
+
+Find `## Status` near the top of the README and replace the body to reflect the new release. Find:
+
+```markdown
+🛰️ **0.1.0 — V1 published.** PD120 and PD180 decoding from raw audio.
+```
+
+Replace with:
+
+```markdown
+🛰️ **0.2.0 — V2.1 published.** PD120, PD180, and PD240 decoding from raw audio.
+```
+
+(Also update the validation paragraph if PD240 hasn't been validated against a real capture yet — note "PD240 validated by synthetic round-trip; real-radio fixture pending.")
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add README.md
+git commit -m "docs(readme): V2.1 — PD240 shipped, table reframed Shipped/Roadmap"
+```
+
+### Task 4.2: Add CHANGELOG entry
+
+**Files:**
+- Modify: `CHANGELOG.md` top section.
+
+- [ ] **Step 1: Read the existing structure**
+
+```bash
+head -30 CHANGELOG.md
+```
+
+Confirm the file uses `## [Unreleased]` followed by the latest released version (`## [0.1.0] - 2026-05-02`).
+
+- [ ] **Step 2: Insert the new entry**
+
+Replace the `## [Unreleased]` header with two sections — a fresh empty `## [Unreleased]` and a new `## [0.2.0]`:
+
+```markdown
+## [Unreleased]
+
+## [0.2.0] - YYYY-MM-DD
+
+V2.1 — PD240 mode coverage. First V2 release. Adds the third PD-family
+mode and the V2 ModeSpec carve-out (`sync_position` field on `ModeSpec`,
+`SyncPosition` enum) that lets later mode-family epics declare their
+sync placement explicitly.
+
+Closes V2.1 epic. Tracks the V2 umbrella ([#9]).
+
+[#9]: https://github.com/jasonherald/slowrx.rs/issues/9
+
+### Added
+
+- **PD240 mode** (`SstvMode::Pd240`, VIS code `0x61`). 640×496, ~240s
+  per image. Same `ChannelLayout::PdYcbcr` as PD120/PD180 — reuses
+  `mode_pd::decode_pd_line_pair` unchanged. Timing constants from
+  slowrx `modespec.c:299-310`.
+- **`SyncPosition` enum + `ModeSpec::sync_position` field.** V2 carve-out
+  per [V2 epic-split design](docs/superpowers/specs/2026-05-02-v2-epic-split-design.md).
+  PD120/PD180/PD240 all use `SyncPosition::LineStart`. The
+  `#[non_exhaustive]` enum will gain a Scottie variant in V2.3.
+
+### Tests
+
+- `tests/roundtrip.rs::pd240_roundtrip` — synthetic encode/decode round-
+  trip with mean per-pixel-diff threshold < 5.0.
+```
+
+Replace `YYYY-MM-DD` with today's date (use `date -I`).
+
+- [ ] **Step 3: Verify the file parses cleanly**
+
+```bash
+head -50 CHANGELOG.md
+```
+
+Expected: clear separation between `[Unreleased]`, `[0.2.0]`, and `[0.1.0]` sections. No stray markdown.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CHANGELOG.md
+git commit -m "docs(changelog): 0.2.0 — V2.1 PD240 release"
+```
+
+### Task 4.3: Bump `Cargo.toml` to 0.2.0
+
+**Files:**
+- Modify: `Cargo.toml:3`.
+
+- [ ] **Step 1: Bump the version**
+
+Change `Cargo.toml:3` from:
+
+```toml
+version = "0.1.0"
+```
+
+to:
+
+```toml
+version = "0.2.0"
+```
+
+- [ ] **Step 2: Update `Cargo.lock`**
+
+Run: `cargo build --all-features --locked 2>&1 | tail -3`
+
+If `--locked` fails because lockfile is out of date, run `cargo build --all-features` (without `--locked`) to refresh it, then run with `--locked` again to confirm.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Cargo.toml Cargo.lock
+git commit -m "chore(release): bump version to 0.2.0"
+```
+
+### Task 4.4: Verify the full release-readiness gate
+
+**Files:** None (verification only).
+
+- [ ] **Step 1: Format check**
+
+```bash
+cargo fmt --all -- --check
+```
+
+Expected: no output (success).
+
+- [ ] **Step 2: Clippy with CI's strict gate**
+
+```bash
+cargo clippy --all-targets --all-features -- -D warnings 2>&1 | tail -10
+```
+
+Expected: no warnings.
+
+- [ ] **Step 3: Full test suite**
+
+```bash
+cargo test --all-features --locked 2>&1 | tail -15
+```
+
+Expected: all tests pass, including the 3 PD round-trips.
+
+- [ ] **Step 4: Doc build with CI's strict gate**
+
+```bash
+RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features 2>&1 | tail -10
+```
+
+Expected: no warnings.
+
+- [ ] **Step 5: Coverage check (≥ 92 % per file)**
+
+```bash
+cargo llvm-cov --all-features --summary-only 2>&1 | tail -20
+```
+
+Expected: per-file coverage column ≥ 92 % across the board. (PD240 added <50 LOC across 2 existing files that were already at high coverage — should remain green.)
+
+If `cargo-llvm-cov` isn't installed: `cargo install cargo-llvm-cov` first.
+
+- [ ] **Step 6: Publish dry-run**
+
+```bash
+cargo publish --dry-run --features cli 2>&1 | tail -15
+```
+
+Expected: `Packaging slowrx v0.2.0`, `Verifying slowrx v0.2.0`, no errors. The `cli` feature must be enabled for the dry-run to compile the optional `slowrx-cli` binary.
+
+### Task 4.5: Open the PR
+
+**Files:** None (GitHub-side change).
+
+Substitute `${V2_1}` with the actual V2.1 issue number captured in Task 0.6.
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+git push -u origin feat/v2.1-pd240
+```
+
+- [ ] **Step 2: Open PR**
+
+```bash
+gh pr create --repo jasonherald/slowrx.rs \
+  --title "feat(pd240): V2.1 — PD240 decoding (closes #${V2_1})" \
+  --body "$(cat <<'EOF'
+## Summary
+
+- Adds `SstvMode::Pd240` (VIS code 0x61) — same `PdYcbcr` channel layout as PD120/PD180, only timing differs.
+- Adds the V2 ModeSpec carve-out: `SyncPosition` enum + `ModeSpec::sync_position` field. PD120/PD180/PD240 all use `LineStart`; the carve-out forces V2.3 Scottie to make its mid-line sync explicit when it lands.
+- New `pd240_roundtrip` synthetic test passes with mean per-pixel diff < 5.0 (matches PD120/PD180 gate).
+- README mode-coverage table updated, CHANGELOG entry added under `[0.2.0]`, `Cargo.toml` bumped.
+
+Spec: `docs/superpowers/specs/2026-05-02-v2-epic-split-design.md`
+
+## Test plan
+
+- [x] `cargo fmt --all -- --check`
+- [x] `cargo clippy --all-targets --all-features -- -D warnings`
+- [x] `cargo test --all-features --locked` (PD120/PD180/PD240 round-trips green)
+- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`
+- [x] `cargo llvm-cov --all-features --summary-only` (≥ 92 % per file)
+- [x] `cargo publish --dry-run --features cli`
+EOF
+)"
+```
+
+Capture the PR URL.
+
+- [ ] **Step 3: Wait for CI**
+
+```bash
+gh pr checks --watch
+```
+
+Expected: all CI jobs (`check`, `msrv`, `audit`, `codeql`, `deny`, publish-dryrun if present) pass.
+
+- [ ] **Step 4: Merge after self-review**
+
+```bash
+gh pr merge --squash --delete-branch
+```
+
+(Use the merge strategy the project's PR history follows. From `git log --oneline -5` it's `Merge pull request #N from <branch>` — that's the GitHub UI default merge, but `--squash` keeps history clean if the project prefers. Check existing convention before merging.)
+
+### Task 4.6: Publish to crates.io
+
+**Files:** None (registry-side change).
+
+- [ ] **Step 1: Sync `main` to local**
+
+```bash
+cd /data/source/slowrx.rs   # back to the main worktree
+git checkout main
+git pull --ff-only
+```
+
+- [ ] **Step 2: Tag the release**
+
+```bash
+git tag -s v0.2.0 -m "v0.2.0 — V2.1 PD240"
+git push origin v0.2.0
+```
+
+- [ ] **Step 3: Publish**
+
+```bash
+cargo publish --features cli
+```
+
+Expected: `Uploading slowrx v0.2.0`, success message. (The crate is already on crates.io from 0.1.0, so this is a version-bump publish, not a first-time publish. Authentication via `cargo login` should already be configured from the 0.1.0 release.)
+
+- [ ] **Step 4: Verify**
+
+```bash
+sleep 30  # allow registry to index
+cargo search slowrx | head -3
+```
+
+Expected: shows `slowrx = "0.2.0"`.
+
+### Task 4.7: Close V2.1 epic + tick umbrella checklist
+
+**Files:** None (GitHub-side change).
+
+- [ ] **Step 1: Close the V2.1 epic**
+
+```bash
+gh issue close ${V2_1} --repo jasonherald/slowrx.rs --comment "Shipped in 0.2.0. PR closed by merge above; crates.io publish complete."
+```
+
+- [ ] **Step 2: Tick the V2.1 row in #9's Children table**
+
+```bash
+gh issue view 9 --repo jasonherald/slowrx.rs --json body --jq .body > /tmp/issue-9-body.md
+sed -i "s|V2.1 | PD-extended | PD240 | 0.2.0 | #${V2_1} |V2.1 | PD-extended | PD240 | 0.2.0 (✅ shipped) | #${V2_1} |" /tmp/issue-9-body.md
+gh issue edit 9 --repo jasonherald/slowrx.rs --body-file /tmp/issue-9-body.md
+```
+
+(The `sed` invocation is a hint — manual edit via `gh issue edit 9 --editor` is fine if `sed` quoting gets fiddly with the table pipes.)
+
+- [ ] **Step 3: Clean up the worktree**
+
+```bash
+git worktree remove ../slowrx.rs-v2.1-pd240
+```
+
+- [ ] **Step 4: Tear down `/tmp/v2-epic-bodies/`**
+
+```bash
+rm -rf /tmp/v2-epic-bodies/ /tmp/issue-9-*.md
+```
+
+---
+
+## Self-review notes (visible to executor)
+
+The author of this plan ran the writing-plans self-review checklist before publishing. Findings:
+
+- **Spec coverage:** All 3 spec acceptance criteria are covered. Phase 0 covers items 1-2 (umbrella Children section + 5 child epics filed). Phases 1-4 cover item 3 (V2.1 implementation plan). The spec's "Open questions" (`*_test_encoder.rs` shape, dispatch key) are deliberately N/A for V2.1: PD240 reuses `pd_test_encoder.rs` directly (no new encoder helper) and there's no dispatch change needed since channel layout is unchanged. Both questions become live in V2.2.
+- **Placeholder scan:** No `TBD`/`TODO`/`add appropriate X` in any code block. Date placeholder in CHANGELOG (`YYYY-MM-DD`) is a deliberate runtime substitution; instruction to use `date -I` is concrete. Issue-number placeholders (`${V2_1}`...`${V2_5}`) are explicit — the executor captures real numbers in Task 0.6 Steps 1-5.
+- **Type consistency:** `SyncPosition::LineStart` used consistently across Phases 1-3. `0x61` consistently for PD240's VIS code in `lookup`, the round-trip match, and tests. `1.000` (line_seconds), `0.020` (sync_seconds), `0.002_08` (porch_seconds), `0.000_382` (pixel_seconds), `0.0` (septr_seconds) consistent between `PD240` const definition and the `pd240_vis_code_resolves` test assertions.
+
+No issues found that required inline fixes during self-review.

--- a/docs/superpowers/specs/2026-05-02-v2-epic-split-design.md
+++ b/docs/superpowers/specs/2026-05-02-v2-epic-split-design.md
@@ -1,0 +1,232 @@
+# slowrx.rs V2 — Epic Split Design
+
+**Status:** Approved 2026-05-02. Ready for implementation planning via the
+[superpowers:writing-plans](https://github.com/anthropic-ai/superpowers) skill.
+
+**Goal:** Decompose the single V2 umbrella ([issue #9]) into focused child
+epics that can ship one at a time, each producing an additive minor crate
+release. Add a parallel child epic for ISS / Zarya real-capture validation.
+
+**Out of scope for this spec:**
+
+- Decoder algorithm details for each mode-family (those land per-epic in the
+  writing-plans skill output).
+- Encoding (slowrx.rs is decode-only).
+- HF SSTV modes (SC2-180, MMSSTV-specific). V2 targets VHF/UHF amateur SSTV.
+- GUI, streaming I/O, or any non-library work.
+- Refactoring shared logic across mode families (deferred — see Risks §4).
+
+[issue #9]: https://github.com/jasonherald/slowrx.rs/issues/9
+
+## Context
+
+`slowrx.rs` shipped 0.1.0 on 2026-05-02 with PD120 + PD180 only — sufficient
+for ARISS reception. V1's architecture deliberately carved out
+`#[non_exhaustive]` enums (`SstvMode`, `ChannelLayout`) and a `septr_seconds`
+field so V2 modes could land additively without churning V1 files. V2
+realizes that promise.
+
+The user is the only consumer plus the [`jasonherald/rtl-sdr`] application.
+There is no external release pressure; the project favors careful delivery
+over fast delivery.
+
+[`jasonherald/rtl-sdr`]: https://github.com/jasonherald/rtl-sdr
+
+## Epic structure
+
+Issue #9 stays open as the V2 umbrella. Five child epics file under it.
+The umbrella body gets a "Children" section linking each child; the umbrella
+closes when V2.1–V2.4 close. V2.5 outlives V2 as an open-ended capture
+tracker.
+
+| #    | Epic              | Modes                          | Files touched                                                     | Est. LOC | Release |
+|------|-------------------|--------------------------------|-------------------------------------------------------------------|----------|---------|
+| V2.1 | PD-extended       | PD240                          | extends `mode_pd.rs`, `modespec.rs` (+1 row), `lib.rs` re-export  | ~150     | 0.2.0   |
+| V2.2 | Robot family      | Robot 36, Robot 72             | new `mode_robot.rs`, `modespec.rs` (+2), `decoder.rs` dispatch    | ~400     | 0.3.0   |
+| V2.3 | Scottie family    | Scottie 1, Scottie 2, DX       | new `mode_scottie.rs`, `modespec.rs` (+3), dispatch               | ~400     | 0.4.0   |
+| V2.4 | Martin family     | Martin 1, Martin 2             | new `mode_martin.rs`, `modespec.rs` (+2), dispatch                | ~300     | 0.5.0   |
+| V2.5 | Zarya validation  | (no decoder)                   | `tests/fixtures/iss-zarya/README.md` + regression test once live  | ~50      | patch   |
+
+**Sequential delivery order:** V2.1 → V2.2 → V2.3 → V2.4. PD240 first because
+it's the lowest-risk extension of existing code (same chroma layout, only
+timing differs) and acts as a confidence-builder that the V1 carve-outs
+work as designed. Robot family second because it's the second-most-likely
+on-air mode after PD. Scottie before Martin because they share RGB-sequential
+layout — Scottie de-risks Martin.
+
+**Closeout per child:** epic closes when the mode-family PR merges, the
+semver bump publishes to crates.io, the CHANGELOG entry lands, and the
+umbrella #9 checklist is ticked.
+
+**V2.5 (Zarya) runs in parallel** as opportunity allows. It does not gate
+any decoder release. Its merge gate is a real-world Zarya capture (RSØISS /
+ISS Russian-side SSTV pass). Recent ARISS-SSTV events from the Russian side
+have used PD120 almost exclusively — already covered by V1 — so V2.5 is
+fixture/observability work, not new decoder work.
+
+## Per-epic shape (mode-family template)
+
+Each mode-family child epic body has these sections:
+
+1. **Mode family** — modes, VIS codes, slowrx C reference (file:line).
+2. **DSP delta from V1** — what's new vs. PD-family chroma/sync logic.
+3. **File plan** — new file path, ≤ 500 LOC cap, additions to `modespec.rs`
+   and `decoder.rs` dispatch.
+4. **Test corpus** — synthetic round-trip in `tests/roundtrip.rs` plus a
+   per-mode encoder helper at `src/<family>_test_encoder.rs`, mirroring
+   `src/pd_test_encoder.rs`.
+5. **Coverage gate** — `cargo llvm-cov` ≥ 92 % per-file maintained.
+6. **Acceptance checklist** — synthetic round-trip green, per-file coverage
+   ≥ 92 %, `CHANGELOG.md` entry, version bump, `cargo publish --dry-run`
+   clean.
+7. **Out of scope** — explicitly: real-radio fixtures (those land
+   asynchronously, not as a merge gate; see Risks §3).
+
+**Intentionally absent from the template:**
+
+- slowrx C cross-validation infrastructure. V1 audits showed this is a large
+  undertaking for marginal gain. We rely on synthetic round-trips and
+  post-hoc audit (V1's Phase-1→Phase-7 recovery pattern) instead.
+- Real-radio capture as a merge gate. Captures arrive on their own schedule.
+- Cross-mode shared-helper refactors. Let Scottie and Martin duplicate;
+  only extract a shared helper if V2.4 shows clear duplication pain.
+
+## Per-epic shape (Zarya template — V2.5 only)
+
+V2.5 has no decoder work. Its body sections are:
+
+1. **Capture goals** — target an RSØISS / ISS Russian-side SSTV pass;
+   document date, frequency (145.800 MHz FM), equipment, audio chain.
+2. **Mode identification** — use `slowrx-cli` to detect the VIS code from
+   the recording; confirm mode (expected: PD120, possibly PD180).
+3. **Fixture acceptance** — drop the WAV under `tests/fixtures/iss-zarya/`,
+   add a regression case, follow the V1 ARISS-corpus pattern (gitignored,
+   no CI gate).
+
+**Acceptance:** at least one Zarya capture decoded to a recognizable image,
+fixture path committed (the WAV itself stays out of git, matching the
+Dec-2017 corpus convention).
+
+## Architectural deltas
+
+Three shared files change. Everything else lives in new per-family modules.
+
+### `modespec.rs` — additive only
+
+The V1 enums are already `#[non_exhaustive]`, so all additions are
+non-breaking.
+
+- New `SstvMode` variants: `Pd240`, `Robot36`, `Robot72`, `Scottie1`,
+  `Scottie2`, `ScottieDx`, `Martin1`, `Martin2`.
+- New `ChannelLayout` variants:
+  - `RobotYuv` — Y line + alternating Cr/Cb chroma (Robot 36); full
+    per-line chroma (Robot 72).
+  - `RgbSequential` — Scottie + Martin both. They share layout; they
+    differ only in sync placement.
+- New `sync_position: SyncPosition` field on `ModeSpec` to capture the
+  Scottie quirk (sync between G and B, not at line start). PD / Robot /
+  Martin all keep `LineStart`. Adding the field is non-breaking — it's a
+  new struct field, not an enum variant change.
+- The `septr_seconds` field carved out in V1 finally takes non-zero values
+  for Robot, Scottie, and Martin. (V1's foresight pays off — the
+  `chan_starts_sec` formula in `mode_pd::decode_pd_line_pair` already uses
+  it term-for-term per `slowrx video.c:88-92`.)
+
+### `decoder.rs` — small dispatch addition (~30–50 LOC)
+
+- The state machine currently calls `mode_pd::decode_pd_line_pair` directly
+  when the active mode's layout is `PdYcbcr`.
+- New dispatch matches on `ChannelLayout` (not `SstvMode`):
+  `RobotYuv` → `mode_robot::decode_line`, `RgbSequential` →
+  `mode_scottie::decode_line` (Scottie + Martin share an entry point;
+  the `sync_position` field disambiguates).
+- The `PdYcbcr` arm stays byte-identical to today. Zero behavioral change
+  for V1 modes.
+
+### `lib.rs` — re-exports
+
+- `pub mod` declarations for new mode modules per epic.
+- New `SstvMode` variants and `ChannelLayout` variants surface through the
+  existing re-export of `crate::modespec::*`.
+- No churn to existing exports.
+
+### Files unchanged by V2 (expected)
+
+`vis.rs`, `sync.rs`, `snr.rs`, `resample.rs`, `image.rs`, `error.rs`. Sync
+correlation is mode-agnostic; per-mode sync placement is metadata on
+`ModeSpec`, not new logic in `sync.rs`. **Caveat:** Risk §1 documents the
+one path under which `sync.rs` or the line-clock advance in `decoder.rs`
+may need to change during V2.3 (Scottie). If that turns out to be required,
+the change lands in V2.3 in scope, not as a separate refactor.
+
+## Versioning
+
+One semver-minor bump per mode-family epic (4 minor bumps total). Adding a
+variant to `#[non_exhaustive]` enums is API-additive — semver-minor under
+the strict rule.
+
+| Epic | Crate version | Trigger                  |
+|------|---------------|--------------------------|
+| V2.1 | 0.2.0         | PD240 ships              |
+| V2.2 | 0.3.0         | Robot 36 + Robot 72 ship |
+| V2.3 | 0.4.0         | Scottie 1 / 2 / DX ship  |
+| V2.4 | 0.5.0         | Martin 1 / 2 ship        |
+| V2.5 | (patch)       | Fixture lands; no API change |
+
+This gives the rtl-sdr application a precise pin to declare against
+("requires `slowrx ≥ 0.3` for Robot support") rather than depending on
+"whatever 0.2.x has."
+
+## Testing posture
+
+Same as V1, no new infrastructure:
+
+- **Synthetic round-trip** per mode-family in `tests/roundtrip.rs` with a
+  per-mode encoder helper (`src/<family>_test_encoder.rs`).
+- **Per-file coverage gate** at 92 %, enforced via `cargo llvm-cov`.
+- **Real-world fixtures** (when they appear) land under
+  `tests/fixtures/<event>/` following the V1 pattern: gitignored corpus,
+  local validation only, no CI gate on real-WAV decoding. The V1 CLI
+  integration test (`tests/cli.rs`) is the model — it skips silently if
+  the fixture isn't present.
+
+## Risks and unknowns
+
+1. **Scottie sync placement** (V2.3) — V1's line-clock advance assumes sync
+   at line start. If hidden assumptions exist, V2.3 fixes them in scope.
+   Mitigation: the `sync_position` field added in V2.1 forces the assumption
+   to be made explicit at dispatch time.
+2. **Robot 36 chroma alternation** (V2.2) — Robot 36 alternates Cr/Cb
+   between consecutive lines. This is genuinely new per-line state, not
+   just timing. Synthetic round-trip must cover both line phases.
+3. **Real-radio gap** — same trap V1 hit (synthetic green, real-radio
+   broken). Without slowrx-C cross-validation, each mode-family will have a
+   window where it passes synthetic tests but its real-radio behavior is
+   unverified. Mitigation: V1's parity-audit recovery pattern remains
+   available; we accept the risk knowingly.
+4. **Fixture availability for V2.5** — Zarya captures are user-dependent.
+   V2.5 may stay open indefinitely. Acceptable — it's a capture tracker,
+   not a release-gate epic. Promising sources (untried as of writing):
+   ARISS-SSTV award gallery, N7CXI mode samples, SSTV-handbook.com sample
+   library, SatNOGS network archives.
+
+## Open questions for writing-plans
+
+- **Per-mode `*_test_encoder.rs` shape** — replicate `pd_test_encoder.rs`
+  exactly, or factor a shared encoder trait? **Recommend: replicate, don't
+  factor. YAGNI.**
+- **Dispatch key in `decoder.rs`** — match on `ChannelLayout` or
+  `SstvMode`? **Recommend: `ChannelLayout`, since Scottie + Martin share
+  an entry point.**
+
+## Acceptance for this spec
+
+This spec is "done" when:
+
+- Issue #9 has been edited to add a "Children" section linking V2.1–V2.5.
+- 5 child epics exist on GitHub with the body sections above filled in.
+- The first child epic (V2.1) has an accepted implementation plan produced
+  by the writing-plans skill.
+
+Spec lifecycle ends here. Each child epic gets its own writing-plans pass
+when it comes up in the queue.

--- a/src/modespec.rs
+++ b/src/modespec.rs
@@ -3,12 +3,12 @@
 //! Translated from slowrx's `modespec.c` (Oona Räisänen, ISC License).
 //! See `NOTICE.md` for full attribution.
 //!
-//! V1 implements PD120 + PD180. V2 modes (PD240, Robot 36/72, Scottie 1/2/DX,
-//! Martin 1/2) are planned but not yet present in the [`SstvMode`] enum or
-//! the lookup tables; each will land with its own PR.
+//! Implemented as of V2.1 (0.2.0): PD120, PD180, PD240. Remaining V2 modes
+//! (Robot 36/72, Scottie 1/2/DX, Martin 1/2) are not yet present in the
+//! [`SstvMode`] enum or the lookup tables; each will land with its own PR.
 
-/// SSTV operating mode. V1 implements [`SstvMode::Pd120`] and
-/// [`SstvMode::Pd180`]; additional modes are planned for V2.
+/// SSTV operating mode. Implemented: [`SstvMode::Pd120`], [`SstvMode::Pd180`],
+/// [`SstvMode::Pd240`]. Additional V2 modes (Robot, Scottie, Martin) planned.
 #[non_exhaustive]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum SstvMode {
@@ -74,7 +74,7 @@ pub enum ChannelLayout {
 /// time, surfacing the V1 line-clock-advance assumption that sync ==
 /// line start.
 ///
-/// V1 + V2.1 only emit [`SyncPosition::LineStart`]; [`SyncPosition::Scottie`]
+/// V1 + V2.1 only emit [`SyncPosition::LineStart`]; the `Scottie` variant
 /// lands with the V2.3 Scottie family epic.
 #[non_exhaustive]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
@@ -85,7 +85,7 @@ pub enum SyncPosition {
 
 /// Look up the [`ModeSpec`] for a given 7-bit VIS code. Returns `None`
 /// if the code is reserved, undefined, or maps to a mode not yet
-/// implemented in this V1 release.
+/// implemented in this release.
 ///
 /// VIS codes are taken from Dave Jones (KB4YZ), 1998: "List of SSTV
 /// Modes with VIS Codes".
@@ -123,7 +123,7 @@ pub fn for_mode(mode: SstvMode) -> ModeSpec {
 }
 
 // Mode timing constants — translated row-for-row from slowrx's
-// modespec.c (PD120 lines 260-271, PD180 lines 286-297).
+// modespec.c (PD120 lines 260-271, PD180 lines 286-297, PD240 lines 299-310).
 
 const PD120: ModeSpec = ModeSpec {
     mode: SstvMode::Pd120,

--- a/src/modespec.rs
+++ b/src/modespec.rs
@@ -16,6 +16,8 @@ pub enum SstvMode {
     Pd120,
     /// PD-180 (640×496, ~180s per image)
     Pd180,
+    /// PD-240 (640×496, ~240s per image)
+    Pd240,
 }
 
 /// Mode timing + layout table entry.
@@ -101,6 +103,7 @@ pub fn lookup(vis_code: u8) -> Option<ModeSpec> {
     match vis_code {
         0x5F => Some(PD120),
         0x60 => Some(PD180),
+        0x61 => Some(PD240),
         _ => None,
     }
 }
@@ -115,6 +118,7 @@ pub fn for_mode(mode: SstvMode) -> ModeSpec {
     match mode {
         SstvMode::Pd120 => PD120,
         SstvMode::Pd180 => PD180,
+        SstvMode::Pd240 => PD240,
     }
 }
 
@@ -144,6 +148,22 @@ const PD180: ModeSpec = ModeSpec {
     sync_seconds: 0.020,
     porch_seconds: 0.002_08,
     pixel_seconds: 0.000_286,
+    septr_seconds: 0.0, // modespec.c: SeptrTime = 0e-3 for PD-family
+    channel_layout: ChannelLayout::PdYcbcr,
+    sync_position: SyncPosition::LineStart,
+};
+
+const PD240: ModeSpec = ModeSpec {
+    mode: SstvMode::Pd240,
+    vis_code: 0x61,
+    line_pixels: 640,
+    image_lines: 496,
+    // slowrx modespec.c:299-310 — PD240 LineTime = 1000e-3,
+    // PixelTime = 0.382e-3, SyncTime = 20e-3, PorchTime = 2.08e-3.
+    line_seconds: 1.000,
+    sync_seconds: 0.020,
+    porch_seconds: 0.002_08,
+    pixel_seconds: 0.000_382,
     septr_seconds: 0.0, // modespec.c: SeptrTime = 0e-3 for PD-family
     channel_layout: ChannelLayout::PdYcbcr,
     sync_position: SyncPosition::LineStart,
@@ -205,9 +225,30 @@ mod tests {
         // mid-line sync without retrofitting V1. PD120/PD180/PD240 all use
         // line-start sync (slowrx video.c:88-92 places sync at the start of
         // each line for PD modes).
-        for mode in [SstvMode::Pd120, SstvMode::Pd180] {
+        for mode in [SstvMode::Pd120, SstvMode::Pd180, SstvMode::Pd240] {
             let spec = for_mode(mode);
             assert_eq!(spec.sync_position, SyncPosition::LineStart);
         }
+    }
+
+    #[test]
+    fn pd240_vis_code_resolves() {
+        let spec = lookup(0x61).expect("PD240 VIS resolves");
+        assert_eq!(spec.mode, SstvMode::Pd240);
+        assert_eq!(spec.vis_code, 0x61);
+        assert_eq!(spec.line_pixels, 640);
+        assert_eq!(spec.image_lines, 496);
+        assert_eq!(spec.channel_layout, ChannelLayout::PdYcbcr);
+        assert_eq!(spec.sync_position, SyncPosition::LineStart);
+        assert_eq!(spec.line_seconds, 1.000);
+        assert_eq!(spec.sync_seconds, 0.020);
+        assert_eq!(spec.porch_seconds, 0.002_08);
+        assert_eq!(spec.pixel_seconds, 0.000_382);
+        assert_eq!(spec.septr_seconds, 0.0);
+    }
+
+    #[test]
+    fn for_mode_returns_pd240_spec() {
+        assert_eq!(for_mode(SstvMode::Pd240).vis_code, 0x61);
     }
 }

--- a/src/modespec.rs
+++ b/src/modespec.rs
@@ -47,6 +47,10 @@ pub struct ModeSpec {
     pub septr_seconds: f64,
     /// Channel layout used by per-mode decoders.
     pub channel_layout: ChannelLayout,
+    /// Where the sync pulse sits within a radio line. See [`SyncPosition`]
+    /// for the rationale (V2 carve-out forcing mid-line sync to be
+    /// explicit when V2.3 Scottie lands).
+    pub sync_position: SyncPosition,
 }
 
 /// Per-mode channel arrangement. PD-family modes use [`ChannelLayout::PdYcbcr`].
@@ -57,6 +61,24 @@ pub enum ChannelLayout {
     /// PD-family: Y(odd) → Cr → Cb → Y(even). One radio line carries
     /// two image rows; chroma is shared between paired rows.
     PdYcbcr,
+}
+
+/// Where the sync pulse sits within a radio line.
+///
+/// PD/Robot/Martin all place sync at line start (the standard SSTV
+/// convention). Scottie modes are the exception — sync sits between G
+/// and B channels, not at line start. Stored here so future mode
+/// decoders are forced to make their sync placement explicit at dispatch
+/// time, surfacing the V1 line-clock-advance assumption that sync ==
+/// line start.
+///
+/// V1 + V2.1 only emit [`SyncPosition::LineStart`]; [`SyncPosition::Scottie`]
+/// lands with the V2.3 Scottie family epic.
+#[non_exhaustive]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum SyncPosition {
+    /// Sync pulse at the start of each radio line. PD, Robot, Martin.
+    LineStart,
 }
 
 /// Look up the [`ModeSpec`] for a given 7-bit VIS code. Returns `None`
@@ -110,6 +132,7 @@ const PD120: ModeSpec = ModeSpec {
     pixel_seconds: 0.000_19,
     septr_seconds: 0.0, // modespec.c: SeptrTime = 0e-3 for PD-family
     channel_layout: ChannelLayout::PdYcbcr,
+    sync_position: SyncPosition::LineStart,
 };
 
 const PD180: ModeSpec = ModeSpec {
@@ -123,6 +146,7 @@ const PD180: ModeSpec = ModeSpec {
     pixel_seconds: 0.000_286,
     septr_seconds: 0.0, // modespec.c: SeptrTime = 0e-3 for PD-family
     channel_layout: ChannelLayout::PdYcbcr,
+    sync_position: SyncPosition::LineStart,
 };
 
 #[cfg(test)]
@@ -173,5 +197,17 @@ mod tests {
         let pd180 = lookup(0x60).expect("PD180");
         assert_eq!(pd120.septr_seconds, 0.0);
         assert_eq!(pd180.septr_seconds, 0.0);
+    }
+
+    #[test]
+    fn pd_modes_have_line_start_sync_position() {
+        // V2 carve-out: ModeSpec.sync_position lets V2.3 Scottie declare
+        // mid-line sync without retrofitting V1. PD120/PD180/PD240 all use
+        // line-start sync (slowrx video.c:88-92 places sync at the start of
+        // each line for PD modes).
+        for mode in [SstvMode::Pd120, SstvMode::Pd180] {
+            let spec = for_mode(mode);
+            assert_eq!(spec.sync_position, SyncPosition::LineStart);
+        }
     }
 }

--- a/src/pd_test_encoder.rs
+++ b/src/pd_test_encoder.rs
@@ -42,9 +42,10 @@ fn fill_to(out: &mut Vec<f32>, freq_hz: f64, target_n: usize, phase: &mut f64) {
     }
 }
 
-/// Encode an image as PD120 / PD180 audio. `ycrcb` is row-major
-/// `[Y, Cr, Cb]` triples of length `width * height`. Pairs of rows
-/// share averaged chroma, matching how the decoder will recover them.
+/// Encode an image as PD-family audio (PD120 / PD180 / PD240). `ycrcb`
+/// is row-major `[Y, Cr, Cb]` triples of length `width * height`. Pairs
+/// of rows share averaged chroma, matching how the decoder will recover
+/// them.
 #[must_use]
 #[doc(hidden)]
 #[allow(dead_code)]

--- a/src/pd_test_encoder.rs
+++ b/src/pd_test_encoder.rs
@@ -49,7 +49,10 @@ fn fill_to(out: &mut Vec<f32>, freq_hz: f64, target_n: usize, phase: &mut f64) {
 #[doc(hidden)]
 #[allow(dead_code)]
 pub fn encode_pd(mode: SstvMode, ycrcb: &[[u8; 3]]) -> Vec<f32> {
-    assert!(matches!(mode, SstvMode::Pd120 | SstvMode::Pd180));
+    assert!(matches!(
+        mode,
+        SstvMode::Pd120 | SstvMode::Pd180 | SstvMode::Pd240
+    ));
     let spec = crate::modespec::for_mode(mode);
     let w = spec.line_pixels;
     let h = spec.image_lines;

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -1,4 +1,4 @@
-//! Synthetic encode → decode round-trip for PD120 and PD180.
+//! Synthetic encode → decode round-trip for PD-family modes (PD120, PD180, PD240).
 
 #![cfg(feature = "test-support")]
 #![allow(clippy::expect_used, clippy::cast_possible_truncation)]

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -41,6 +41,7 @@ fn run_roundtrip(mode: SstvMode) {
     let vis_code = match mode {
         SstvMode::Pd120 => 0x5F,
         SstvMode::Pd180 => 0x60,
+        SstvMode::Pd240 => 0x61,
         _ => unreachable!(),
     };
     let mut audio = slowrx::__test_support::vis::synth_vis(vis_code, 0.0);
@@ -106,4 +107,9 @@ fn pd120_roundtrip() {
 #[test]
 fn pd180_roundtrip() {
     run_roundtrip(SstvMode::Pd180);
+}
+
+#[test]
+fn pd240_roundtrip() {
+    run_roundtrip(SstvMode::Pd240);
 }


### PR DESCRIPTION
## Summary

- Adds **`SstvMode::Pd240`** (VIS code `0x61`) — same `PdYcbcr` channel layout as PD120/PD180, only timing constants differ. Constants translated from slowrx `modespec.c:299-310` (`LineTime=1000e-3`, `PixelTime=0.382e-3`, etc.) and verified bit-exact via f64 hex comparison.
- Adds the V2 ModeSpec carve-out: **`SyncPosition` enum** (`#[non_exhaustive]`, single `LineStart` variant) and a new **`sync_position: SyncPosition` field** on `ModeSpec`. PD120/PD180/PD240 all use `LineStart`; the carve-out forces V2.3 Scottie to make its mid-line sync placement explicit when it lands.
- Adds **`pd240_roundtrip`** synthetic encode/decode test (`tests/roundtrip.rs`). Passes the same `mean < 5.0` per-pixel-RGB-diff threshold as PD120/PD180 — empirical confirmation that the PD-family generalization in V1 actually generalizes.
- README mode-coverage table reframed `V1/V2 → Shipped/Roadmap` (PD now `PD120, PD180, PD240` shipped); Status section bumped to `0.2.0 — V2.1 published`; the validation paragraph honestly distinguishes ARISS-validated PD120/PD180 from synthetic-only PD240 (real-radio fixture pending).
- `CHANGELOG.md` entry under `[0.2.0] - 2026-05-02`. `Cargo.toml` bumped to `0.2.0`.

Spec: [`docs/superpowers/specs/2026-05-02-v2-epic-split-design.md`](docs/superpowers/specs/2026-05-02-v2-epic-split-design.md)
Plan: [`docs/superpowers/plans/2026-05-02-v2.1-pd240.md`](docs/superpowers/plans/2026-05-02-v2.1-pd240.md)

Closes #63 (V2.1 epic). Tracks #9 (V2 umbrella) — V2.1 row in the Children table will be ticked as part of the merge follow-up.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features --locked` — all 91 tests pass (86 lib + 0 cli-bin + 1 cli-integration + 3 roundtrip + 1 doctest); `pd240_roundtrip` runs in ~78s
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features` — clean (one latent intra-doc-link bug introduced earlier in the branch was caught locally and fixed in `d346ef3` before push)
- [x] `cargo llvm-cov --all-features --summary-only` — every library file ≥ 92% line coverage (lowest is `resample.rs` at 93.71%; `bin/slowrx_cli.rs` at 0% as expected — needs gitignored ARISS fixtures)
- [x] `cargo publish --dry-run --features cli` — packages 21 files, 237 KiB → 74 KiB compressed, verifies clean

## Process notes

This PR was executed under the `superpowers:subagent-driven-development` skill with strict per-task verification (read every diff manually, re-ran every CI gate locally, cross-checked PD240 timing constants against the slowrx C source byte-for-byte). The full implementer + spec-reviewer + code-quality-reviewer ceremony fired on every TDD-pair commit. Two follow-up doc-cleanup commits (`d346ef3`, `089c5e1`) capture review-driven fixes inline rather than deferring.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes - Version 0.2.0

* **New Features**
  * Added support for PD240 SSTV mode.
  * Expanded validated decoding coverage for PD120/PD180 from raw audio.

* **Documentation**
  * Updated mode coverage roadmap to reflect PD120/PD180/PD240 as shipped modes.
  * Added comprehensive V2.1 implementation and release planning documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->