### PR TITLE
fix(0.2.1): post-V2.1 final-review cleanup — 2 important + 5 minor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1] - 2026-05-02
+
+Patch release bundling the post-merge final-review cleanup of V2.1
+(PD240). Two important user-visible fixes plus five minor consistency
+items.
+
+### Fixed
+
+- **`slowrx-cli` saved PD240 images as `img-NNN-unknown.png`** instead of
+  `img-NNN-pd240.png`. The `mode_tag` match in `src/bin/slowrx_cli.rs`
+  was missing the `SstvMode::Pd240` arm; the wildcard arm absorbed it
+  silently because `SstvMode` is `#[non_exhaustive]`. Added the explicit
+  arm; rewrote the wildcard's comment to flag the trap so future
+  variant additions don't repeat it.
+- **Crate-level rustdoc Status block was stale** (`src/lib.rs`). Said
+  "Pre-0.1 — under active development. Public API is not yet stable."
+  on the docs.rs landing page for `0.2.0`. Refreshed to `0.2.x` V2.1
+  language linking to the V2 roadmap ([#9]).
+
+### Changed
+
+- Re-exported `SyncPosition` from the crate root so downstream callers
+  can write `slowrx::SyncPosition::LineStart` instead of the deeper
+  `slowrx::modespec::SyncPosition::LineStart` path. Adds public surface
+  ahead of V2.3 Scottie, which will introduce a second variant.
+- Stale "PD120/PD180" mentions refreshed to "PD120/PD180/PD240" in:
+  `src/mode_pd.rs` (channel-time-offsets explanation) and
+  `docs/intentional-deviations.md` (mean-diff observation).
+
+### Tests
+
+- `src/mode_pd.rs::tests::chan_starts_sec_septr_zero...` — loop now
+  covers `Pd240` alongside `Pd120`/`Pd180`, verifying the
+  `chan_starts_sec` formula stays numerically equivalent for all
+  current PD-family modes.
+- `src/decoder.rs::tests::process_emits_vis_detected_for_pd240_burst` —
+  new sibling of the existing PD120/PD180 VIS-detection unit tests.
+
+[#9]: https://github.com/jasonherald/slowrx.rs/issues/9
+
 ## [0.2.0] - 2026-05-02
 
 V2.1 — PD240 mode coverage. First V2 release. Adds the third PD-family

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -707,7 +707,7 @@ checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "slowrx"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slowrx"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 rust-version = "1.85"
 description = "Pure-Rust SSTV (Slow-Scan TV) decoder library — a port of slowrx by Oona Räisänen"

--- a/docs/intentional-deviations.md
+++ b/docs/intentional-deviations.md
@@ -137,9 +137,9 @@ on real radio — verified visually against the Dec-2017 ARISS captures
 — but the synthetic "instant step" inputs trip the SNR-adaptive
 selector + boundary FFT in ways the slewed real-audio doesn't.
 
-Mean diff staying excellent (1.5–1.9 on PD120/PD180) shows the
-decoder is mostly fine; the `max` is dominated by a handful of
-boundary pixels per image.
+Mean diff stays excellent across the PD family (1.5–1.9 on PD120/PD180,
+similarly low on PD240) — the decoder is mostly fine; the `max` is
+dominated by a handful of boundary pixels per image.
 
 ### When to revisit
 

--- a/src/bin/slowrx_cli.rs
+++ b/src/bin/slowrx_cli.rs
@@ -283,8 +283,12 @@ fn mode_tag(mode: SstvMode) -> &'static str {
     match mode {
         SstvMode::Pd120 => "pd120",
         SstvMode::Pd180 => "pd180",
-        // SstvMode is non-exhaustive; future modes get a generic tag
-        // until the binary's match adds a specific case.
+        SstvMode::Pd240 => "pd240",
+        // SstvMode is #[non_exhaustive] which forces a wildcard arm in
+        // matches even within the same crate. New variants will use
+        // this fallback — when adding one, also add an explicit arm
+        // above. (V2.1 PD240 trap: missed this match and shipped images
+        // as `img-NNN-unknown.png` until 0.2.1.)
         _ => "unknown",
     }
 }

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -529,6 +529,27 @@ mod tests {
     }
 
     #[test]
+    fn process_emits_vis_detected_for_pd240_burst() {
+        use crate::vis::tests::synth_vis;
+        let mut d = SstvDecoder::new(WORKING_SAMPLE_RATE_HZ).expect("decoder");
+        let mut burst = synth_vis(0x61, 0.0);
+        burst.extend(std::iter::repeat_n(0.0_f32, 512));
+        let events = d.process(&burst);
+        let hedr = events
+            .iter()
+            .find_map(|e| match e {
+                SstvEvent::VisDetected {
+                    mode: SstvMode::Pd240,
+                    hedr_shift_hz,
+                    ..
+                } => Some(*hedr_shift_hz),
+                _ => None,
+            })
+            .expect("expected VisDetected for PD240");
+        assert!(hedr.abs() < 10.0);
+    }
+
+    #[test]
     fn reset_clears_sample_counter() {
         let mut d = SstvDecoder::new(11_025).expect("decoder");
         let _ = d.process(&[0.0_f32; 1024]);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,8 +7,10 @@
 //!
 //! ## Status
 //!
-//! Pre-0.1 — under active development. Public API is not yet stable.
-//! See <https://github.com/jasonherald/slowrx.rs> for the implementation roadmap.
+//! `0.2.x` — V2.1 published with PD120, PD180, and PD240 decoding. The
+//! public API is `#[non_exhaustive]`-protected for additive growth as
+//! V2.x mode-family epics land. See
+//! <https://github.com/jasonherald/slowrx.rs/issues/9> for the V2 roadmap.
 //!
 //! ## Example
 //!
@@ -128,7 +130,9 @@ pub mod pd_test_encoder;
 pub use crate::decoder::{SstvDecoder, SstvEvent};
 pub use crate::error::{Error, Result};
 pub use crate::image::SstvImage;
-pub use crate::modespec::{for_mode, lookup as lookup_vis, ChannelLayout, ModeSpec, SstvMode};
+pub use crate::modespec::{
+    for_mode, lookup as lookup_vis, ChannelLayout, ModeSpec, SstvMode, SyncPosition,
+};
 pub use crate::resample::{Resampler, WORKING_SAMPLE_RATE_HZ};
 
 /// Test-support — exposed under the `test-support` feature for integration

--- a/src/mode_pd.rs
+++ b/src/mode_pd.rs
@@ -304,9 +304,10 @@ pub(crate) fn decode_pd_line_pair(
     // Y(odd) → Cr → Cb → Y(even). Mirrors slowrx video.c:88-92:
     //   ChanStart[n+1] = ChanStart[n] + ChanLen[n] + SeptrTime
     // where ChanLen[n] = PixelTime * ImgWidth.
-    // SeptrTime = 0 for PD120/PD180 (modespec.c), so septr_secs is a no-op
-    // now, but having it here prevents a silent break when non-PD modes
-    // (Robot, Scottie, Martin — all with non-zero SeptrTime) are added in V2.
+    // SeptrTime = 0 for the entire PD family (PD120/PD180/PD240, modespec.c),
+    // so septr_secs is a no-op for current modes — but having it here
+    // prevents a silent break when non-PD modes (Robot, Scottie, Martin —
+    // all with non-zero SeptrTime) are added in V2.
     let chan_len = f64::from(width) * pixel_secs;
     let chan_starts_sec = [
         sync_secs + porch_secs,                                     // Y(odd): 0 septr
@@ -508,6 +509,7 @@ mod tests {
         for spec in [
             crate::modespec::for_mode(crate::modespec::SstvMode::Pd120),
             crate::modespec::for_mode(crate::modespec::SstvMode::Pd180),
+            crate::modespec::for_mode(crate::modespec::SstvMode::Pd240),
         ] {
             let sync = spec.sync_seconds;
             let porch = spec.porch_seconds;


### PR DESCRIPTION
## Summary

Patch release bundling the 7 items the post-merge final code review of V2.1 (PD240) surfaced.

### Important (user-visible bugs in 0.2.0)

- **`slowrx-cli` saved PD240 images as `img-NNN-unknown.png`** instead of `img-NNN-pd240.png`. The `mode_tag` match in `src/bin/slowrx_cli.rs` was missing the `SstvMode::Pd240` arm; the wildcard absorbed it silently because `SstvMode` is `#[non_exhaustive]`. Added the explicit arm + rewrote the wildcard's comment to flag the trap concretely so future variant additions don't repeat it.
- **Crate-level rustdoc Status block was stale.** `src/lib.rs:8-11` still said *"Pre-0.1 — under active development. Public API is not yet stable."* — that's the docs.rs landing page text for `0.2.0`. Refreshed to `0.2.x` V2.1 wording linking to the V2 roadmap (#9).

### Minor (consistency cleanups)

- Re-exported `SyncPosition` from the crate root (`slowrx::SyncPosition` instead of `slowrx::modespec::SyncPosition`) ahead of V2.3 Scottie introducing a second variant.
- Refreshed two stale "PD120/PD180" mentions: one in `src/mode_pd.rs` (channel-time-offsets explanation), one in `docs/intentional-deviations.md` (mean-diff observation).
- `src/mode_pd.rs::tests::chan_starts_sec_septr_zero...` test loop now covers `Pd240` in addition to `Pd120`/`Pd180`.
- New `src/decoder.rs::tests::process_emits_vis_detected_for_pd240_burst` — sibling of the existing PD120/PD180 VIS-detection unit tests.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features --locked` — 92 tests pass (87 lib + 0 cli-bin + 1 cli-integration + 3 roundtrip + 1 doctest)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features` — clean
- [x] `cargo publish --dry-run --features cli --allow-dirty` — packages 21 files, 240 KiB → 75 KiB compressed

## Process notes

This is a dedicated patch PR rather than rolling these into V2.2 because the two Important items are real bugs in the just-shipped 0.2.0 (PD240-tagged-as-unknown will affect every downstream user that decodes PD240 with the CLI). Bundled with the 5 minor items per "no deferments" policy — better to land them all together and only pay one publish/PR-review cost.

Implementation followed the same `superpowers:subagent-driven-development` ceremony as V2.1 (implementer + spec-reviewer + code-quality-reviewer per task batch).

Closes nothing on its own — V2.1 epic #63 already closed when PR #68 merged. This is residual cleanup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release 0.2.1

* **Bug Fixes**
  * Fixed slowrx-cli to save PD240 images with correct mode-tagged filenames.

* **Documentation**
  * Updated crate documentation to reflect 0.2.x status and V2 roadmap.
  * Refined documentation about synthetic round-trip tolerance testing across PD modes.

* **Tests**
  * Added tests for PD240 VIS-detection and mode-specific decoding behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->