### PR TITLE
feat(robot): V2.2 — Robot 24 / 36 / 72 decoding (closes #64)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,11 +20,12 @@ Thumbs.db
 # or clone manually from https://github.com/windytan/slowrx)
 /original
 
-# Local ARISS reference fixtures used for the real-data success gate.
-# Real ARISS recordings (audio + decoded reference images) live here for
-# manual validation against our decoder. NOT committed — the redistribution
+# Local reference fixtures used for the real-data success gate.
+# Real recordings (audio + decoded reference images) live here for manual
+# validation against our decoder. NOT committed — the redistribution
 # license for community-shared captures is unclear, and we don't want to
-# bloat the published crate with ~250 MB of fixtures.
+# bloat the published crate with hundreds of MB of fixtures.
 /docs/wav_files
+/tests/fixtures
 
 original

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Closes V2.2 epic ([#64]). Tracks the V2 umbrella ([#9]).
 
 [#9]: https://github.com/jasonherald/slowrx.rs/issues/9
 [#64]: https://github.com/jasonherald/slowrx.rs/issues/64
+[#70]: https://github.com/jasonherald/slowrx.rs/issues/70
 [#71]: https://github.com/jasonherald/slowrx.rs/issues/71
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,97 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-05-02
+
+V2.2 — Robot family mode coverage. Adds Robot 24 (`SstvMode::Robot24`,
+VIS `0x04`), Robot 36 (`SstvMode::Robot36`, VIS `0x08`), and Robot 72
+(`SstvMode::Robot72`, VIS `0x0C`). First V2 release that introduces a
+non-PD decoder; introduces the cross-mode-family dispatch refactor in
+`decoder.rs`.
+
+Closes V2.2 epic ([#64]). Tracks the V2 umbrella ([#9]).
+
+[#9]: https://github.com/jasonherald/slowrx.rs/issues/9
+[#64]: https://github.com/jasonherald/slowrx.rs/issues/64
+[#71]: https://github.com/jasonherald/slowrx.rs/issues/71
+
+### Added
+
+- **Robot 24, Robot 36, Robot 72 modes.** All three at 320×240 image
+  resolution. Timing constants from slowrx `modespec.c:130-167`. R36/R24
+  share decoder code (chroma alternation + neighbor-row duplication per
+  slowrx `video.c:182-191`, `:421-425`); R72 uses the simpler 3-channel
+  Y/U/V sequential layout per `video.c:60-101` default case.
+- **`ChannelLayout::RobotYuv` enum variant** covering all three Robot
+  modes. Per-mode chroma topology lives inside `mode_robot.rs` (the
+  internal mode-match mirrors slowrx's `switch(Mode)` cases).
+- **`src/mode_robot.rs`** — new Robot-family decoder. Reuses
+  `mode_pd::decode_one_channel_into` (visibility bumped from private to
+  `pub(crate)`; the parameter `pair_seconds` was renamed to mode-
+  agnostic `time_offset_seconds`) and `mode_pd::ycbcr_to_rgb`.
+- **`src/robot_test_encoder.rs`** — synthetic encoder for round-trip
+  testing. Mirrors `pd_test_encoder.rs` shape.
+- **Per-mode chroma planes side buffer** on `DecodingState`
+  (`chroma_planes: Option<[Vec<u8>; 2]>`). Allocated only for
+  `ChannelLayout::RobotYuv`; lets R36/R24 compose RGB after both chroma
+  channels (own + duplicated-from-neighbor) are present.
+- **`tests/ariss_fram2_validation.md`** — committed procedure for the
+  V2.2 real-audio merge gate (decode the 12 ARISS Fram2 reference WAVs
+  and visually compare against the 12 reference JPGs).
+
+### Changed
+
+- **`decoder.rs::run_findsync_and_decode`** now dispatches on
+  `ChannelLayout`. PD path is byte-identical to V2.1 (zero PD120/180/240
+  regression risk). Robot path loops per image line and calls
+  `mode_robot::decode_line`.
+- **`target_audio_samples` computation** now branches on
+  `spec.channel_layout`: PD (line pairing) keeps `image_lines / 2 ×
+  line_seconds`; Robot (no pairing) uses `image_lines × line_seconds`.
+  Mirrors slowrx C `video.c:251-254`. Surfaced during Phase 5 Fram2
+  validation — the prior unconditional PD-style formula had been
+  cutting Robot decode in half on real audio.
+- **`pd_modes_have_line_start_sync_position` test renamed to
+  `all_v2_modes_have_line_start_sync_position`** and extended to cover
+  all six current modes (PD + Robot).
+- **`bin/slowrx_cli.rs::mode_tag`** — added `Robot24`/`Robot36`/`Robot72`
+  arms (same trap V2.1 PD240 fell into; caught pre-merge this time).
+
+### Tests
+
+- `tests/roundtrip.rs::robot72_roundtrip`,
+  `tests/roundtrip.rs::robot36_roundtrip`,
+  `tests/roundtrip.rs::robot24_roundtrip` — synthetic round-trip with
+  mean per-pixel-diff threshold < 5.0 (same threshold as PD).
+- `src/decoder.rs::tests::process_emits_vis_detected_for_robot{24,36,72}_burst`
+  — VIS-detection unit tests.
+
+### Validation
+
+- Validated against 12 ARISS Fram2 Robot 36 captures
+  (<https://ariss-usa.org/ARISS_SSTV/Fram2Test/>) on 2026-05-02 — all 12
+  produced visually-matching PNGs after the Phase 5 `target_audio_samples`
+  fix landed. Procedure documented at `tests/ariss_fram2_validation.md`.
+- Faint vertical squiggle artifacts in real-radio output (not present in
+  the reference JPGs) are tracked as a parity gap for a future quality
+  pass at [#71].
+
+### Known caveats
+
+- **Robot 24 ships without R24-specific real-radio evidence.** Inherits
+  R36 validation by structural identity (R24 and R36 share decoder code;
+  only the mode tag and VIS code differ — timing constants are
+  bit-identical).
+- **Robot 72 ships with synthetic-only coverage.** No public R72 capture
+  was sourced during V2.2 brainstorm. Real-radio fixture pending; tracked
+  in [#70].
+- **Row 0 chroma artifact in R36/R24.** Image row 0 has Y own + Cr own
+  + Cb at zero-init (no previous radio line to duplicate Cb forward).
+  Faithful to slowrx C, which writes `Image[][][]` with `calloc` and
+  never updates row 0's Cb. Visible as a faint color cast on the very
+  top row of the decoded image. Documented in
+  `mode_robot::decode_r36_or_r24_line`.
+
 ## [0.2.1] - 2026-05-02
 
 Patch release bundling the post-merge final-review cleanup of V2.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -707,7 +707,7 @@ checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "slowrx"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slowrx"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 rust-version = "1.85"
 description = "Pure-Rust SSTV (Slow-Scan TV) decoder library — a port of slowrx by Oona Räisänen"

--- a/README.md
+++ b/README.md
@@ -13,14 +13,19 @@
 
 ## Status
 
-🛰️ **0.2.0 — V2.1 published.** PD120, PD180, and PD240 decoding from raw audio.
+🛰️ **0.3.0 — V2.2 published.** PD120, PD180, PD240, Robot 24, Robot 36, and Robot 72 decoding from raw audio.
 
-PD120 and PD180 are validated end-to-end against ARISS Dec-2017 captures:
-6 of 7 fixtures decode to images visually matching the reference JPGs
-(the 7th is a truncated capture missing the VIS leader). PD240 currently
-ships with synthetic encode/decode round-trip coverage only — a real-radio
-fixture is pending. Remaining V2 mode coverage (Robot, Scottie, Martin)
-is on the [roadmap](https://github.com/jasonherald/slowrx.rs/issues/9).
+PD120, PD180, and Robot 36 are validated end-to-end against real-radio
+captures: PD120/PD180 against the ARISS Dec-2017 corpus (6 of 7
+fixtures decode to images visually matching the reference JPGs),
+Robot 36 against the ARISS Fram2 corpus (all 12 fixtures decode to
+images visually matching the reference JPGs — see
+`tests/ariss_fram2_validation.md`). PD240 ships with synthetic
+round-trip coverage only — a real-radio fixture is pending. Robot 24
+and Robot 72 ship with synthetic coverage; Robot 24 inherits Robot 36's
+evidence by structural identity (same decoder code path, only LineTime
+differs). Remaining V2 mode coverage (Scottie, Martin) is on the
+[roadmap](https://github.com/jasonherald/slowrx.rs/issues/9).
 
 ## Install
 
@@ -54,7 +59,7 @@ CLI:
 
 ```bash
 slowrx-cli --input recording.wav --output ./out
-# → out/img-001-pd120.png, out/img-002-pd180.png, ...
+# → out/img-001-pd120.png, out/img-001-robot36.png, ...
 ```
 
 ## What it does
@@ -65,7 +70,7 @@ samples. Mode coverage roadmap:
 | Mode family | Shipped | Roadmap |
 |---|---|---|
 | **PD** | PD120, PD180, PD240 | — |
-| **Robot** | — | Robot 36, Robot 72 |
+| **Robot** | Robot 24, Robot 36, Robot 72 | — |
 | **Scottie** | — | Scottie 1, Scottie 2, Scottie DX |
 | **Martin** | — | Martin 1, Martin 2 |
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ CLI:
 
 ```bash
 slowrx-cli --input recording.wav --output ./out
-# → out/img-001-pd120.png, out/img-001-robot36.png, ...
+# → out/img-001-pd120.png, out/img-002-robot36.png, ...
 ```
 
 ## What it does

--- a/docs/intentional-deviations.md
+++ b/docs/intentional-deviations.md
@@ -150,3 +150,64 @@ Either:
 2. Add a real-audio cross-validation suite (gitignored fixtures already
    exist in `docs/wav_files/`; the `slowrx-cli` binary covers ad-hoc
    smokes).
+
+---
+
+## Robot family pixel-time offset: `(x + 0.5)` vs slowrx C `(x - 0.5)`
+
+**Files:** `src/mode_pd.rs::decode_one_channel_into` ↔ slowrx `video.c:140-142` (PD case) vs. `:196-198` (non-PD case).
+**Tracking:** Surfaced during V2.2 P3 (Robot 72) code review.
+
+### What slowrx does
+
+slowrx C uses **two different per-pixel time formulas**:
+
+- **PD modes** (`video.c:140-142`):
+  `Time = round(Rate * (y/2 * LineTime + ChanStart + PixelTime * (x + 0.5)))`
+  Pixel sampling centered at `(x + 0.5) * PixelTime` from channel start.
+
+- **Non-PD modes** including Robot 72 (`video.c:196-198`):
+  `Time = round(Rate * (y * LineTime + ChanStart + (x - 0.5) / Width * ChanLen[Channel]))`
+  Pixel sampling centered at `(x - 0.5) * (ChanLen / Width)` from channel start —
+  i.e., `(x - 0.5) * PixelTime` for non-Robot-alt modes where ChanLen = PixelTime * Width.
+
+The two forms differ by **1 pixel-time** in the per-pixel sampling offset.
+
+### What we do
+
+The Rust port reuses `mode_pd::decode_one_channel_into` for both PD and Robot 72.
+That helper uses the PD `(x + 0.5)` formula. So Robot 72 in slowrx.rs samples each
+pixel `1 * pixel_seconds` later than slowrx C would.
+
+### Why we deviated
+
+Sharing one helper between PD and R72 keeps the codebase smaller and the FFT
+windowing logic single-source. The synthetic round-trip (`tests/roundtrip.rs::robot72_roundtrip`)
+passes at the same `mean < 5.0` threshold as PD because the encoder
+(`robot_test_encoder::encode_r72`) ALSO emits at the same per-pixel timing — the
+encoder/decoder pair is internally consistent.
+
+### Real-radio impact
+
+Against real-radio audio (e.g. ARISS Fram2 Robot 36 corpus — which this V2.2
+work uses as the merge gate), the deviation manifests as a **half-pixel
+horizontal shift** in the decoded image relative to slowrx C's output. For
+real audio the FFT window is wider than a half-pixel, so visual quality is
+unaffected at the per-image scale. The Phase 5 visual validation against the
+12 ARISS Fram2 reference JPGs is the empirical test.
+
+### When to revisit
+
+Three triggers would prompt revisiting:
+
+1. **Phase 4 R36/R24 round-trip fails** because Y has 2× pixel-time and the
+   asymmetric `(x ± 0.5)` formula amplifies a per-channel offset error that
+   was tolerable for R72.
+2. **Fram2 visual validation surfaces a measurable horizontal shift** vs. the
+   reference JPGs.
+3. **A future audit cross-validates pixel-by-pixel against slowrx C output**
+   on the same audio file — that would expose the half-pixel offset directly.
+
+If any of these fires, the fix is to introduce a per-mode pixel-offset selector
+(e.g., a `pixel_offset_within_channel: f64` field on `ModeSpec` set to 0.5 for
+PD and -0.5 for non-PD), and route it through `decode_one_channel_into`.

--- a/docs/intentional-deviations.md
+++ b/docs/intentional-deviations.md
@@ -211,3 +211,15 @@ Three triggers would prompt revisiting:
 If any of these fires, the fix is to introduce a per-mode pixel-offset selector
 (e.g., a `pixel_offset_within_channel: f64` field on `ModeSpec` set to 0.5 for
 PD and -0.5 for non-PD), and route it through `decode_one_channel_into`.
+
+### Status
+
+- ✅ Trigger #1 cleared as of V2.2 Phase 4: R36/R24 synthetic round-trips
+  pass at `mean < 5.0` despite Y being at 2× pixel-time. The encoder
+  emits at the same `(x + 0.5)` offset the decoder reads at, so the
+  R36/R24 round-trip is internally consistent — the deviation is invisible
+  to the synthetic gate.
+- Triggers #2 and #3 remain open. Phase 5 (Fram2 visual validation) is
+  the next empirical test; a future cross-validation against slowrx C
+  output on the same audio file would expose the half-pixel offset
+  directly.

--- a/docs/intentional-deviations.md
+++ b/docs/intentional-deviations.md
@@ -223,3 +223,38 @@ PD and -0.5 for non-PD), and route it through `decode_one_channel_into`.
   the next empirical test; a future cross-validation against slowrx C
   output on the same audio file would expose the half-pixel offset
   directly.
+
+---
+
+## Faint vertical squiggle artifacts in Robot real-radio decode
+
+**Files:** `src/mode_robot.rs` (and plausibly `src/mode_pd.rs::decode_one_channel_into`).
+**Tracking issue:** [#71](https://github.com/jasonherald/slowrx.rs/issues/71).
+
+### What we observe
+
+When decoding real-radio Robot 36 audio (verified against the 12 ARISS
+Fram2 WAVs during V2.2 Phase 5), our output PNGs exhibit faint vertical
+squiggle artifacts every ~20–30 pixels. The image content is correct
+and recognizable — the artifacts are a fine pattern overlaid on the
+content.
+
+The reference JPGs ARISS publishes alongside the WAVs do NOT show these
+artifacts, which means whatever decoder produced the references handles
+this case better than ours.
+
+### Why this isn't a "deviation" yet
+
+This is more of an **open quality gap** than a deliberate deviation.
+We're tracking it here so future audits know it's a known and
+documented behavior, not a missed bug. V2.2 ships with this gap because
+the image content is correct and visually validates against the
+reference.
+
+### When to revisit
+
+When [#71](https://github.com/jasonherald/slowrx.rs/issues/71) is
+prioritized, or whenever a downstream consumer asks for cleaner output.
+The investigation paths in #71 cover SNR-adaptive Hann selector
+re-engagement (V1 deferral #44), slowrx C cross-validation, and per-
+pixel sub-bin interpolation.

--- a/docs/superpowers/plans/2026-05-02-v2.2-robot.md
+++ b/docs/superpowers/plans/2026-05-02-v2.2-robot.md
@@ -1,0 +1,2200 @@
+# V2.2 — Robot Family Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land Robot 24, Robot 36, and Robot 72 SSTV decoding (slowrx 0.3.0). Includes the first cross-mode-family dispatch refactor in `decoder.rs`.
+
+**Architecture:** Add three `SstvMode` variants and one `ChannelLayout::RobotYuv` variant (additive — `#[non_exhaustive]` enums). New `src/mode_robot.rs` houses Robot-family decoding; internally matches on mode to handle R36/R24 (2-channel Y + alternating chroma with neighbor-row duplication) vs R72 (3-channel Y/U/V sequential). `decoder.rs` gains a `match channel_layout { ... }` block at the dispatch site. R36 ships with a real-audio merge gate against the 12 ARISS Fram2 fixtures; R24 inherits R36's evidence by structural identity; R72 ships on synthetic round-trip alone.
+
+**Tech Stack:** Rust 2021 (MSRV 1.85), `rustfft`, `thiserror`, `proptest`. CI runs `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --all-features --locked`, `cargo doc -D warnings`. Release: `cargo publish --dry-run/publish`. GitHub via `gh` CLI.
+
+**Spec reference:** `docs/superpowers/specs/2026-05-02-v2.2-robot-design.md`.
+**slowrx C reference (locally):** `original/slowrx/modespec.c:130-167` (Robot timing rows), `:376` (VIS map), `original/slowrx/video.c:60-101` (channel time computation), `:104-130` (NumChans switch), `:178-209` (per-line PixelGrid for non-PD modes), `:421-425` (Robot chroma duplication).
+
+**Working directory throughout:** `/data/source/slowrx.rs-v2.2-robot` (worktree on `feat/v2.2-robot`).
+
+---
+
+## Phase 0 — V2.2 epic #64 body update
+
+Quick housekeeping: link the V2.2 epic to the design spec so the GitHub UI shows it.
+
+### Task 0.1: Append spec link to V2.2 epic body
+
+**Files:** None (GitHub-side change).
+
+- [ ] **Step 1: Fetch current body**
+
+```bash
+gh issue view 64 --repo jasonherald/slowrx.rs --json body --jq .body > /tmp/issue-64-current.md
+```
+
+- [ ] **Step 2: Append spec link line**
+
+```bash
+cat >> /tmp/issue-64-current.md <<'EOF'
+
+---
+
+**Design spec:** [`docs/superpowers/specs/2026-05-02-v2.2-robot-design.md`](https://github.com/jasonherald/slowrx.rs/blob/main/docs/superpowers/specs/2026-05-02-v2.2-robot-design.md)
+EOF
+```
+
+- [ ] **Step 3: Push the updated body**
+
+```bash
+gh issue edit 64 --repo jasonherald/slowrx.rs --body-file /tmp/issue-64-current.md
+gh issue view 64 --repo jasonherald/slowrx.rs --json body --jq .body | tail -5
+```
+
+Expected: the new "Design spec" link appears at the bottom of #64.
+
+---
+
+## Phase 1 — ModeSpec foundation
+
+Add `Robot24`/`Robot36`/`Robot72` to `SstvMode`, `RobotYuv` to `ChannelLayout`, three `ROBOT*` const `ModeSpec`s, and the corresponding `lookup`/`for_mode` arms. TDD-pair commit (failing tests first, implementation second).
+
+### Task 1.1: Failing tests for Robot lookup/for_mode
+
+**Files:**
+- Modify: `src/modespec.rs` `mod tests` block.
+
+- [ ] **Step 1: Append the tests inside the existing `mod tests { ... }` block**, just before the module's closing brace:
+
+```rust
+    #[test]
+    fn robot24_vis_code_resolves() {
+        let spec = lookup(0x04).expect("R24 VIS resolves");
+        assert_eq!(spec.mode, SstvMode::Robot24);
+        assert_eq!(spec.vis_code, 0x04);
+        assert_eq!(spec.line_pixels, 320);
+        assert_eq!(spec.image_lines, 240);
+        assert_eq!(spec.channel_layout, ChannelLayout::RobotYuv);
+        assert_eq!(spec.sync_position, SyncPosition::LineStart);
+        assert_eq!(spec.line_seconds, 0.150);
+        assert_eq!(spec.sync_seconds, 0.009);
+        assert_eq!(spec.porch_seconds, 0.003);
+        assert_eq!(spec.septr_seconds, 0.006);
+        assert_eq!(spec.pixel_seconds, 0.000_137_5);
+    }
+
+    #[test]
+    fn robot36_vis_code_resolves() {
+        let spec = lookup(0x08).expect("R36 VIS resolves");
+        assert_eq!(spec.mode, SstvMode::Robot36);
+        assert_eq!(spec.vis_code, 0x08);
+        assert_eq!(spec.line_pixels, 320);
+        assert_eq!(spec.image_lines, 240);
+        assert_eq!(spec.channel_layout, ChannelLayout::RobotYuv);
+        assert_eq!(spec.sync_position, SyncPosition::LineStart);
+        assert_eq!(spec.line_seconds, 0.150);
+        assert_eq!(spec.sync_seconds, 0.009);
+        assert_eq!(spec.porch_seconds, 0.003);
+        assert_eq!(spec.septr_seconds, 0.006);
+        assert_eq!(spec.pixel_seconds, 0.000_137_5);
+    }
+
+    #[test]
+    fn robot72_vis_code_resolves() {
+        let spec = lookup(0x0C).expect("R72 VIS resolves");
+        assert_eq!(spec.mode, SstvMode::Robot72);
+        assert_eq!(spec.vis_code, 0x0C);
+        assert_eq!(spec.line_pixels, 320);
+        assert_eq!(spec.image_lines, 240);
+        assert_eq!(spec.channel_layout, ChannelLayout::RobotYuv);
+        assert_eq!(spec.sync_position, SyncPosition::LineStart);
+        assert_eq!(spec.line_seconds, 0.300);
+        assert_eq!(spec.sync_seconds, 0.009);
+        assert_eq!(spec.porch_seconds, 0.003);
+        assert_eq!(spec.septr_seconds, 0.0047);
+        assert_eq!(spec.pixel_seconds, 0.000_287_5);
+    }
+
+    #[test]
+    fn for_mode_returns_robot_specs() {
+        assert_eq!(for_mode(SstvMode::Robot24).vis_code, 0x04);
+        assert_eq!(for_mode(SstvMode::Robot36).vis_code, 0x08);
+        assert_eq!(for_mode(SstvMode::Robot72).vis_code, 0x0C);
+    }
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+`cargo test --features test-support --lib robot 2>&1 | tail -10`
+
+Expected: compilation FAIL — `cannot find variant 'Robot24'/'Robot36'/'Robot72' for enum SstvMode`, and `no variant 'RobotYuv' on ChannelLayout`.
+
+This is the TDD "write failing test" half. Task 1.2 makes them pass.
+
+### Task 1.2: Add Robot variants + RobotYuv + consts + lookup/for_mode arms
+
+**Files:**
+- Modify: `src/modespec.rs`.
+
+- [ ] **Step 1: Add three variants to `SstvMode`**
+
+Inside the `pub enum SstvMode { ... }` block, after `Pd240`:
+
+```rust
+    /// Robot 24 (320×240, ~24s per image)
+    Robot24,
+    /// Robot 36 (320×240, ~36s per image)
+    Robot36,
+    /// Robot 72 (320×240, ~72s per image)
+    Robot72,
+```
+
+- [ ] **Step 2: Add `RobotYuv` variant to `ChannelLayout`**
+
+Inside the `pub enum ChannelLayout { ... }` block, after `PdYcbcr`:
+
+```rust
+    /// Robot family: Y (single luma channel) plus chroma. R36/R24 carry
+    /// alternating Cr/Cb per radio line with each chroma sample
+    /// duplicated to the next image row; R72 carries Y/U/V sequentially
+    /// per line. The shape difference is mode-internal — see
+    /// `mode_robot::decode_line` for the per-mode dispatch.
+    RobotYuv,
+```
+
+- [ ] **Step 3: Add three `const` `ModeSpec`s** after `const PD240`:
+
+```rust
+const ROBOT24: ModeSpec = ModeSpec {
+    mode: SstvMode::Robot24,
+    vis_code: 0x04,
+    line_pixels: 320,
+    image_lines: 240,
+    // slowrx modespec.c:156-167 — R24 LineTime = 150e-3,
+    // PixelTime = 0.1375e-3, SyncTime = 9e-3, PorchTime = 3e-3,
+    // SeptrTime = 6e-3.
+    line_seconds: 0.150,
+    sync_seconds: 0.009,
+    porch_seconds: 0.003,
+    pixel_seconds: 0.000_137_5,
+    septr_seconds: 0.006,
+    channel_layout: ChannelLayout::RobotYuv,
+    sync_position: SyncPosition::LineStart,
+};
+
+const ROBOT36: ModeSpec = ModeSpec {
+    mode: SstvMode::Robot36,
+    vis_code: 0x08,
+    line_pixels: 320,
+    image_lines: 240,
+    // slowrx modespec.c:143-154 — R36 LineTime = 150e-3,
+    // PixelTime = 0.1375e-3, SyncTime = 9e-3, PorchTime = 3e-3,
+    // SeptrTime = 6e-3.  Identical timing to R24.
+    line_seconds: 0.150,
+    sync_seconds: 0.009,
+    porch_seconds: 0.003,
+    pixel_seconds: 0.000_137_5,
+    septr_seconds: 0.006,
+    channel_layout: ChannelLayout::RobotYuv,
+    sync_position: SyncPosition::LineStart,
+};
+
+const ROBOT72: ModeSpec = ModeSpec {
+    mode: SstvMode::Robot72,
+    vis_code: 0x0C,
+    line_pixels: 320,
+    image_lines: 240,
+    // slowrx modespec.c:130-141 — R72 LineTime = 300e-3,
+    // PixelTime = 0.2875e-3, SyncTime = 9e-3, PorchTime = 3e-3,
+    // SeptrTime = 4.7e-3.
+    line_seconds: 0.300,
+    sync_seconds: 0.009,
+    porch_seconds: 0.003,
+    pixel_seconds: 0.000_287_5,
+    septr_seconds: 0.0047,
+    channel_layout: ChannelLayout::RobotYuv,
+    sync_position: SyncPosition::LineStart,
+};
+```
+
+- [ ] **Step 4: Update `lookup` to add three new arms**
+
+```rust
+pub fn lookup(vis_code: u8) -> Option<ModeSpec> {
+    match vis_code {
+        0x04 => Some(ROBOT24),
+        0x08 => Some(ROBOT36),
+        0x0C => Some(ROBOT72),
+        0x5F => Some(PD120),
+        0x60 => Some(PD180),
+        0x61 => Some(PD240),
+        _ => None,
+    }
+}
+```
+
+(Numeric ascending order. Comment if useful; not required.)
+
+- [ ] **Step 5: Update `for_mode` to add three new arms**
+
+```rust
+pub fn for_mode(mode: SstvMode) -> ModeSpec {
+    match mode {
+        SstvMode::Pd120 => PD120,
+        SstvMode::Pd180 => PD180,
+        SstvMode::Pd240 => PD240,
+        SstvMode::Robot24 => ROBOT24,
+        SstvMode::Robot36 => ROBOT36,
+        SstvMode::Robot72 => ROBOT72,
+    }
+}
+```
+
+- [ ] **Step 6: Generalize `pd_modes_have_line_start_sync_position` test**
+
+Find the existing test (which currently iterates `[Pd120, Pd180, Pd240]`) and rename to `all_v2_modes_have_line_start_sync_position`, extending the loop:
+
+```rust
+    #[test]
+    fn all_v2_modes_have_line_start_sync_position() {
+        // V2 carve-out: ModeSpec.sync_position lets V2.3 Scottie declare
+        // mid-line sync without retrofitting V1. PD/Robot/Martin all use
+        // line-start sync; Scottie is the V2.3 exception.
+        for mode in [
+            SstvMode::Pd120,
+            SstvMode::Pd180,
+            SstvMode::Pd240,
+            SstvMode::Robot24,
+            SstvMode::Robot36,
+            SstvMode::Robot72,
+        ] {
+            let spec = for_mode(mode);
+            assert_eq!(spec.sync_position, SyncPosition::LineStart);
+        }
+    }
+```
+
+- [ ] **Step 7: Update module-level rustdoc**
+
+Find `src/modespec.rs:6-8` (the "Implemented as of V2.1 (0.2.0): PD120, PD180, PD240" doc) and update for V2.2:
+
+```rust
+//! Implemented as of V2.2 (0.3.0): PD120, PD180, PD240, Robot 24, Robot 36,
+//! Robot 72. Remaining V2 modes (Scottie 1/2/DX, Martin 1/2) are not yet
+//! present in the [`SstvMode`] enum or the lookup tables; each will land
+//! with its own PR.
+```
+
+Also update the `SstvMode` enum doc at line ~10:
+
+```rust
+/// SSTV operating mode. Implemented: [`SstvMode::Pd120`], [`SstvMode::Pd180`],
+/// [`SstvMode::Pd240`], [`SstvMode::Robot24`], [`SstvMode::Robot36`],
+/// [`SstvMode::Robot72`]. Additional V2 modes (Scottie, Martin) planned.
+```
+
+And the comment block above the const definitions (search for `// Mode timing constants — translated row-for-row from`):
+
+```rust
+// Mode timing constants — translated row-for-row from slowrx's
+// modespec.c (PD120 lines 260-271, PD180 lines 286-297, PD240 lines 299-310,
+// R72 lines 130-141, R36 lines 143-154, R24 lines 156-167).
+```
+
+- [ ] **Step 8: Run modespec tests**
+
+`cargo test --features test-support --lib modespec:: 2>&1 | tail -15`
+
+Expected: 9 tests pass — 3 pre-existing (`pd120_vis_code_resolves`, `pd180_vis_code_resolves`, `pd240_vis_code_resolves`), 1 generalized (`all_v2_modes_have_line_start_sync_position`), 4 new (`robot24_vis_code_resolves`, `robot36_vis_code_resolves`, `robot72_vis_code_resolves`, `for_mode_returns_robot_specs`), plus `unknown_vis_codes_return_none` and `pd_modes_have_zero_septr_seconds` and `for_mode_returns_matching_spec`.
+
+(That test count may differ; what matters is **all** modespec tests pass and the 4 new ones are in the list.)
+
+- [ ] **Step 9: Run full suite**
+
+`cargo test --all-features --locked 2>&1 | grep -E "^test result"`
+
+Expected: every suite "ok", zero failed. The `chan_starts_sec_septr_zero...` test in `mode_pd.rs` only loops `Pd120/Pd180/Pd240` — unaffected.
+
+- [ ] **Step 10: Run full CI gate**
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --all-targets --all-features -- -D warnings 2>&1 | tail -3
+RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features 2>&1 | tail -3
+```
+
+All clean.
+
+- [ ] **Step 11: Commit (covers Tasks 1.1 + 1.2)**
+
+```bash
+git add src/modespec.rs
+git commit -m "feat(modespec): add Robot24/36/72 variants + RobotYuv layout + lookup arms
+
+Three new SstvMode variants (Robot24/36/72), one new ChannelLayout
+variant (RobotYuv), three new ModeSpec consts with timing constants
+translated from slowrx modespec.c:130-167, three new lookup arms (VIS
+codes 0x04/0x08/0x0C from VISmap row 0), three new for_mode arms.
+Generalized pd_modes_have_line_start_sync_position to
+all_v2_modes_have_line_start_sync_position covering PD + Robot.
+
+Refs: docs/superpowers/specs/2026-05-02-v2.2-robot-design.md"
+```
+
+---
+
+## Phase 2 — `mode_robot.rs` stub + `decoder.rs` dispatch refactor
+
+Land the foundation that lets the project compile and PD modes still work, with Robot dispatched to a stub. After this phase, Robot WAVs will produce a black image (stub fills zeros) but won't crash. The dispatch refactor regression-tests against existing PD round-trips.
+
+### Task 2.1: Create `src/mode_robot.rs` stub + add to `lib.rs`
+
+**Files:**
+- Create: `src/mode_robot.rs`
+- Modify: `src/lib.rs`
+
+- [ ] **Step 1: Create `src/mode_robot.rs`**
+
+```rust
+//! Robot-family mode decoder.
+//!
+//! Robot 24 / Robot 36: 2-channel layout per radio line — Y (full width,
+//! 2× pixel-time per channel allocation) followed by alternating Cr/Cb
+//! (Cr on even-indexed Y rows, Cb on odd, each chroma sample duplicated
+//! to the neighbor image row). Robot 72: 3-channel layout per radio
+//! line — Y, U, V each at full pixel-time. All three share
+//! [`ChannelLayout::RobotYuv`] in the public API; the per-mode case
+//! split mirrors slowrx `video.c:60-101` (channel-time switch) and
+//! `:104-130` (NumChans switch).
+//!
+//! Translated from slowrx's `video.c` (Oona Räisänen, ISC License).
+//! Per-mode chroma layout: video.c lines 60-101, 178-209, 421-425.
+//! YUV→RGB matrix: video.c lines 446-451 (shared with PD; we re-use
+//! `mode_pd::ycbcr_to_rgb`). See `NOTICE.md` for full attribution.
+//!
+//! V2.2 stub — `decode_line` writes zeros pending Phase 3/4 fill-in.
+//! See `docs/superpowers/plans/2026-05-02-v2.2-robot.md`.
+
+use crate::modespec::{ModeSpec, SstvMode};
+
+/// Decode one Robot radio line into `image`. The R24/R36 path also
+/// writes duplicated chroma to the neighbor image row (with bounds
+/// guard) per slowrx `video.c:424-425`.
+///
+/// `line_index` is the 0-based image row this radio line emits Y for;
+/// `line_seconds_offset` is `f64::from(line_index) * spec.line_seconds`
+/// (un-rounded — the per-pixel time computation does the single
+/// `round()` to match slowrx `video.c:140-142`).
+///
+/// V2.2 stub — fills the row with zeros. Replaced by per-mode decode
+/// in Phases 3 and 4.
+#[allow(clippy::too_many_arguments, clippy::needless_pass_by_value)]
+pub(crate) fn decode_line(
+    spec: ModeSpec,
+    mode: SstvMode,
+    line_index: u32,
+    _audio: &[f32],
+    _skip_samples: i64,
+    _line_seconds_offset: f64,
+    _rate_hz: f64,
+    image: &mut crate::image::SstvImage,
+    _demod: &mut crate::mode_pd::PdDemod,
+    _snr_est: &mut crate::snr::SnrEstimator,
+    _hedr_shift_hz: f64,
+) {
+    debug_assert!(matches!(
+        mode,
+        SstvMode::Robot24 | SstvMode::Robot36 | SstvMode::Robot72
+    ));
+    // Stub: write zeros. Replaced in Phase 3 (R72) and Phase 4 (R36/R24)
+    // of the V2.2 implementation plan.
+    for x in 0..spec.line_pixels {
+        image.put_pixel(x, line_index, [0, 0, 0]);
+    }
+}
+```
+
+- [ ] **Step 2: Add `pub mod mode_robot;` to `src/lib.rs`**
+
+Find the `pub mod` block (around line 32-41) and add:
+
+```rust
+pub mod mode_robot;
+```
+
+Place it between `pub mod mode_pd;` and `pub mod modespec;` (alphabetical ordering of the `mode_*` files).
+
+- [ ] **Step 3: Build + test**
+
+```bash
+cargo build --all-features --locked 2>&1 | tail -3
+cargo test --all-features --locked 2>&1 | grep -E "^test result"
+```
+
+Expected: builds clean. All existing tests still pass. (No new test added in this task — Phase 3/4 add the round-trip tests that exercise the decoder.)
+
+### Task 2.2: Refactor `decoder.rs` dispatch to match on `ChannelLayout`
+
+**Files:**
+- Modify: `src/decoder.rs`.
+
+The existing dispatch (lines ~330-375) loops over PD pairs and calls `mode_pd::decode_pd_line_pair` directly. Refactor to dispatch on `ChannelLayout`. PD path stays byte-identical; new `RobotYuv` path loops over individual lines and calls `mode_robot::decode_line`.
+
+- [ ] **Step 1: Locate the existing dispatch site**
+
+Open `src/decoder.rs` and find the function that currently contains the `for pair in 0..pair_count { let pair_seconds = ...; crate::mode_pd::decode_pd_line_pair(...) }` block (around line 330). The function is the `run_findsync_and_decode` (or similarly-named) helper called from the `Decoding` arm of `process`.
+
+- [ ] **Step 2: Replace the dispatch block**
+
+Inside the function, replace the existing `for pair in 0..pair_count { ... emit LineDecoded for both rows ... }` block with a `match d.spec.channel_layout` block:
+
+```rust
+match d.spec.channel_layout {
+    crate::modespec::ChannelLayout::PdYcbcr => {
+        let pair_count = d.spec.image_lines / 2;
+        for pair in 0..pair_count {
+            let pair_seconds = f64::from(pair) * d.spec.line_seconds;
+            crate::mode_pd::decode_pd_line_pair(
+                d.spec,
+                pair,
+                &d.audio,
+                skip,
+                pair_seconds,
+                rate,
+                &mut d.image,
+                pd_demod,
+                snr_est,
+                d.hedr_shift_hz,
+            );
+            let row0 = pair * 2;
+            let row1 = row0 + 1;
+            for r in [row0, row1] {
+                let start = (r as usize) * line_pixels;
+                let end = start + line_pixels;
+                out.push(SstvEvent::LineDecoded {
+                    mode: d.mode,
+                    line_index: r,
+                    pixels: d.image.pixels[start..end].to_vec(),
+                });
+            }
+        }
+    }
+    crate::modespec::ChannelLayout::RobotYuv => {
+        // Robot is per-line (no PD line-pairing). For R36/R24 the
+        // chroma-duplication writes to the next image row; that's
+        // handled inside mode_robot::decode_line. LineDecoded for image
+        // row N is emitted after radio-line N's decode — for R36/R24
+        // row 0 the Cb channel is at zero-init at this point (slowrx
+        // C does the same; final ImageComplete carries the populated
+        // state).
+        for line in 0..d.spec.image_lines {
+            let line_seconds_offset = f64::from(line) * d.spec.line_seconds;
+            crate::mode_robot::decode_line(
+                d.spec,
+                d.mode,
+                line,
+                &d.audio,
+                skip,
+                line_seconds_offset,
+                rate,
+                &mut d.image,
+                pd_demod,
+                snr_est,
+                d.hedr_shift_hz,
+            );
+            let start = (line as usize) * line_pixels;
+            let end = start + line_pixels;
+            out.push(SstvEvent::LineDecoded {
+                mode: d.mode,
+                line_index: line,
+                pixels: d.image.pixels[start..end].to_vec(),
+            });
+        }
+    }
+}
+```
+
+The `pair_count`, `pair_seconds` line above the existing match (if any) needs to be moved INSIDE the `PdYcbcr` arm so it's not computed for Robot. Verify by reading the current code around line 330 of `src/decoder.rs` and adapting accordingly — the spec describes it but exact line numbers may have shifted slightly.
+
+- [ ] **Step 3: Run all PD tests** (regression net for the dispatch refactor)
+
+```bash
+cargo test --features test-support --lib decoder:: 2>&1 | tail -10
+cargo test --test roundtrip --features test-support 2>&1 | tail -10
+```
+
+Expected: ALL tests pass. PD120/PD180/PD240 round-trips green (this is the regression check). Three Robot round-trips DON'T exist yet — Phase 3/4 adds them.
+
+- [ ] **Step 4: Smoke test against Fram2**
+
+```bash
+ls tests/fixtures/ariss-fram2/Slide01.wav  # should exist
+cargo build --release --features cli
+mkdir -p /tmp/v22-smoke
+./target/release/slowrx-cli --input tests/fixtures/ariss-fram2/Slide01.wav --output /tmp/v22-smoke 2>&1 | tail -5
+ls /tmp/v22-smoke
+```
+
+Expected: `1 VIS, 240 lines, 1 image(s)` and a `img-001-robot36.png` file. The PNG will be all-black (stub) — that's correct for this phase.
+
+If you see `0 VIS`: VIS detection didn't find Robot 36 in this WAV. Investigate; the modespec changes should make `lookup(0x08)` return `Some(ROBOT36)`. Re-check the Phase 1 commit and the build.
+
+If you see `1 VIS, 0 lines`: dispatch refactor didn't enter the RobotYuv arm. Check the match block actually ran by adding `dbg!(d.spec.channel_layout)` temporarily.
+
+- [ ] **Step 5: Run full CI gate**
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --all-targets --all-features -- -D warnings 2>&1 | tail -3
+cargo test --all-features --locked 2>&1 | grep -E "^test result"
+RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features 2>&1 | tail -3
+```
+
+All clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib.rs src/mode_robot.rs src/decoder.rs
+git commit -m "feat(decoder): cross-family dispatch on ChannelLayout + mode_robot stub
+
+decoder.rs run_findsync_and_decode now matches on d.spec.channel_layout:
+PdYcbcr arm is byte-identical to today's PD line-pair loop; RobotYuv
+arm loops per image line and calls mode_robot::decode_line. PD regression
+tests (pd120/pd180/pd240 roundtrip) confirm zero behavior change.
+
+mode_robot.rs lands as a stub (writes zeros). Phase 3 fills R72; Phase 4
+fills R36/R24.
+
+Refs: V2.2 epic #64"
+```
+
+### Task 2.3: VIS-detection unit tests for Robot24/36/72
+
+**Files:**
+- Modify: `src/decoder.rs` `mod tests` block.
+
+Mirror the existing `process_emits_vis_detected_for_pd{120,180,240}_burst` tests at the end of `decoder.rs::tests`. These verify the modespec lookup path end-to-end through the VIS detector.
+
+- [ ] **Step 1: Append three tests** inside the existing `decoder::tests` module (find the V2.1 `process_emits_vis_detected_for_pd240_burst` test and add the new ones immediately after):
+
+```rust
+    #[test]
+    fn process_emits_vis_detected_for_robot24_burst() {
+        use crate::vis::tests::synth_vis;
+        let mut d = SstvDecoder::new(WORKING_SAMPLE_RATE_HZ).expect("decoder");
+        let mut burst = synth_vis(0x04, 0.0);
+        burst.extend(std::iter::repeat_n(0.0_f32, 512));
+        let events = d.process(&burst);
+        let hedr = events
+            .iter()
+            .find_map(|e| match e {
+                SstvEvent::VisDetected {
+                    mode: SstvMode::Robot24,
+                    hedr_shift_hz,
+                    ..
+                } => Some(*hedr_shift_hz),
+                _ => None,
+            })
+            .expect("expected VisDetected for Robot24");
+        assert!(hedr.abs() < 10.0);
+    }
+
+    #[test]
+    fn process_emits_vis_detected_for_robot36_burst() {
+        use crate::vis::tests::synth_vis;
+        let mut d = SstvDecoder::new(WORKING_SAMPLE_RATE_HZ).expect("decoder");
+        let mut burst = synth_vis(0x08, 0.0);
+        burst.extend(std::iter::repeat_n(0.0_f32, 512));
+        let events = d.process(&burst);
+        let hedr = events
+            .iter()
+            .find_map(|e| match e {
+                SstvEvent::VisDetected {
+                    mode: SstvMode::Robot36,
+                    hedr_shift_hz,
+                    ..
+                } => Some(*hedr_shift_hz),
+                _ => None,
+            })
+            .expect("expected VisDetected for Robot36");
+        assert!(hedr.abs() < 10.0);
+    }
+
+    #[test]
+    fn process_emits_vis_detected_for_robot72_burst() {
+        use crate::vis::tests::synth_vis;
+        let mut d = SstvDecoder::new(WORKING_SAMPLE_RATE_HZ).expect("decoder");
+        let mut burst = synth_vis(0x0C, 0.0);
+        burst.extend(std::iter::repeat_n(0.0_f32, 512));
+        let events = d.process(&burst);
+        let hedr = events
+            .iter()
+            .find_map(|e| match e {
+                SstvEvent::VisDetected {
+                    mode: SstvMode::Robot72,
+                    hedr_shift_hz,
+                    ..
+                } => Some(*hedr_shift_hz),
+                _ => None,
+            })
+            .expect("expected VisDetected for Robot72");
+        assert!(hedr.abs() < 10.0);
+    }
+```
+
+- [ ] **Step 2: Run the three new tests**
+
+`cargo test --features test-support --lib process_emits_vis_detected_for_robot 2>&1 | tail -10`
+
+Expected: 3 passed.
+
+- [ ] **Step 3: Full suite**
+
+`cargo test --all-features --locked 2>&1 | grep -E "^test result"`
+
+Expected: every "ok".
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/decoder.rs
+git commit -m "test(decoder): VIS-detection unit tests for Robot24/36/72
+
+Sibling of the existing PD VIS-detection tests. Each test feeds a
+synthetic VIS burst at Robot's VIS code (0x04/0x08/0x0C), confirms
+the decoder emits VisDetected with the correct mode, and checks that
+the synthetic burst reports near-zero hedr-shift.
+
+Refs: V2.2 epic #64"
+```
+
+---
+
+## Phase 3 — Robot 72 decoder + synthetic round-trip
+
+Robot 72 is the simpler case: 3 channels (Y/U/V) sequential, no chroma alternation. Implement first as a confidence-builder before tackling R36/R24.
+
+### Task 3.1: Create `src/robot_test_encoder.rs` with R72 path
+
+**Files:**
+- Create: `src/robot_test_encoder.rs`
+- Modify: `src/lib.rs`.
+
+Synthetic encoder that mirrors `pd_test_encoder.rs` but emits Robot audio. R72 path lands first; R36/R24 paths added in Task 4.1.
+
+- [ ] **Step 1: Create `src/robot_test_encoder.rs`**
+
+```rust
+//! Synthetic Robot encoder for round-trip testing. Produces continuous-
+//! phase FM audio matching the encoder side of the SSTV protocol.
+//!
+//! Test-only — gated behind `cfg(any(test, feature = "test-support"))`.
+//! Lives in its own file so the production decoder stays under the
+//! 500-LOC ceiling.
+//!
+//! **R36/R24 round-trip constraint:** the source ycrcb buffer must have
+//! adjacent rows share chroma (ycrcb[2k][1] == ycrcb[2k+1][1] for Cr;
+//! ycrcb[2k+1][2] == ycrcb[2k+2][2] for Cb), because the decoder
+//! duplicates each chroma sample to the neighbor row (slowrx
+//! video.c:424-425). Source images that violate this constraint cannot
+//! round-trip losslessly.
+
+#![allow(
+    clippy::cast_precision_loss,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    clippy::cast_possible_wrap
+)]
+
+use crate::modespec::SstvMode;
+use crate::resample::WORKING_SAMPLE_RATE_HZ;
+use std::f64::consts::PI;
+
+const SYNC_HZ: f64 = 1200.0;
+const PORCH_HZ: f64 = 1500.0;
+const BLACK_HZ: f64 = 1500.0;
+const WHITE_HZ: f64 = 2300.0;
+
+fn lum_to_freq(lum: u8) -> f64 {
+    BLACK_HZ + (WHITE_HZ - BLACK_HZ) * f64::from(lum) / 255.0
+}
+
+/// Emit samples up to absolute sample index `target_n`, advancing phase.
+/// Cumulative-target pattern (matches `pd_test_encoder::fill_to`) so
+/// per-tone rounding doesn't compound across the line.
+fn fill_to(out: &mut Vec<f32>, freq_hz: f64, target_n: usize, phase: &mut f64) {
+    let dphi = 2.0 * PI * freq_hz / f64::from(WORKING_SAMPLE_RATE_HZ);
+    while out.len() < target_n {
+        out.push(phase.sin() as f32);
+        *phase += dphi;
+        if *phase > 2.0 * PI {
+            *phase -= 2.0 * PI;
+        }
+    }
+}
+
+/// Encode an image as Robot 24 / 36 / 72 audio. `ycrcb` is row-major
+/// `[Y, Cr, Cb]` triples of length `width * height`.
+///
+/// R72: emits Y / U / V sequentially per radio line, with septr between.
+/// R36/R24: emits Y / (Cr if y%2==0 else Cb) per radio line, with septr
+/// between Y and chroma. The decoder duplicates the chroma sample to
+/// the neighbor row, so the source ycrcb buffer must have adjacent rows
+/// share chroma (see file-level doc).
+#[must_use]
+#[doc(hidden)]
+#[allow(dead_code)]
+pub fn encode_robot(mode: SstvMode, ycrcb: &[[u8; 3]]) -> Vec<f32> {
+    assert!(matches!(
+        mode,
+        SstvMode::Robot24 | SstvMode::Robot36 | SstvMode::Robot72
+    ));
+    let spec = crate::modespec::for_mode(mode);
+    let w = spec.line_pixels;
+    let h = spec.image_lines;
+    assert_eq!(ycrcb.len() as u32, w * h);
+
+    let sr = f64::from(WORKING_SAMPLE_RATE_HZ);
+    let mut out = Vec::new();
+    let mut phase = 0.0_f64;
+
+    let mut t = 0.0_f64;
+    let advance = |t: &mut f64, secs: f64| -> usize {
+        *t += secs;
+        (*t * sr).round() as usize
+    };
+
+    match mode {
+        SstvMode::Robot72 => encode_r72(&mut out, &mut phase, &mut t, advance, &spec, ycrcb),
+        SstvMode::Robot24 | SstvMode::Robot36 => {
+            // Filled in Task 4.1
+            unimplemented!("R36/R24 encoder lands in V2.2 Phase 4")
+        }
+        _ => unreachable!(),
+    }
+
+    out
+}
+
+#[allow(clippy::too_many_arguments)]
+fn encode_r72(
+    out: &mut Vec<f32>,
+    phase: &mut f64,
+    t: &mut f64,
+    mut advance: impl FnMut(&mut f64, f64) -> usize,
+    spec: &crate::modespec::ModeSpec,
+    ycrcb: &[[u8; 3]],
+) {
+    let w = spec.line_pixels;
+    let h = spec.image_lines;
+    for y in 0..h {
+        // Sync + porch.
+        fill_to(out, SYNC_HZ, advance(t, spec.sync_seconds), phase);
+        fill_to(out, PORCH_HZ, advance(t, spec.porch_seconds), phase);
+
+        // Y channel.
+        for x in 0..w {
+            let lum = ycrcb[(y * w + x) as usize][0];
+            fill_to(out, lum_to_freq(lum), advance(t, spec.pixel_seconds), phase);
+        }
+
+        // Septr between Y and U.
+        fill_to(out, PORCH_HZ, advance(t, spec.septr_seconds), phase);
+
+        // U (Cr) channel.
+        for x in 0..w {
+            let cr = ycrcb[(y * w + x) as usize][1];
+            fill_to(out, lum_to_freq(cr), advance(t, spec.pixel_seconds), phase);
+        }
+
+        // Septr between U and V.
+        fill_to(out, PORCH_HZ, advance(t, spec.septr_seconds), phase);
+
+        // V (Cb) channel.
+        for x in 0..w {
+            let cb = ycrcb[(y * w + x) as usize][2];
+            fill_to(out, lum_to_freq(cb), advance(t, spec.pixel_seconds), phase);
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Re-export from `__test_support` in `src/lib.rs`**
+
+Find the `__test_support` module (around line 137-148) and extend `mode_pd` re-exports section, adding a sibling `mode_robot` block:
+
+```rust
+    pub mod mode_robot {
+        pub use crate::robot_test_encoder::encode_robot;
+    }
+```
+
+- [ ] **Step 3: Add `pub(crate) mod robot_test_encoder;` next to the existing `pd_test_encoder` module declaration**
+
+Find `pub mod pd_test_encoder;` (gated by `cfg(any(test, feature = "test-support"))`) and add a sibling line:
+
+```rust
+#[cfg(any(test, feature = "test-support"))]
+#[doc(hidden)]
+pub mod robot_test_encoder;
+```
+
+- [ ] **Step 4: Build with the test-support feature**
+
+`cargo build --features test-support 2>&1 | tail -3`
+
+Expected: compiles cleanly.
+
+- [ ] **Step 5: Run all existing tests** (no regression)
+
+`cargo test --all-features --locked 2>&1 | grep -E "^test result"`
+
+Expected: all pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib.rs src/robot_test_encoder.rs
+git commit -m "test(robot): synthetic encoder for Robot 72 (R36/R24 in next commit)
+
+Mirrors pd_test_encoder.rs structure. Cumulative-target fill_to
+pattern; lum_to_freq mapping at 1500-2300 Hz. R72 path emits Y/U/V
+sequentially per line with septr between channels. R36/R24 paths
+unimplemented!() until Phase 4.
+
+Refs: V2.2 epic #64"
+```
+
+### Task 3.2: Implement R72 decode path in `mode_robot::decode_line`
+
+**Files:**
+- Modify: `src/mode_robot.rs`.
+
+Replace the stub's "fill row with zeros" body with the per-mode dispatch and the R72 implementation.
+
+- [ ] **Step 1: Replace `decode_line` body**
+
+Remove the placeholder zero-fill loop and replace `decode_line`'s body with a per-mode `match`:
+
+```rust
+pub(crate) fn decode_line(
+    spec: ModeSpec,
+    mode: SstvMode,
+    line_index: u32,
+    audio: &[f32],
+    skip_samples: i64,
+    line_seconds_offset: f64,
+    rate_hz: f64,
+    image: &mut crate::image::SstvImage,
+    demod: &mut crate::mode_pd::PdDemod,
+    snr_est: &mut crate::snr::SnrEstimator,
+    hedr_shift_hz: f64,
+) {
+    match mode {
+        SstvMode::Robot72 => decode_r72_line(
+            spec,
+            line_index,
+            audio,
+            skip_samples,
+            line_seconds_offset,
+            rate_hz,
+            image,
+            demod,
+            snr_est,
+            hedr_shift_hz,
+        ),
+        SstvMode::Robot24 | SstvMode::Robot36 => {
+            // Filled in Phase 4.
+            unimplemented!("R36/R24 decoder lands in V2.2 Phase 4")
+        }
+        _ => unreachable!("decode_line must be called with a Robot variant"),
+    }
+}
+```
+
+- [ ] **Step 2: Add `decode_r72_line` helper**
+
+Below `decode_line`, add the R72 implementation. Mirrors `mode_pd::decode_pd_line_pair` shape but for one image row with 3 sequential channels (Y/U/V):
+
+```rust
+/// Decode one R72 radio line into image[`line_index`].
+///
+/// R72 channel layout per slowrx `video.c:60-101` (default case):
+/// `ChanLen[0..3] = pixel_seconds * width` for each of Y, U, V.
+/// `ChanStart[0] = sync + porch`, `ChanStart[1] = ChanStart[0] +
+/// chan_len + septr`, `ChanStart[2] = ChanStart[1] + chan_len + septr`.
+#[allow(clippy::too_many_arguments)]
+fn decode_r72_line(
+    spec: ModeSpec,
+    line_index: u32,
+    audio: &[f32],
+    skip_samples: i64,
+    line_seconds_offset: f64,
+    rate_hz: f64,
+    image: &mut crate::image::SstvImage,
+    demod: &mut crate::mode_pd::PdDemod,
+    snr_est: &mut crate::snr::SnrEstimator,
+    hedr_shift_hz: f64,
+) {
+    let sync_secs = spec.sync_seconds;
+    let porch_secs = spec.porch_seconds;
+    let pixel_secs = spec.pixel_seconds;
+    let septr_secs = spec.septr_seconds;
+    let width = spec.line_pixels;
+    let chan_len = f64::from(width) * pixel_secs;
+
+    // Per slowrx video.c:60-101 default case (R72 falls here):
+    // ChanStart[0] = sync + porch                              (Y)
+    // ChanStart[1] = ChanStart[0] + chan_len + septr           (U / Cr)
+    // ChanStart[2] = ChanStart[1] + chan_len + septr           (V / Cb)
+    let chan_starts_sec = [
+        sync_secs + porch_secs,
+        sync_secs + porch_secs + chan_len + septr_secs,
+        sync_secs + porch_secs + 2.0 * chan_len + 2.0 * septr_secs,
+    ];
+
+    let width_us = width as usize;
+    let chan_bounds_abs: [(i64, i64); 3] = std::array::from_fn(|i| {
+        let start_sec = chan_starts_sec[i];
+        let end_sec = start_sec + chan_len;
+        let start_abs =
+            skip_samples + ((line_seconds_offset + start_sec) * rate_hz).round() as i64;
+        let end_abs =
+            skip_samples + ((line_seconds_offset + end_sec) * rate_hz).round() as i64;
+        (start_abs, end_abs)
+    });
+
+    let mut y = vec![0_u8; width_us];
+    let mut cr = vec![0_u8; width_us];
+    let mut cb = vec![0_u8; width_us];
+
+    let buffers: [&mut [u8]; 3] = [&mut y, &mut cr, &mut cb];
+    for (chan_idx, buf) in buffers.into_iter().enumerate() {
+        crate::mode_pd::decode_one_channel_into_pub(
+            buf,
+            chan_starts_sec[chan_idx],
+            chan_bounds_abs[chan_idx],
+            spec,
+            audio,
+            skip_samples,
+            line_seconds_offset,
+            rate_hz,
+            demod,
+            snr_est,
+            hedr_shift_hz,
+        );
+    }
+
+    for x in 0..width_us {
+        let rgb = crate::mode_pd::ycbcr_to_rgb(y[x], cr[x], cb[x]);
+        image.put_pixel(x as u32, line_index, rgb);
+    }
+}
+```
+
+**Note on `decode_one_channel_into_pub`:** the existing `mode_pd::decode_one_channel_into` is a private function. To reuse it from `mode_robot`, expose it as `pub(crate)` with a renamed alias. In `src/mode_pd.rs`, find `fn decode_one_channel_into(...)` and rename / re-export so that `mode_robot` can call it. The cleanest path: change `fn decode_one_channel_into(...)` to `pub(crate) fn decode_one_channel_into_pub(...)` (or keep the original name and just change visibility — the `_pub` suffix in the example above is illustrative; choose whichever feels cleanest). Update the call site inside `mode_pd::decode_pd_line_pair` to use the new name.
+
+This visibility change is an additive refactor — no behavior change, no PD regression risk, and is the natural shape for cross-mode decoder reuse. Keep the rename minimal (visibility only, no signature change).
+
+- [ ] **Step 3: Update `mode_pd.rs` to expose `decode_one_channel_into`**
+
+Open `src/mode_pd.rs`, find the existing `fn decode_one_channel_into(...)` (around line 388), and change visibility:
+
+```rust
+pub(crate) fn decode_one_channel_into(
+```
+
+(The function stays in `mode_pd.rs`; it's just no longer module-private. No code-body change.)
+
+In Task 3.2 Step 2's `decode_r72_line` snippet above, replace any reference to `decode_one_channel_into_pub` with `crate::mode_pd::decode_one_channel_into` to match.
+
+- [ ] **Step 4: Build**
+
+`cargo build --features test-support 2>&1 | tail -3`
+
+Expected: compiles cleanly. The `unimplemented!()` for R36/R24 won't fire unless those modes are exercised; PD and R72 paths are valid.
+
+### Task 3.3: Add `r72_roundtrip` test, verify
+
+**Files:**
+- Modify: `tests/roundtrip.rs`.
+
+Add the round-trip test that exercises the new R72 encoder and decoder end-to-end.
+
+- [ ] **Step 1: Add a Robot test-image helper to `tests/roundtrip.rs`**
+
+After the existing `test_image()` function (the PD helper), add:
+
+```rust
+/// Build a synthetic Robot test image: gradient luma + smooth chroma
+/// stripes designed so adjacent rows share chroma (required for R36/R24
+/// round-trip — see `robot_test_encoder.rs` doc; harmless for R72).
+#[allow(
+    clippy::cast_precision_loss,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss
+)]
+fn test_robot_image(mode: SstvMode) -> (u32, u32, Vec<[u8; 3]>) {
+    let spec = slowrx::for_mode(mode);
+    let w = spec.line_pixels;
+    let h = spec.image_lines;
+    let mut ycrcb = Vec::with_capacity((w * h) as usize);
+    for y in 0..h {
+        for x in 0..w {
+            let lum = ((f64::from(x)) / (f64::from(w)) * 255.0) as u8;
+            // Cr alternates every 4 rows (so adjacent even-odd Y row
+            // pairs share Cr — required for R36/R24 round-trip).
+            // Cb alternates every 4 rows offset by 1 (so adjacent
+            // odd-even pairs share Cb — also required for R36/R24).
+            let cr = if y % 4 < 2 { 200 } else { 56 };
+            let cb = if (y + 1) % 4 < 2 { 200 } else { 56 };
+            ycrcb.push([lum, cr, cb]);
+        }
+    }
+    (w, h, ycrcb)
+}
+
+fn run_robot_roundtrip(mode: SstvMode) {
+    let (w, h, ycrcb) = test_robot_image(mode);
+
+    let vis_code = match mode {
+        SstvMode::Robot24 => 0x04,
+        SstvMode::Robot36 => 0x08,
+        SstvMode::Robot72 => 0x0C,
+        _ => unreachable!(),
+    };
+    let mut audio = slowrx::__test_support::vis::synth_vis(vis_code, 0.0);
+    audio.extend(slowrx::__test_support::mode_robot::encode_robot(mode, &ycrcb));
+    audio.extend(std::iter::repeat_n(0.0_f32, 2048));
+
+    let mut d = SstvDecoder::new(WORKING_SAMPLE_RATE_HZ).expect("decoder");
+    let events = d.process(&audio);
+
+    let img = events
+        .iter()
+        .find_map(|e| match e {
+            SstvEvent::ImageComplete {
+                image,
+                partial: false,
+            } => Some(image.clone()),
+            _ => None,
+        })
+        .expect("ImageComplete event");
+
+    assert_eq!(img.mode, mode);
+    assert_eq!(img.width, w);
+    assert_eq!(img.height, h);
+
+    let mut max_diff = 0_u8;
+    let mut sum_diff: u64 = 0;
+    let mut n: u64 = 0;
+    for (i, src) in ycrcb.iter().enumerate() {
+        let src_rgb = slowrx::__test_support::mode_pd::ycbcr_to_rgb(src[0], src[1], src[2]);
+        let dec = img.pixels[i];
+        for ch in 0..3 {
+            let d = (i32::from(src_rgb[ch]) - i32::from(dec[ch])).unsigned_abs() as u8;
+            if d > max_diff {
+                max_diff = d;
+            }
+            sum_diff += u64::from(d);
+            n += 1;
+        }
+    }
+    let mean = sum_diff as f64 / n as f64;
+    assert!(mean < 5.0, "{mode:?}: max_diff={max_diff} mean={mean:.2}");
+}
+```
+
+- [ ] **Step 2: Append the `r72_roundtrip` test at the end of `tests/roundtrip.rs`**
+
+```rust
+#[test]
+fn robot72_roundtrip() {
+    run_robot_roundtrip(SstvMode::Robot72);
+}
+```
+
+- [ ] **Step 3: Run the test in isolation**
+
+```bash
+cargo test --test roundtrip --features test-support robot72_roundtrip -- --nocapture 2>&1 | tail -10
+```
+
+Expected: PASS with `mean < 5.0`. R72 takes more wall time than PD120 (~30s end-to-end given the line count + audio duration, possibly faster).
+
+If FAIL with `mean >= 5.0`: do NOT relax the threshold. Investigate. Likely culprits: (a) `decode_one_channel_into` zero-padding bound off-by-one (compare with PD's call pattern), (b) `chan_starts_sec` formula mistranslated from slowrx C, (c) `septr_seconds` value wrong.
+
+If FAIL with "expected ImageComplete event": dispatch isn't reaching the RobotYuv arm OR `decode_r72_line` is panicking. Add `dbg!` and re-run.
+
+- [ ] **Step 4: Run all round-trips together** (regression)
+
+```bash
+cargo test --test roundtrip --features test-support 2>&1 | tail -10
+```
+
+Expected: 4 tests pass — PD120, PD180, PD240, R72.
+
+- [ ] **Step 5: Run full CI gate**
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --all-targets --all-features -- -D warnings 2>&1 | tail -3
+cargo test --all-features --locked 2>&1 | grep -E "^test result"
+RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features 2>&1 | tail -3
+```
+
+All clean.
+
+- [ ] **Step 6: Commit (covers Tasks 3.1 + 3.2 + 3.3)**
+
+```bash
+git add src/mode_robot.rs src/mode_pd.rs tests/roundtrip.rs
+git commit -m "feat(mode_robot): implement Robot 72 decoder + round-trip
+
+R72 is the simpler Robot variant: 3 channels (Y/U/V) sequential at
+full pixel rate, no chroma alternation. mode_robot::decode_line now
+dispatches per-mode (Robot72 → decode_r72_line); R36/R24 still
+unimplemented!() pending Phase 4.
+
+Reuses crate::mode_pd::decode_one_channel_into (visibility bumped
+from private to pub(crate) — no behavior change). Synthetic
+robot_test_encoder.rs gains R72 path. tests/roundtrip.rs adds
+robot72_roundtrip with the same mean<5.0 threshold as PD modes.
+
+Refs: V2.2 epic #64"
+```
+
+---
+
+## Phase 4 — Robot 36 / Robot 24 decoder + synthetic round-trip
+
+R36/R24 share decoder code byte-for-byte (only `LineTime` differs and the spec lookup handles that). Implement the chroma-alternation + neighbor-row-duplication path.
+
+### Task 4.1: Add R36/R24 path to `robot_test_encoder.rs`
+
+**Files:**
+- Modify: `src/robot_test_encoder.rs`.
+
+- [ ] **Step 1: Replace the `unimplemented!()` arm with a call to a new `encode_r36_or_r24` helper**
+
+In `src/robot_test_encoder.rs::encode_robot`, change the match:
+
+```rust
+    match mode {
+        SstvMode::Robot72 => encode_r72(&mut out, &mut phase, &mut t, advance, &spec, ycrcb),
+        SstvMode::Robot24 | SstvMode::Robot36 => {
+            encode_r36_or_r24(&mut out, &mut phase, &mut t, advance, &spec, ycrcb)
+        }
+        _ => unreachable!(),
+    }
+```
+
+- [ ] **Step 2: Add the `encode_r36_or_r24` helper**
+
+Below `encode_r72`, add:
+
+```rust
+/// Robot 36 / Robot 24 channel layout per slowrx `video.c:60-101` (R36/R24 case):
+/// ChanLen[0] = pixel_seconds * width * 2 (Y allocated 2× pixel-time).
+/// ChanLen[1] = ChanLen[2] = pixel_seconds * width (alternating chroma).
+/// ChanStart[0] = sync + porch.
+/// ChanStart[1] = ChanStart[0] + ChanLen[0] + septr.
+/// ChanStart[2] = ChanStart[1].  (Same time slot as ch[1] — the
+/// chroma channel at this time is determined by the row's parity.)
+///
+/// Per radio line N, the encoder emits:
+///   - Sync (2× width-pixels worth of time) at SYNC_HZ
+///   - Porch at PORCH_HZ
+///   - Y for image row N, sample-rate `pixel_seconds` per pixel,
+///     emitted across `width * 2` pixel-time worth of audio (R36/R24
+///     allocate Y twice the per-channel time)
+///   - Septr at PORCH_HZ
+///   - Chroma: Cr if N%2==0, Cb if N%2==1; one sample per `pixel_seconds`
+#[allow(clippy::too_many_arguments)]
+fn encode_r36_or_r24(
+    out: &mut Vec<f32>,
+    phase: &mut f64,
+    t: &mut f64,
+    mut advance: impl FnMut(&mut f64, f64) -> usize,
+    spec: &crate::modespec::ModeSpec,
+    ycrcb: &[[u8; 3]],
+) {
+    let w = spec.line_pixels;
+    let h = spec.image_lines;
+    for y in 0..h {
+        // Sync + porch.
+        fill_to(out, SYNC_HZ, advance(t, spec.sync_seconds), phase);
+        fill_to(out, PORCH_HZ, advance(t, spec.porch_seconds), phase);
+
+        // Y channel — emitted at pixel_seconds per source pixel,
+        // BUT Y's allocated time is pixel_seconds * width * 2 per
+        // R36/R24 ChanLen[0]. We emit width samples at pixel_seconds
+        // each, which produces `pixel_seconds * width` of audio — that's
+        // half of the allocated Y channel time. The other half comes
+        // from the SAME source pixels emitted again. (This matches
+        // slowrx's per-pixel emission and the decoder's expectation.)
+        //
+        // NOTE: in slowrx, the encoder side emits each Y sample for
+        // its full chunk; the decoder reads at pixel-time positions
+        // computed from chan_len. We mirror that: emit width samples
+        // each at `pixel_seconds * 2` (so the total Y duration is
+        // pixel_seconds * width * 2 = ChanLen[0]).
+        for x in 0..w {
+            let lum = ycrcb[(y * w + x) as usize][0];
+            fill_to(
+                out,
+                lum_to_freq(lum),
+                advance(t, spec.pixel_seconds * 2.0),
+                phase,
+            );
+        }
+
+        // Septr between Y and chroma.
+        fill_to(out, PORCH_HZ, advance(t, spec.septr_seconds), phase);
+
+        // Chroma — Cr on even rows, Cb on odd rows.
+        let chroma_idx = if y % 2 == 0 { 1 } else { 2 };
+        for x in 0..w {
+            let chroma = ycrcb[(y * w + x) as usize][chroma_idx];
+            fill_to(
+                out,
+                lum_to_freq(chroma),
+                advance(t, spec.pixel_seconds),
+                phase,
+            );
+        }
+    }
+}
+```
+
+- [ ] **Step 2.5 (NB about Y timing):** the slowrx C convention is that Y in R36/R24 has `ChanLen[0] = PixelTime * Width * 2` — this is the ALLOCATED time, but per slowrx `video.c:196-198` the per-pixel time formula uses `ChanLen[Channel]`, not `ChanLen[0]` for Y. Since `Channel == 0` (Y), it uses `ChanLen[0] = PixelTime * Width * 2`, meaning each Y pixel is sampled at `(x - 0.5) / Width * (PixelTime * Width * 2) = PixelTime * 2 * (x - 0.5)`. So Y pixels are spaced by `PixelTime * 2` — what we emit above. The decoder needs to read at the same spacing. **Sanity-check:** if you find the decoder needs `PixelTime` (single) instead of `PixelTime * 2` for Y, the encoder above is wrong; investigate slowrx's exact decoder pixel-time arithmetic.
+
+- [ ] **Step 3: Build**
+
+`cargo build --features test-support 2>&1 | tail -3`
+
+Expected: compiles cleanly.
+
+- [ ] **Step 4: Re-run R72 round-trip** (regression check — new helper shouldn't break R72 path)
+
+```bash
+cargo test --test roundtrip --features test-support robot72_roundtrip 2>&1 | tail -5
+```
+
+Expected: PASS.
+
+### Task 4.2: Implement R36/R24 decode path in `mode_robot::decode_line`
+
+**Files:**
+- Modify: `src/mode_robot.rs`.
+
+R36/R24 share decoder logic — only `LineTime` differs (R24 = 150ms, R36 = 150ms — actually identical!). The spec lookup gives identical `ModeSpec` field values for R24 and R36 except for `mode` and `vis_code`. Decode logic can be one function used for both.
+
+- [ ] **Step 1: Replace the `unimplemented!()` arm with a call to `decode_r36_or_r24_line`**
+
+In `src/mode_robot.rs::decode_line`'s match:
+
+```rust
+        SstvMode::Robot24 | SstvMode::Robot36 => decode_r36_or_r24_line(
+            spec,
+            line_index,
+            audio,
+            skip_samples,
+            line_seconds_offset,
+            rate_hz,
+            image,
+            demod,
+            snr_est,
+            hedr_shift_hz,
+        ),
+```
+
+- [ ] **Step 2: Add the `decode_r36_or_r24_line` helper**
+
+Below `decode_r72_line`, add:
+
+```rust
+/// Decode one R36 or R24 radio line into image[`line_index`] and
+/// duplicate the chroma sample to image[`line_index + 1`] (with bounds
+/// guard at the last image row).
+///
+/// Channel layout per slowrx `video.c:60-101` (R36/R24 case):
+/// `ChanLen[0] = pixel_seconds * width * 2` (Y allocated 2× per-channel
+/// time); `ChanLen[1] = ChanLen[2] = pixel_seconds * width`.
+/// `ChanStart[0] = sync + porch`; `ChanStart[1] = ChanStart[0] +
+/// ChanLen[0] + septr`; `ChanStart[2] = ChanStart[1]` (chroma channel
+/// reuses ch[1]'s time slot — actual channel determined by row parity).
+///
+/// Per slowrx `video.c:182-191` and `:421-425`: chroma channel is Cr
+/// on even-indexed image rows (y % 2 == 0), Cb on odd; each chroma
+/// sample is duplicated to image[y+1][channel] (last-row guard
+/// applied). image[y+1][channel] starts zero-initialized; image[0]
+/// has only its Cr (no Cb), image[h-1] has only Cb-from-self (Cr from
+/// h-2's duplication).
+#[allow(clippy::too_many_arguments)]
+fn decode_r36_or_r24_line(
+    spec: ModeSpec,
+    line_index: u32,
+    audio: &[f32],
+    skip_samples: i64,
+    line_seconds_offset: f64,
+    rate_hz: f64,
+    image: &mut crate::image::SstvImage,
+    demod: &mut crate::mode_pd::PdDemod,
+    snr_est: &mut crate::snr::SnrEstimator,
+    hedr_shift_hz: f64,
+) {
+    let sync_secs = spec.sync_seconds;
+    let porch_secs = spec.porch_seconds;
+    let pixel_secs = spec.pixel_seconds;
+    let septr_secs = spec.septr_seconds;
+    let width = spec.line_pixels;
+    let chan_len_y = f64::from(width) * pixel_secs * 2.0;
+    let chan_len_chroma = f64::from(width) * pixel_secs;
+
+    let chan_start_y = sync_secs + porch_secs;
+    let chan_start_chroma = chan_start_y + chan_len_y + septr_secs;
+
+    let width_us = width as usize;
+
+    let y_bounds_abs = {
+        let start_abs =
+            skip_samples + ((line_seconds_offset + chan_start_y) * rate_hz).round() as i64;
+        let end_abs = skip_samples
+            + ((line_seconds_offset + chan_start_y + chan_len_y) * rate_hz).round() as i64;
+        (start_abs, end_abs)
+    };
+    let chroma_bounds_abs = {
+        let start_abs = skip_samples
+            + ((line_seconds_offset + chan_start_chroma) * rate_hz).round() as i64;
+        let end_abs = skip_samples
+            + ((line_seconds_offset + chan_start_chroma + chan_len_chroma) * rate_hz).round()
+                as i64;
+        (start_abs, end_abs)
+    };
+
+    let mut y_buf = vec![0_u8; width_us];
+    let mut chroma_buf = vec![0_u8; width_us];
+
+    // Y is at 2× pixel-time per pixel — patch the per-pixel time the
+    // decoder expects. We can't pass `pixel_seconds * 2` directly into
+    // `decode_one_channel_into` because that helper reads `pixel_seconds`
+    // from `spec`. Synthesize a temporary `ModeSpec` with the doubled
+    // pixel rate for the Y channel decode.
+    let mut spec_y = spec;
+    spec_y.pixel_seconds = pixel_secs * 2.0;
+
+    crate::mode_pd::decode_one_channel_into(
+        &mut y_buf,
+        chan_start_y,
+        y_bounds_abs,
+        spec_y,
+        audio,
+        skip_samples,
+        line_seconds_offset,
+        rate_hz,
+        demod,
+        snr_est,
+        hedr_shift_hz,
+    );
+
+    crate::mode_pd::decode_one_channel_into(
+        &mut chroma_buf,
+        chan_start_chroma,
+        chroma_bounds_abs,
+        spec, // chroma uses spec's native pixel_seconds
+        audio,
+        skip_samples,
+        line_seconds_offset,
+        rate_hz,
+        demod,
+        snr_est,
+        hedr_shift_hz,
+    );
+
+    // Determine which chroma channel arrived this radio line.
+    let chroma_channel: usize = if line_index % 2 == 0 { 1 } else { 2 };
+
+    // Compose RGB for the current row. We need both Cr and Cb for each
+    // pixel; the missing one for this row may have been written by the
+    // PREVIOUS radio line's chroma duplication. Read it back from the
+    // image buffer if present, else use 128 (neutral chroma) as fallback
+    // for the very first row.
+    //
+    // Image storage: each pixel is [R, G, B] (already converted from
+    // YCbCr), so we can't read raw chroma back from image. Instead, we
+    // need to track raw chroma per row to compose at the end. Slowrx C
+    // does this by storing raw Y/Cr/Cb in a side buffer (`Image` array
+    // is YUV-typed pre-conversion). Our `SstvImage` stores RGB only.
+    //
+    // Approach: we need a side buffer for raw chroma. Easiest path —
+    // image has Cr/Cb planes for this purpose. But our image type
+    // doesn't have those. So this decoder must:
+    //   a) Receive a side YCbCr buffer, OR
+    //   b) Defer RGB conversion until after both chroma channels are known
+    //
+    // (b) means: store raw Y + raw chroma_at_this_line into a per-image
+    // chroma buffer that lives across decode_line calls. The simplest
+    // shape: pass &mut [u8] sliced by row, or store in DecodingState.
+    //
+    // BUT: our function signature only has `&mut SstvImage` (RGB
+    // post-conversion). That's a structural limit of the V1 dispatch
+    // contract. Two options:
+    //
+    //   1. Extend DecodingState (in decoder.rs) to hold an optional
+    //      `chroma_planes: Option<[Vec<u8>; 2]>` for Robot modes,
+    //      and pass &mut to mode_robot::decode_line.
+    //   2. Use a SCRATCH buffer parameter on decode_line to hold
+    //      chroma planes for the Robot families.
+    //
+    // For V2.2 we adopt option (1): DecodingState gains an optional
+    // chroma planes field, populated only for ChannelLayout::RobotYuv.
+    // See the corresponding decoder.rs edit below.
+
+    // The per-row composition logic continues — see decoder.rs edits
+    // for how `chroma_planes` is plumbed in. Each row fills its own
+    // chroma channel + duplicates to next row's chroma slot. After
+    // the entire image is decoded, run a final pass that converts
+    // YCbCr → RGB using the full chroma planes.
+    //
+    // For now, write Y + chroma into the image (RGB position) with a
+    // simplified placeholder: convert with neutral chroma until the
+    // chroma-planes plumbing is in place.
+
+    let _ = (chan_len_y, chan_len_chroma); // silence dead_code warnings if any
+    todo!("chroma-planes plumbing requires decoder.rs DecodingState edit — Phase 4 Task 4.2");
+}
+```
+
+**Important note on the `todo!()`:** the R36/R24 implementation requires plumbing a chroma-planes side buffer through `DecodingState` in `decoder.rs`. The decode-line API as it stands today writes RGB directly to `SstvImage`, but R36/R24 need the raw chroma to compose RGB AFTER both chroma channels are present (own + duplicated-from-neighbor). This Phase 4 Task includes the decoder.rs edit; see Step 3.
+
+- [ ] **Step 3: Plumb chroma planes through `DecodingState` for the RobotYuv path**
+
+Open `src/decoder.rs`. Find the `DecodingState` struct (around line 75). Add an optional chroma-planes field that's populated only for `ChannelLayout::RobotYuv`:
+
+```rust
+struct DecodingState {
+    mode: SstvMode,
+    spec: crate::modespec::ModeSpec,
+    image: SstvImage,
+    audio: Vec<f32>,
+    has_sync: Vec<bool>,
+    next_probe_sample: usize,
+    sync_tracker: SyncTracker,
+    hedr_shift_hz: f64,
+    target_audio_samples: usize,
+    /// Per-mode chroma planes. `None` for `ChannelLayout::PdYcbcr` (PD
+    /// converts YCbCr→RGB in-place per pair). `Some([cr, cb])` for
+    /// `ChannelLayout::RobotYuv` — each is `image_lines * line_pixels`
+    /// bytes, populated as radio lines are decoded; final pass composes
+    /// RGB after the entire image's chroma is in place.
+    chroma_planes: Option<[Vec<u8>; 2]>,
+}
+```
+
+Update the `DecodingState` constructor (search for `DecodingState {` literal initialization) to populate `chroma_planes`:
+
+```rust
+    chroma_planes: match spec.channel_layout {
+        crate::modespec::ChannelLayout::PdYcbcr => None,
+        crate::modespec::ChannelLayout::RobotYuv => {
+            let n = (spec.image_lines as usize) * (spec.line_pixels as usize);
+            Some([vec![0_u8; n], vec![0_u8; n]])
+        }
+    },
+```
+
+Also extend the `mode_robot::decode_line` signature to accept the chroma planes:
+
+```rust
+pub(crate) fn decode_line(
+    spec: ModeSpec,
+    mode: SstvMode,
+    line_index: u32,
+    audio: &[f32],
+    skip_samples: i64,
+    line_seconds_offset: f64,
+    rate_hz: f64,
+    image: &mut crate::image::SstvImage,
+    chroma_planes: Option<&mut [Vec<u8>; 2]>,  // NEW PARAM
+    demod: &mut crate::mode_pd::PdDemod,
+    snr_est: &mut crate::snr::SnrEstimator,
+    hedr_shift_hz: f64,
+) {
+    ...
+}
+```
+
+Update the dispatch site in `decoder.rs` to pass `chroma_planes`:
+
+```rust
+    crate::mode_robot::decode_line(
+        d.spec,
+        d.mode,
+        line,
+        &d.audio,
+        skip,
+        line_seconds_offset,
+        rate,
+        &mut d.image,
+        d.chroma_planes.as_mut(),
+        pd_demod,
+        snr_est,
+        d.hedr_shift_hz,
+    );
+```
+
+The R72 path doesn't need chroma_planes (it composes RGB in-place); pass it but ignore in `decode_r72_line` (parameter named `_chroma_planes`). The R36/R24 path uses it to:
+  1. Write own chroma into chroma_planes[chroma_channel - 1] at row line_index
+  2. Duplicate to chroma_planes[chroma_channel - 1] at row line_index + 1 (with bounds guard)
+  3. Read back the OTHER chroma channel for this row from chroma_planes[other_channel - 1] at row line_index (zero-init for first row)
+  4. Compose RGB from raw Y + both chroma values (own + read-back)
+  5. Write RGB to image
+
+Replace the `todo!()` in `decode_r36_or_r24_line` with the full body using the planes plumbing above. The chroma-duplicate write must guard against `line_index + 1 >= image_lines`.
+
+- [ ] **Step 4: Build**
+
+`cargo build --features test-support 2>&1 | tail -3`
+
+Expected: compiles cleanly. R72 unaffected (uses `_chroma_planes`).
+
+### Task 4.3: Add `r36_roundtrip` + `r24_roundtrip` tests, verify
+
+**Files:**
+- Modify: `tests/roundtrip.rs`.
+
+- [ ] **Step 1: Append the two tests at the end of `tests/roundtrip.rs`**
+
+```rust
+#[test]
+fn robot36_roundtrip() {
+    run_robot_roundtrip(SstvMode::Robot36);
+}
+
+#[test]
+fn robot24_roundtrip() {
+    run_robot_roundtrip(SstvMode::Robot24);
+}
+```
+
+- [ ] **Step 2: Run them in isolation**
+
+```bash
+cargo test --test roundtrip --features test-support robot36_roundtrip -- --nocapture 2>&1 | tail -10
+cargo test --test roundtrip --features test-support robot24_roundtrip -- --nocapture 2>&1 | tail -10
+```
+
+Expected: both PASS with `mean < 5.0`.
+
+If FAIL: most likely culprits — chroma-plane indexing math (row * width + x), bounds-guard for last-row duplication off-by-one, or the test_robot_image's chroma period not surviving the duplication (recheck Task 3.3 Step 1's chroma stripe periods).
+
+- [ ] **Step 3: Run all 6 round-trips together**
+
+```bash
+cargo test --test roundtrip --features test-support 2>&1 | tail -10
+```
+
+Expected: 6 tests pass (PD120/PD180/PD240/R72/R36/R24). Total wall time: 3-5 minutes.
+
+- [ ] **Step 4: Run full CI gate**
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --all-targets --all-features -- -D warnings 2>&1 | tail -3
+cargo test --all-features --locked 2>&1 | grep -E "^test result"
+RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features 2>&1 | tail -3
+```
+
+All clean.
+
+- [ ] **Step 5: Commit (covers Tasks 4.1 + 4.2 + 4.3)**
+
+```bash
+git add src/mode_robot.rs src/robot_test_encoder.rs src/decoder.rs tests/roundtrip.rs
+git commit -m "feat(mode_robot): implement Robot 36 + Robot 24 decoder + round-trips
+
+R36/R24 share decoder code (only LineTime differs in the spec; both
+have identical timing values otherwise). decode_r36_or_r24_line
+implements the 2-channel layout per slowrx video.c:60-101 (R36/R24
+case): Y at 2× pixel-time, chroma at 1× with row-parity-determined
+Cr/Cb assignment and duplication to image[y+1][channel].
+
+Plumbed chroma_planes side buffer through DecodingState for
+ChannelLayout::RobotYuv (RGB composition deferred until both chroma
+channels are present, since duplication only fills one channel per
+radio line). PD path unaffected (chroma_planes = None).
+
+robot_test_encoder.rs gains the R36/R24 path. tests/roundtrip.rs
+adds robot36_roundtrip + robot24_roundtrip with the same mean<5.0
+threshold as PD/R72. Synthetic test image picks chroma stripe periods
+that survive the encoder's vertical chroma halving.
+
+Refs: V2.2 epic #64"
+```
+
+---
+
+## Phase 5 — Real-audio Fram2 validation (merge gate)
+
+The 12 ARISS Fram2 WAV+JPG pairs at `tests/fixtures/ariss-fram2/` (gitignored) are the merge gate per the spec. `slowrx-cli` must produce 12 PNG outputs that visually match the 12 reference JPGs.
+
+### Task 5.1: Create `tests/ariss_fram2_validation.md` (committed procedure doc)
+
+**Files:**
+- Create: `tests/ariss_fram2_validation.md` (NOT gitignored — checked-in procedure doc).
+
+- [ ] **Step 1: Write the procedure**
+
+```markdown
+# ARISS Fram2 Real-Audio Validation Procedure
+
+The ARISS Fram2 mission (April 2025) used Robot 36 and ARISS-USA
+published 12 reference WAV + JPG pairs for decoder validation:
+<https://ariss-usa.org/ARISS_SSTV/Fram2Test/>.
+
+This is the merge gate for V2.2 (Robot family decoding) and the
+regression net for any future change to `mode_robot.rs` or the
+`ChannelLayout::RobotYuv` dispatch.
+
+## Prerequisites
+
+1. Pull the 12 WAV + 12 JPG pairs into `tests/fixtures/ariss-fram2/`
+   (gitignored corpus — license unclear for redistribution):
+
+   ```bash
+   mkdir -p tests/fixtures/ariss-fram2
+   cd tests/fixtures/ariss-fram2
+   for n in 01 02 03 04 05 06 07 08 09 10 11 12; do
+     curl -O "https://ariss-usa.org/ARISS_SSTV/Fram2Test/Slide${n}.wav"
+     curl -O "https://ariss-usa.org/ARISS_SSTV/Fram2Test/Slide${n}-Robot-36-Color.jpg"
+   done
+   ```
+
+2. Build slowrx-cli in release mode:
+
+   ```bash
+   cargo build --release --features cli
+   ```
+
+## Run validation
+
+Decode all 12 WAVs and inspect each PNG against its reference JPG:
+
+```bash
+mkdir -p /tmp/fram2-validate
+for n in 01 02 03 04 05 06 07 08 09 10 11 12; do
+  ./target/release/slowrx-cli \
+    --input "tests/fixtures/ariss-fram2/Slide${n}.wav" \
+    --output "/tmp/fram2-validate/" 2>&1 | tail -2
+  # Rename so each output is identifiable
+  mv "/tmp/fram2-validate/img-001-robot36.png" \
+     "/tmp/fram2-validate/Slide${n}-decoded.png"
+done
+```
+
+Each WAV should produce: `1 VIS, 240 lines, 1 image(s)` and a PNG file.
+
+Open both directories in an image viewer and visually compare each
+`Slide${n}-decoded.png` against the reference
+`tests/fixtures/ariss-fram2/Slide${n}-Robot-36-Color.jpg`.
+
+## Acceptance criteria (visual match)
+
+For all 12 slides:
+
+1. **Recognizable image content.** The same scene appears in both —
+   you can identify subjects, text, shapes.
+
+2. **Color accuracy within slowrx tolerances.** Hue and brightness
+   approximately match. Slight tonal drift is acceptable; obvious
+   color casts (everything blue / red / green) are NOT acceptable.
+
+3. **Geometric integrity.** Image dimensions are 320×240. The image
+   isn't distorted or shifted. Slight slant (a few pixels per line)
+   is acceptable if the C reference shows it; large slant is not.
+
+4. **No black/blank rows or columns.** Each row decoded should have
+   visible content. Occasional sync slips on noisy lines (1-2
+   per image) are acceptable.
+
+If a slide fails any criterion above, do NOT merge V2.2. Investigate.
+
+## Common failure modes and where to look
+
+- **All 12 images upside-down or scrambled colors:** chroma channel
+  swap (Cr/Cb confusion) in `mode_robot::decode_r36_or_r24_line`. Check
+  the row-parity-to-chroma-channel mapping — slowrx C: even row → ch1
+  (Cr), odd row → ch2 (Cb).
+
+- **Pixel time off — image squished horizontally:** `pixel_seconds * 2`
+  for the Y channel decode is wrong. Re-read slowrx
+  `video.c:60-101` R36/R24 case ChanLen[0] — should be PixelTime *
+  Width * 2.
+
+- **Top row has wrong/missing color:** expected — image[0] never gets
+  Cb written (slowrx C does the same). If row 0 is solid green/blue,
+  that's the zero-init Cb showing through. Acceptable.
+
+- **Decoder panics or crashes:** likely chroma-duplicate bounds guard
+  missing — `line_index + 1 == image_lines` should be a no-op.
+
+## Pass/fail recording
+
+After validation, append a one-line note to `CHANGELOG.md` under the
+`[0.3.0]` section noting the date and the result. Example:
+
+> Validated against 12 ARISS Fram2 Robot 36 captures on 2026-05-XX —
+> all 12 produced visually-matching images.
+
+Or, if some failed and were fixed, document the iteration:
+
+> Validated against 12 ARISS Fram2 Robot 36 captures on 2026-05-XX
+> after one decoder fix (commit XXXXXXX).
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add tests/ariss_fram2_validation.md
+git commit -m "docs(test): ARISS Fram2 real-audio validation procedure
+
+Document the V2.2 (Robot family) merge gate: decode all 12 ARISS
+Fram2 reference WAVs and visually compare against the 12 reference
+JPGs. Records prerequisites (corpus download, release build), the
+run procedure, acceptance criteria, common failure modes, and
+pass/fail recording in the CHANGELOG.
+
+The corpus itself stays gitignored (tests/fixtures/ariss-fram2/) —
+license for community-shared captures is unclear and the payload is
+~82 MB. Procedure doc is committed.
+
+Refs: V2.2 epic #64"
+```
+
+### Task 5.2: Run the validation procedure against the 12 Fram2 WAVs
+
+**Files:** None (validation run, not code).
+
+- [ ] **Step 1: Build release**
+
+`cargo build --release --features cli 2>&1 | tail -3`
+
+Expected: clean.
+
+- [ ] **Step 2: Decode all 12 slides**
+
+```bash
+mkdir -p /tmp/fram2-validate
+for n in 01 02 03 04 05 06 07 08 09 10 11 12; do
+  ./target/release/slowrx-cli \
+    --input "tests/fixtures/ariss-fram2/Slide${n}.wav" \
+    --output "/tmp/fram2-validate/" 2>&1 | tail -2
+  if [ -f "/tmp/fram2-validate/img-001-robot36.png" ]; then
+    mv "/tmp/fram2-validate/img-001-robot36.png" \
+       "/tmp/fram2-validate/Slide${n}-decoded.png"
+  else
+    echo "Slide${n}: NO IMAGE PRODUCED"
+  fi
+done
+ls -la /tmp/fram2-validate/
+```
+
+Expected: 12 PNG files, one per slide.
+
+- [ ] **Step 3: Visually compare each PNG against its reference JPG**
+
+Open both `tests/fixtures/ariss-fram2/Slide${n}-Robot-36-Color.jpg`
+and `/tmp/fram2-validate/Slide${n}-decoded.png` for n = 01..12 in an
+image viewer. Walk through the acceptance criteria from Task 5.1.
+
+If any fail, STOP. Investigate using the common-failure-modes hints
+in `tests/ariss_fram2_validation.md`. Fix in `mode_robot.rs` (or
+elsewhere as the issue dictates), commit the fix, and re-run from
+Step 2.
+
+- [ ] **Step 4: Record validation result**
+
+In a temp note file (e.g. `/tmp/fram2-result.txt`), record the date,
+slowrx version, and pass/fail per slide. This goes into the CHANGELOG
+in Task 6.2.
+
+```bash
+cat > /tmp/fram2-result.txt <<EOF
+ARISS Fram2 validation — slowrx 0.3.0-pre — $(date -I)
+
+Slide01: <pass/fail + 1-line observation if fail>
+Slide02: ...
+...
+Slide12: ...
+EOF
+```
+
+---
+
+## Phase 6 — Release prep + PR + publish
+
+Standard V2.x release ceremony (matches V2.1's Phase 4).
+
+### Task 6.1: Update `README.md` mode-coverage table
+
+**Files:**
+- Modify: `README.md`.
+
+- [ ] **Step 1: Read** `README.md` to find the `## Status` block and the mode-coverage table.
+
+- [ ] **Step 2: Update Status block**
+
+Replace `🛰️ **0.2.0 — V2.1 published.** PD120, PD180, and PD240 decoding from raw audio.` with:
+
+```markdown
+🛰️ **0.3.0 — V2.2 published.** PD120, PD180, PD240, Robot 24, Robot 36, and Robot 72 decoding from raw audio.
+```
+
+Update the validation-language paragraph to reflect Fram2 and the existing Dec-2017 corpus:
+
+```markdown
+PD120, PD180, and Robot 36 are validated end-to-end against real-radio
+captures: PD120/PD180 against the ARISS Dec-2017 corpus (6 of 7
+fixtures decode to images visually matching the reference JPGs),
+Robot 36 against the ARISS Fram2 corpus (all 12 fixtures decode to
+images visually matching the reference JPGs). PD240 ships with
+synthetic round-trip coverage only — a real-radio fixture is
+pending. Robot 24 and Robot 72 ship with synthetic coverage; Robot
+24 inherits Robot 36's evidence by structural identity (same decoder
+code path, only LineTime differs). Remaining V2 mode coverage
+(Scottie, Martin) is on the [roadmap](https://github.com/jasonherald/slowrx.rs/issues/9).
+```
+
+- [ ] **Step 3: Update mode-coverage table**
+
+Find the `| **PD** | PD120, PD180, PD240 | — |` row and the Robot row below. Update both:
+
+```markdown
+| Mode family | Shipped | Roadmap |
+|---|---|---|
+| **PD** | PD120, PD180, PD240 | — |
+| **Robot** | Robot 24, Robot 36, Robot 72 | — |
+| **Scottie** | — | Scottie 1, Scottie 2, Scottie DX |
+| **Martin** | — | Martin 1, Martin 2 |
+```
+
+- [ ] **Step 4: Update CLI usage hint** if the example mentions specific modes:
+
+Find the Quick start section's CLI hint:
+
+```bash
+slowrx-cli --input recording.wav --output ./out
+# → out/img-001-pd120.png, out/img-001-robot36.png, ...
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add README.md
+git commit -m "docs(readme): V2.2 — Robot family shipped, status block + mode table updated"
+```
+
+### Task 6.2: Add CHANGELOG entry
+
+**Files:**
+- Modify: `CHANGELOG.md`.
+
+- [ ] **Step 1: Insert a new `[0.3.0]` section** between `## [Unreleased]` and the existing `## [0.2.1]`. Use today's date (`date -I`):
+
+```markdown
+## [Unreleased]
+
+## [0.3.0] - 2026-05-XX
+
+V2.2 — Robot family mode coverage. Adds Robot 24 (`SstvMode::Robot24`,
+VIS `0x04`), Robot 36 (`SstvMode::Robot36`, VIS `0x08`), and Robot 72
+(`SstvMode::Robot72`, VIS `0x0C`). First V2 release that introduces a
+non-PD decoder; introduces the cross-mode-family dispatch refactor in
+`decoder.rs`.
+
+Closes V2.2 epic ([#64]). Tracks the V2 umbrella ([#9]).
+
+[#9]: https://github.com/jasonherald/slowrx.rs/issues/9
+[#64]: https://github.com/jasonherald/slowrx.rs/issues/64
+
+### Added
+
+- **Robot 24, Robot 36, Robot 72 modes.** All three at 320×240 image
+  resolution. Timing constants from slowrx `modespec.c:130-167`. R36/R24
+  share decoder code (chroma alternation + neighbor-row duplication per
+  slowrx `video.c:182-191`, `:421-425`); R72 uses the simpler 3-channel
+  Y/U/V sequential layout per `video.c:60-101` default case.
+- **`ChannelLayout::RobotYuv` enum variant** covering all three Robot
+  modes. Per-mode chroma topology lives inside `mode_robot.rs` (the
+  internal mode-match mirrors slowrx's `switch(Mode)` cases at
+  `video.c:60-101` and `:104-130`).
+- **`src/mode_robot.rs`** — new Robot-family decoder. Reuses
+  `mode_pd::decode_one_channel_into` (visibility bumped from private to
+  `pub(crate)`) and `mode_pd::ycbcr_to_rgb`.
+- **`src/robot_test_encoder.rs`** — synthetic encoder for round-trip
+  testing. Mirrors `pd_test_encoder.rs` shape.
+- **Per-mode chroma planes side buffer** on `DecodingState` in
+  `decoder.rs` (`chroma_planes: Option<[Vec<u8>; 2]>`). Allocated only
+  for `ChannelLayout::RobotYuv`; lets R36/R24 compose RGB after both
+  chroma channels (own + duplicated-from-neighbor) are present.
+
+### Changed
+
+- **`decoder.rs::run_findsync_and_decode`** now dispatches on
+  `ChannelLayout`. PD path is byte-identical to V2.1 (zero PD120/180/240
+  regression risk). Robot path loops per image line and calls
+  `mode_robot::decode_line`.
+- **`pd_modes_have_line_start_sync_position` test renamed to
+  `all_v2_modes_have_line_start_sync_position`** and extended to cover
+  all six current modes (PD + Robot).
+
+### Tests
+
+- `tests/roundtrip.rs::robot72_roundtrip`,
+  `tests/roundtrip.rs::robot36_roundtrip`,
+  `tests/roundtrip.rs::robot24_roundtrip` — synthetic round-trip with
+  mean per-pixel-diff threshold < 5.0.
+- `src/decoder.rs::tests::process_emits_vis_detected_for_robot{24,36,72}_burst`
+  — new VIS-detection unit tests.
+
+### Validation
+
+- Validated against 12 ARISS Fram2 Robot 36 captures
+  (https://ariss-usa.org/ARISS_SSTV/Fram2Test/) on YYYY-MM-DD — all 12
+  produced visually-matching images. Procedure documented at
+  `tests/ariss_fram2_validation.md`.
+
+## [0.2.1] - 2026-05-02
+```
+
+(Replace `2026-05-XX` and `YYYY-MM-DD` with actual dates from `date -I`.
+The validation date is the result recorded in Task 5.2 Step 4.)
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add CHANGELOG.md
+git commit -m "docs(changelog): 0.3.0 — V2.2 Robot family release"
+```
+
+### Task 6.3: Bump `Cargo.toml` to 0.3.0
+
+**Files:**
+- Modify: `Cargo.toml`, `Cargo.lock`.
+
+- [ ] **Step 1: Update `Cargo.toml`**
+
+Change `version = "0.2.1"` to `version = "0.3.0"`.
+
+- [ ] **Step 2: Update `Cargo.lock`**
+
+```bash
+cargo build --all-features 2>&1 | tail -3
+cargo build --all-features --locked 2>&1 | tail -3
+```
+
+The first regenerates the lockfile; the second confirms it's in sync.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Cargo.toml Cargo.lock
+git commit -m "chore(release): bump version to 0.3.0"
+```
+
+### Task 6.4: Run full release-readiness gate
+
+**Files:** None.
+
+- [ ] **Step 1: All four CI commands**
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --all-targets --all-features -- -D warnings 2>&1 | tail -3
+cargo test --all-features --locked 2>&1 | grep -E "^test result"
+RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features 2>&1 | tail -3
+```
+
+All clean.
+
+- [ ] **Step 2: Coverage check**
+
+```bash
+cargo llvm-cov --all-features --summary-only 2>&1 | tail -25
+```
+
+Verify per-file line coverage ≥ 92% for: `decoder.rs`, `error.rs`,
+`image.rs`, `lib.rs`, `mode_pd.rs`, `mode_robot.rs`, `modespec.rs`,
+`pd_test_encoder.rs`, `resample.rs`, `robot_test_encoder.rs`, `snr.rs`,
+`sync.rs`, `vis.rs`.
+
+`bin/slowrx_cli.rs` will likely show 0% (CLI integration test
+gitignored — V1 carve-out, not a regression).
+
+If `mode_robot.rs` or `robot_test_encoder.rs` is below 92%, identify
+which lines are uncovered and add a targeted unit test in
+`mod tests` to exercise that code path. Common gaps: edge cases like
+"last row chroma duplication bounds guard" — exercise by adding a
+synthetic test that writes only the last-row chroma.
+
+- [ ] **Step 3: Publish dry-run**
+
+```bash
+cargo publish --dry-run --features cli --allow-dirty 2>&1 | tail -10
+```
+
+Expected: `Packaged N files, ~N KiB`, `Verifying slowrx v0.3.0`,
+`Uploading...` (aborted by dry-run).
+
+`--allow-dirty` is required because the `original/` clone (gitignored)
+trips cargo's dirty check — same situation as 0.2.0/0.2.1 publish.
+
+### Task 6.5: Open the V2.2 PR
+
+**Files:** None (GitHub-side change).
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+git push -u origin feat/v2.2-robot 2>&1 | tail -5
+```
+
+- [ ] **Step 2: Open PR**
+
+```bash
+gh pr create --repo jasonherald/slowrx.rs \
+  --title "feat(robot): V2.2 — Robot 24 / 36 / 72 decoding (closes #64)" \
+  --body "$(cat <<'EOF'
+## Summary
+
+- Adds **Robot 24, Robot 36, Robot 72** SSTV modes (VIS codes 0x04 / 0x08 / 0x0C). Timing constants translated from slowrx `modespec.c:130-167`.
+- Introduces **`ChannelLayout::RobotYuv`** variant — `#[non_exhaustive]` enum addition, no V1/V2.1 API churn.
+- Introduces the **first cross-mode-family dispatch refactor** in `decoder.rs`. PD path is byte-identical to V2.1; Robot path loops per image line and calls `mode_robot::decode_line`.
+- New **`src/mode_robot.rs`** decoder. Internally matches on mode for R36/R24 (2-channel Y + alternating chroma + neighbor-row duplication per slowrx `video.c:182-191`, `:421-425`) vs R72 (3-channel sequential per `video.c:60-101` default). Reuses `mode_pd::decode_one_channel_into` (visibility bumped to `pub(crate)`) and `mode_pd::ycbcr_to_rgb`.
+- New **`src/robot_test_encoder.rs`** synthetic encoder. Three new round-trip tests (`robot{24,36,72}_roundtrip`) with the same `mean < 5.0` threshold as PD.
+- **Real-audio merge gate satisfied:** all 12 ARISS Fram2 Robot 36 reference WAVs decode to images visually matching the 12 reference JPGs. Procedure committed at `tests/ariss_fram2_validation.md`.
+
+Spec: [`docs/superpowers/specs/2026-05-02-v2.2-robot-design.md`](docs/superpowers/specs/2026-05-02-v2.2-robot-design.md)
+Plan: [`docs/superpowers/plans/2026-05-02-v2.2-robot.md`](docs/superpowers/plans/2026-05-02-v2.2-robot.md)
+
+Closes #64 (V2.2 epic). Tracks #9 (V2 umbrella).
+
+## Test plan
+
+- [x] `cargo fmt --all -- --check`
+- [x] `cargo clippy --all-targets --all-features -- -D warnings`
+- [x] `cargo test --all-features --locked` — all tests pass (PD + Robot round-trips, VIS-detection unit tests for all 6 current modes, modespec lookups for all 6)
+- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`
+- [x] `cargo llvm-cov --all-features --summary-only` — every library file ≥ 92% line coverage including `mode_robot.rs` and `robot_test_encoder.rs`
+- [x] `cargo publish --dry-run --features cli --allow-dirty`
+- [x] **Real-audio Fram2 validation** — all 12 reference WAVs decode to visually-matching images per `tests/ariss_fram2_validation.md`
+EOF
+)"
+```
+
+- [ ] **Step 3: Wait for CI**
+
+```bash
+gh pr checks --watch
+```
+
+Expected: all CI jobs pass.
+
+- [ ] **Step 4: User-side review and merge** (handoff to user — same shape as V2.1).
+
+### Task 6.6: Post-merge — tag, publish
+
+**Files:** None (registry-side change).
+
+- [ ] **Step 1: Sync local main**
+
+```bash
+cd /data/source/slowrx.rs
+git checkout main
+git pull --ff-only origin main 2>&1 | tail -3
+```
+
+- [ ] **Step 2: Tag**
+
+```bash
+git tag -a v0.3.0 -m "v0.3.0 — V2.2 Robot family"
+git push origin v0.3.0 2>&1 | tail -3
+```
+
+- [ ] **Step 3: Publish**
+
+```bash
+cargo publish --features cli --allow-dirty 2>&1 | tail -10
+```
+
+Expected: `Published slowrx v0.3.0 at registry crates-io`.
+
+- [ ] **Step 4: Verify**
+
+```bash
+sleep 30
+cargo search slowrx | head -2
+```
+
+Expected: shows `slowrx = "0.3.0"`.
+
+### Task 6.7: Close V2.2 epic + tick #9 umbrella + cleanup
+
+**Files:** None (GitHub-side change + local cleanup).
+
+- [ ] **Step 1: Verify #64 was auto-closed by the merge**
+
+```bash
+gh issue view 64 --repo jasonherald/slowrx.rs --json state --jq .state
+```
+
+If still OPEN: `gh issue close 64 --comment "Shipped in 0.3.0."`.
+
+- [ ] **Step 2: Tick V2.2 row in #9**
+
+Substitute the actual SHA of the merge commit if desired. Edit #9's
+body to mark the V2.2 row as shipped:
+
+```bash
+gh issue view 9 --repo jasonherald/slowrx.rs --json body --jq .body > /tmp/issue-9-body.md
+# In the file, change:
+#   | V2.2 | Robot family | Robot 36, Robot 72 | 0.3.0 | #64 |
+# To:
+#   | V2.2 | Robot family | Robot 24, Robot 36, Robot 72 | 0.3.0 (shipped) | #64 |
+# Note: if R24 was added to scope per V2.2 brainstorm decision, also reflect that.
+gh issue edit 9 --repo jasonherald/slowrx.rs --body-file /tmp/issue-9-body.md
+gh issue view 9 --repo jasonherald/slowrx.rs --json body --jq .body | grep "V2.2"
+```
+
+- [ ] **Step 3: Clean up worktree + local branch**
+
+```bash
+cd /data/source/slowrx.rs
+git worktree remove /data/source/slowrx.rs-v2.2-robot 2>&1 | tail -2
+git branch -d feat/v2.2-robot 2>&1 | tail -2
+git worktree list
+```
+
+Expected: only `/data/source/slowrx.rs` remains.
+
+The Fram2 fixtures stay in `/data/source/slowrx.rs-v2.2-robot/tests/fixtures/ariss-fram2/` — but that directory is removed by `git worktree remove`. If you want the fixtures preserved for future R36 regression work, copy them BEFORE removing the worktree:
+
+```bash
+cp -r /data/source/slowrx.rs-v2.2-robot/tests/fixtures /tmp/preserved-ariss-fram2
+git worktree remove /data/source/slowrx.rs-v2.2-robot
+mkdir -p /data/source/slowrx.rs/tests
+mv /tmp/preserved-ariss-fram2 /data/source/slowrx.rs/tests/fixtures
+```
+
+(The main worktree's `.gitignore` already covers `/tests/fixtures` after the V2.2 merge, so they stay gitignored.)
+
+---
+
+## Self-review notes
+
+The plan author ran the writing-plans self-review checklist:
+
+- **Spec coverage:** all spec sections (Modes/constants, Architecture/types, File layout, Dispatch, Testing posture, Real-audio Fram2 gate, Versioning, Risks) are addressed by tasks. The 5 risks named in the spec map to: Risk 1 (R36 chroma duplication) → Phase 4 + Phase 5 (Fram2 validation); Risk 2 (dispatch regression) → Phase 2 Task 2.2 Step 3 (PD round-trip regression check); Risk 3 (R72 no real-audio) → CHANGELOG entry in Task 6.2 (and #70 backlog tracker); Risk 4 (R24 inheritance) → Task 5.2's structural-equivalence note + CHANGELOG; Risk 5 (coverage gate noise on new files) → Task 6.4 Step 2 with explicit 92%-per-file check on the new files.
+- **Placeholder scan:** no TBD/TODO/incomplete-detail items in code blocks. Every `unimplemented!()` is intentional and has a referenced phase that fills it. Every commit message is byte-specified. The CHANGELOG date placeholders (`2026-05-XX`, `YYYY-MM-DD`) are deliberate runtime substitutions with `date -I` instructions.
+- **Type consistency:** `decode_line`, `decode_r72_line`, `decode_r36_or_r24_line`, `encode_robot`, `encode_r72`, `encode_r36_or_r24`, `chroma_planes`, `RobotYuv` — all referenced consistently across phases. `decode_one_channel_into` (visibility bump) is referenced consistently in Task 3.2 Step 3 and Task 4.2.
+- **One known unknown:** Task 4.1 Step 2.5 calls out a sanity-check on the Y pixel-time formula. If that turns out to be wrong (encoder/decoder disagree), Phase 4 round-trip will fail — diagnose by comparing encoder emission timing with the decoder's `pixel_seconds * 2` read formula. This is the "thorny" part of R36/R24 to get right; document any deviation in `docs/intentional-deviations.md` if it lands.
+
+No issues found that required inline fixes during self-review.

--- a/docs/superpowers/specs/2026-05-02-v2.2-robot-design.md
+++ b/docs/superpowers/specs/2026-05-02-v2.2-robot-design.md
@@ -1,0 +1,219 @@
+# slowrx.rs V2.2 — Robot Family Design Specification
+
+**Status:** Approved 2026-05-02. Ready for implementation planning via the
+[superpowers:writing-plans](https://github.com/anthropic-ai/superpowers) skill.
+
+**Goal:** Add Robot 24, Robot 36, and Robot 72 SSTV mode decoding to
+`slowrx.rs`. Ships as `slowrx 0.3.0` per the V2 epic-split plan ([#9],
+[#64]). Includes the first cross-mode-family dispatch refactor in
+`decoder.rs`.
+
+**Out of scope for this spec:**
+- Robot B&W modes (Robot 8BW / 12BW / 24BW) — different `ColorEnc=BW`,
+  different decoder. Tracked in [#70].
+- Wraase SC-2 modes — separate mode family, future epic if requested.
+- Numerical pixel-diff against reference JPGs — visual comparison is the
+  V2.2 gate; numerical diff requires careful JPG-artifact handling.
+  Tracked in [#70].
+- `Decoder` trait abstraction over mode-family decoders — premature with
+  2-3 implementations. Tracked in [#70].
+
+[#9]: https://github.com/jasonherald/slowrx.rs/issues/9
+[#64]: https://github.com/jasonherald/slowrx.rs/issues/64
+[#70]: https://github.com/jasonherald/slowrx.rs/issues/70
+
+## Context
+
+V2.1 (PD240) shipped as `slowrx 0.2.0` and patched as `0.2.1`. The V2
+epic-split design (`docs/superpowers/specs/2026-05-02-v2-epic-split-design.md`)
+mapped the V2 path; V2.2 is the second mode-family epic and the first
+that introduces a non-PD decoder. The user's standing policy is **no
+deferments or simplifications, faithful translation**, with **real-audio
+fixture validation as a merge gate when fixtures are available** (see
+ARISS Fram2 corpus below).
+
+## Modes and constants
+
+All values translated row-for-row from `original/slowrx/modespec.c:130-167`
+(timing rows) and `:376` (the `VISmap[]` table).
+
+| Mode | VIS | Image | SyncTime | PorchTime | SeptrTime | PixelTime | LineTime | NumChans | C row |
+|------|-----|-------|----------|-----------|-----------|-----------|----------|----------|---|
+| Robot 24 | `0x04` | 320×240 | 9 ms | 3 ms | 6 ms | 0.1375 ms | 150 ms | 2 | `modespec.c:156-167` |
+| Robot 36 | `0x08` | 320×240 | 9 ms | 3 ms | 6 ms | 0.1375 ms | 150 ms | 2 | `modespec.c:143-154` |
+| Robot 72 | `0x0C` | 320×240 | 9 ms | 3 ms | 4.7 ms | 0.2875 ms | 300 ms | 3 | `modespec.c:130-141` |
+
+R24 and R36 share decoder structure: Y at 2× pixel-time per channel-
+allocation + alternating chroma (Cr on even-indexed Y rows, Cb on odd),
+with chroma duplicated to the neighbor row (slowrx `video.c:182-191`,
+`:424-425`). R72 is the simpler 3-channel sequential layout (Y / U / V
+each at 1× pixel-time), no row-phase alternation.
+
+## Architecture
+
+### Type-system additions (additive only — V1/V2.1 API unchanged)
+
+`SstvMode` gains three variants:
+
+```rust
+pub enum SstvMode {
+    Pd120, Pd180, Pd240,             // V1 + V2.1
+    Robot24, Robot36, Robot72,       // V2.2
+}
+```
+
+`ChannelLayout` gains one variant covering all three Robot modes:
+
+```rust
+pub enum ChannelLayout {
+    PdYcbcr,                         // V1 + V2.1
+    RobotYuv,                        // V2.2 (R24, R36, R72)
+}
+```
+
+The R24/R36-vs-R72 chroma-shape difference (subsampled-alternating vs
+full-per-line) lives **inside** `mode_robot.rs` as a per-mode `match`,
+mirroring slowrx's own `switch(Mode)` cases at `video.c:60-101` and
+`:104-130`. We deliberately do **not** introduce a separate
+`ChannelLayout::RobotYuvAlt` variant — that would over-fit "consistency"
+to a structural detail slowrx itself doesn't surface (slowrx uses `Mode`
+directly, not a layout type).
+
+`ModeSpec` gains **no new fields**. Existing `septr_seconds` accommodates
+Robot's non-zero values (R24/R36 = 6ms, R72 = 4.7ms). Existing
+`sync_position: SyncPosition::LineStart` applies to all Robot modes
+(slowrx confirms — R24/R36/R72 all have sync at line start).
+
+### File layout
+
+**New files:**
+
+| File | Purpose | Cap | Notes |
+|------|---------|-----|-------|
+| `src/mode_robot.rs` | Robot-family decoder | ≤ 500 LOC | Public entry: `pub(crate) fn decode_line(spec, mode, audio, skip, line_seconds, rate, image, demod, snr_est, hedr_shift_hz)`. Internally matches on `mode` for R24/R36 (2-channel alternating) vs R72 (3-channel full). |
+| `src/robot_test_encoder.rs` | Synthetic encoder for round-trip tests | ≤ 300 LOC | Test-support gated. Mirrors `pd_test_encoder.rs`. Exports `pub fn encode_robot(mode, ycrcb)`. |
+
+**Modified files:**
+
+- `src/modespec.rs` — 3 new `SstvMode` variants, 3 new `ModeSpec` consts,
+  `ChannelLayout::RobotYuv` variant, 3 new `lookup`/`for_mode` arms.
+  Generalize the existing `pd_modes_have_line_start_sync_position` test
+  to `all_v2_modes_have_line_start_sync_position` (PD + Robot share
+  `LineStart`; Scottie is the eventual exception in V2.3).
+- `src/decoder.rs` — **the dispatch refactor**. The current direct call
+  to `mode_pd::decode_pd_line_pair` at lines 341-352 becomes a
+  `match d.spec.channel_layout { PdYcbcr => mode_pd::decode_pd_line_pair(...), RobotYuv => mode_robot::decode_line(...) }`.
+  The `PdYcbcr` arm is byte-identical to today (zero PD-mode regression
+  risk). Add three `process_emits_vis_detected_for_robot{24,36,72}_burst`
+  unit tests mirroring the V2.1 PD pattern.
+- `src/lib.rs` — `pub mod mode_robot;`, plus `pub use mode_robot::*` if
+  any types need re-export. Add `mode_robot::encode_robot` to
+  `__test_support`.
+- `tests/roundtrip.rs` — three new VIS arms (`Robot24 => 0x04`,
+  `Robot36 => 0x08`, `Robot72 => 0x0C`), three new round-trip tests
+  (`robot24_roundtrip`, `robot36_roundtrip`, `robot72_roundtrip`). Use a
+  dedicated `run_robot_roundtrip(mode)` helper alongside the existing
+  `run_roundtrip(mode)` (PD-specific) — keeps test infrastructure flat.
+
+**Files unchanged by V2.2:** `vis.rs`, `sync.rs`, `snr.rs`, `resample.rs`,
+`image.rs`, `error.rs`, `mode_pd.rs`, `pd_test_encoder.rs`. The dispatch
+refactor in `decoder.rs` is the only V1 file behavior change, and the
+`PdYcbcr` arm is a literal copy of today's call.
+
+### Dispatch shape
+
+Match block on `ChannelLayout` (no trait abstraction yet — premature with
+two implementations; revisit in V2.4 per [#70]). Both decoder functions
+take the same positional argument list — no shared parameter struct. YAGNI.
+
+## Testing posture
+
+### Synthetic round-trip (per-PR gate)
+
+Same `mean < 5.0` per-pixel-RGB-diff threshold as PD. Three new tests in
+`tests/roundtrip.rs` exercising each Robot mode end-to-end through the
+synthetic encoder.
+
+**R36/R24 test-image construction** must produce chroma that survives the
+encoder's vertical halving (each chroma sample duplicated to neighbor
+row). The `test_robot_image()` helper picks Cr/Cb periods that change
+slowly enough that adjacent-row pairs share chroma — same approach
+PD's test image uses for line-pair averaging.
+
+### Real-audio validation (merge gate — Robot 36 only)
+
+The April 2025 ARISS Fram2 mission used Robot 36. ARISS-USA published 12
+reference WAV+JPG pairs at
+<https://ariss-usa.org/ARISS_SSTV/Fram2Test/>. Already pulled to
+`tests/fixtures/ariss-fram2/` (gitignored, V1 corpus convention).
+
+**Merge gate:** the V2.2 PR cannot merge until `slowrx-cli` produces 12
+PNG outputs that visually match the 12 reference JPGs. Visual comparison
+is by-eye (matches the V1 ARISS gate); standard slowrx artifacts
+(occasional sync slips on noisy lines, slight slant) acceptable if the
+reference shows them too.
+
+| After phase | Expected `slowrx-cli` output on `Slide01.wav` | What it tells us |
+|---|---|---|
+| modespec changes | `1 VIS, 0 lines, 0 image(s)` (mode detected, decoder absent — likely panic until decode site lands) | Mode detection works |
+| `mode_robot.rs` landed | `1 VIS, 240 lines, 1 image(s)` → `img-001-robot36.png` written | Decoder produces output |
+| Visual match on all 12 slides | 12 PNGs visually matching reference JPGs | **Merge gate satisfied** |
+
+**R24 inherits R36's evidence.** R24 shares R36's decoder code byte-for-
+byte (only `LineTime` differs, and the C source confirms — `modespec.c`
+shows R24 and R36 have identical channel-time/chroma-layout entries in
+`video.c:60-101` and `:104-130`). If R36 visually-matches all 12 Fram2
+slides, R24 inherits that confidence. R24-specific real-radio fixtures
+are essentially extinct on the air; this is the practical bar.
+
+**R72 ships on synthetic round-trip alone.** No public R72 capture
+sourced during the V2.2 brainstorm. Tracked in [#70] as an open-ended
+fixture-tracker (drop a real R72 WAV into `tests/fixtures/<event>/`
+whenever one appears, then post-hoc validate).
+
+### Coverage gate
+
+`cargo llvm-cov` ≥ 92% per-file maintained. New files (`mode_robot.rs`,
+`robot_test_encoder.rs`) ship with ≥ 92% line coverage from the synthetic
+round-trip path. Pre-existing 0% coverage on `bin/slowrx_cli.rs` is
+unchanged (CLI integration test depends on gitignored fixtures —
+documented V1 carve-out, not a regression).
+
+## Versioning
+
+Single semver-minor bump per the V2 epic-split design: `0.2.1 → 0.3.0`.
+`#[non_exhaustive]` enums make this additive at the API level; minor is
+the strict semver call.
+
+## Risks
+
+1. **R36/R24 chroma alternation + duplication is the load-bearing
+   novelty.** Most likely place a synthetic-passes-real-fails gap could
+   open. Mitigated by the Fram2 real-audio merge gate.
+2. **First cross-family dispatch refactor in `decoder.rs`.** Refactoring
+   carries V1 regression risk for PD120/PD180/PD240. Mitigated by: (a)
+   the `PdYcbcr` arm is byte-identical to today's call, (b) existing PD
+   round-trip + VIS-detection tests act as the regression net.
+3. **Robot 72 ships without real-audio evidence.** Tracked in [#70].
+4. **Robot 24 ships without R24-specific real-audio evidence.** Inherits
+   R36 validation by structural identity (same decoder code path, only
+   `LineTime` differs). Documented in CHANGELOG when V2.2 ships.
+5. **Coverage-gate noise from new files.** If the synthetic round-trip
+   doesn't exercise some chroma-edge path (e.g., last-row chroma
+   duplication boundary), per-file coverage might dip below 92%. Plan
+   should include a `cargo llvm-cov` step before declaring V2.2 done.
+
+## Acceptance for this spec
+
+This spec is "done" when:
+
+- A V2.2 implementation plan exists at
+  `docs/superpowers/plans/2026-05-02-v2.2-robot.md`.
+- The plan covers: ModeSpec additions, dispatch refactor, mode_robot
+  decoder, robot_test_encoder, round-trip tests, Fram2 visual validation
+  procedure, CHANGELOG/version bump, PR + merge + publish.
+- The Fram2 visual-validation procedure has a concrete documented form
+  (where the procedure lives, how to run it, what "visually match" means
+  in this context).
+
+Spec lifecycle ends here. Implementation drives off the plan.

--- a/src/bin/slowrx_cli.rs
+++ b/src/bin/slowrx_cli.rs
@@ -284,11 +284,15 @@ fn mode_tag(mode: SstvMode) -> &'static str {
         SstvMode::Pd120 => "pd120",
         SstvMode::Pd180 => "pd180",
         SstvMode::Pd240 => "pd240",
+        SstvMode::Robot24 => "robot24",
+        SstvMode::Robot36 => "robot36",
+        SstvMode::Robot72 => "robot72",
         // SstvMode is #[non_exhaustive] which forces a wildcard arm in
         // matches even within the same crate. New variants will use
         // this fallback — when adding one, also add an explicit arm
         // above. (V2.1 PD240 trap: missed this match and shipped images
-        // as `img-NNN-unknown.png` until 0.2.1.)
+        // as `img-NNN-unknown.png` until 0.2.1. Same trap caught for
+        // V2.2 Robot24/36/72 during code review of the dispatch refactor.)
         _ => "unknown",
     }
 }

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -586,6 +586,69 @@ mod tests {
     }
 
     #[test]
+    fn process_emits_vis_detected_for_robot24_burst() {
+        use crate::vis::tests::synth_vis;
+        let mut d = SstvDecoder::new(WORKING_SAMPLE_RATE_HZ).expect("decoder");
+        let mut burst = synth_vis(0x04, 0.0);
+        burst.extend(std::iter::repeat_n(0.0_f32, 512));
+        let events = d.process(&burst);
+        let hedr = events
+            .iter()
+            .find_map(|e| match e {
+                SstvEvent::VisDetected {
+                    mode: SstvMode::Robot24,
+                    hedr_shift_hz,
+                    ..
+                } => Some(*hedr_shift_hz),
+                _ => None,
+            })
+            .expect("expected VisDetected for Robot24");
+        assert!(hedr.abs() < 10.0);
+    }
+
+    #[test]
+    fn process_emits_vis_detected_for_robot36_burst() {
+        use crate::vis::tests::synth_vis;
+        let mut d = SstvDecoder::new(WORKING_SAMPLE_RATE_HZ).expect("decoder");
+        let mut burst = synth_vis(0x08, 0.0);
+        burst.extend(std::iter::repeat_n(0.0_f32, 512));
+        let events = d.process(&burst);
+        let hedr = events
+            .iter()
+            .find_map(|e| match e {
+                SstvEvent::VisDetected {
+                    mode: SstvMode::Robot36,
+                    hedr_shift_hz,
+                    ..
+                } => Some(*hedr_shift_hz),
+                _ => None,
+            })
+            .expect("expected VisDetected for Robot36");
+        assert!(hedr.abs() < 10.0);
+    }
+
+    #[test]
+    fn process_emits_vis_detected_for_robot72_burst() {
+        use crate::vis::tests::synth_vis;
+        let mut d = SstvDecoder::new(WORKING_SAMPLE_RATE_HZ).expect("decoder");
+        let mut burst = synth_vis(0x0C, 0.0);
+        burst.extend(std::iter::repeat_n(0.0_f32, 512));
+        let events = d.process(&burst);
+        let hedr = events
+            .iter()
+            .find_map(|e| match e {
+                SstvEvent::VisDetected {
+                    mode: SstvMode::Robot72,
+                    hedr_shift_hz,
+                    ..
+                } => Some(*hedr_shift_hz),
+                _ => None,
+            })
+            .expect("expected VisDetected for Robot72");
+        assert!(hedr.abs() < 10.0);
+    }
+
+    #[test]
     fn reset_clears_sample_counter() {
         let mut d = SstvDecoder::new(11_025).expect("decoder");
         let _ = d.process(&[0.0_f32; 1024]);

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -328,38 +328,74 @@ impl SstvDecoder {
         let skip = result.skip_samples;
 
         let line_pixels = d.spec.line_pixels as usize;
-        let pair_count = d.spec.image_lines / 2;
-        for pair in 0..pair_count {
-            // slowrx `video.c:140-142` computes pixel time as
-            // `Skip + round(Rate * (y/2 * LineTime + ChanStart +
-            // PixelTime * (x + 0.5)))`. Compute `pair_seconds = y/2 *
-            // LineTime` here (un-rounded) and let
-            // [`crate::mode_pd::decode_pd_line_pair`] fold it into its
-            // own `round()`, so per-pair rounding error never
-            // accumulates.
-            let pair_seconds = f64::from(pair) * d.spec.line_seconds;
-            crate::mode_pd::decode_pd_line_pair(
-                d.spec,
-                pair,
-                &d.audio,
-                skip,
-                pair_seconds,
-                rate,
-                &mut d.image,
-                pd_demod,
-                snr_est,
-                d.hedr_shift_hz,
-            );
-            let row0 = pair * 2;
-            let row1 = row0 + 1;
-            for r in [row0, row1] {
-                let start = (r as usize) * line_pixels;
-                let end = start + line_pixels;
-                out.push(SstvEvent::LineDecoded {
-                    mode: d.mode,
-                    line_index: r,
-                    pixels: d.image.pixels[start..end].to_vec(),
-                });
+        match d.spec.channel_layout {
+            crate::modespec::ChannelLayout::PdYcbcr => {
+                let pair_count = d.spec.image_lines / 2;
+                for pair in 0..pair_count {
+                    // slowrx `video.c:140-142` computes pixel time as
+                    // `Skip + round(Rate * (y/2 * LineTime + ChanStart +
+                    // PixelTime * (x + 0.5)))`. Compute `pair_seconds = y/2 *
+                    // LineTime` here (un-rounded) and let
+                    // [`crate::mode_pd::decode_pd_line_pair`] fold it into its
+                    // own `round()`, so per-pair rounding error never
+                    // accumulates.
+                    let pair_seconds = f64::from(pair) * d.spec.line_seconds;
+                    crate::mode_pd::decode_pd_line_pair(
+                        d.spec,
+                        pair,
+                        &d.audio,
+                        skip,
+                        pair_seconds,
+                        rate,
+                        &mut d.image,
+                        pd_demod,
+                        snr_est,
+                        d.hedr_shift_hz,
+                    );
+                    let row0 = pair * 2;
+                    let row1 = row0 + 1;
+                    for r in [row0, row1] {
+                        let start = (r as usize) * line_pixels;
+                        let end = start + line_pixels;
+                        out.push(SstvEvent::LineDecoded {
+                            mode: d.mode,
+                            line_index: r,
+                            pixels: d.image.pixels[start..end].to_vec(),
+                        });
+                    }
+                }
+            }
+            crate::modespec::ChannelLayout::RobotYuv => {
+                // Robot is per-line (no PD line-pairing). For R36/R24 the
+                // chroma-duplication writes to the next image row; that's
+                // handled inside mode_robot::decode_line. LineDecoded for image
+                // row N is emitted after radio-line N's decode — for R36/R24
+                // row 0 the Cb channel is at zero-init at this point (slowrx
+                // C does the same; final ImageComplete carries the populated
+                // state).
+                for line in 0..d.spec.image_lines {
+                    let line_seconds_offset = f64::from(line) * d.spec.line_seconds;
+                    crate::mode_robot::decode_line(
+                        d.spec,
+                        d.mode,
+                        line,
+                        &d.audio,
+                        skip,
+                        line_seconds_offset,
+                        rate,
+                        &mut d.image,
+                        pd_demod,
+                        snr_est,
+                        d.hedr_shift_hz,
+                    );
+                    let start = (line as usize) * line_pixels;
+                    let end = start + line_pixels;
+                    out.push(SstvEvent::LineDecoded {
+                        mode: d.mode,
+                        line_index: line,
+                        pixels: d.image.pixels[start..end].to_vec(),
+                    });
+                }
             }
         }
 

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -94,6 +94,20 @@ struct DecodingState {
     /// [`find_sync`] and per-pair decode. Computed at state-entry as
     /// `image_lines / 2 × line_seconds × FINDSYNC_AUDIO_HEADROOM × work_rate`.
     target_audio_samples: usize,
+    /// Per-mode chroma planes side buffer.
+    ///
+    /// `None` for `ChannelLayout::PdYcbcr` (PD composes RGB in-place per
+    /// pair — see `mode_pd::decode_pd_line_pair`).
+    ///
+    /// `Some([cr_plane, cb_plane])` for `ChannelLayout::RobotYuv`. Each
+    /// plane is `image_lines * line_pixels` bytes, populated as radio
+    /// lines are decoded. R72 doesn't actually use these (composes RGB
+    /// in-place like PD), but R36/R24 need them: each radio line N
+    /// writes its own chroma + duplicates to the next row's chroma slot
+    /// (slowrx `video.c:421-425`); RGB composition for row N reads the
+    /// duplicated-from-N-1 chroma channel that the line N-1 decode
+    /// wrote earlier.
+    chroma_planes: Option<[Vec<u8>; 2]>,
 }
 
 /// Headroom factor on the buffered audio length before [`find_sync`]
@@ -221,6 +235,14 @@ impl SstvDecoder {
                                 sync_tracker: SyncTracker::new(detected.hedr_shift_hz),
                                 hedr_shift_hz: detected.hedr_shift_hz,
                                 target_audio_samples: target,
+                                chroma_planes: match spec.channel_layout {
+                                    crate::modespec::ChannelLayout::PdYcbcr => None,
+                                    crate::modespec::ChannelLayout::RobotYuv => {
+                                        let n = (spec.image_lines as usize)
+                                            * (spec.line_pixels as usize);
+                                        Some([vec![0_u8; n], vec![0_u8; n]])
+                                    }
+                                },
                             }));
                             continue; // re-enter loop to process leftover audio
                         }
@@ -384,6 +406,7 @@ impl SstvDecoder {
                         line_seconds_offset,
                         rate,
                         &mut d.image,
+                        d.chroma_planes.as_mut(),
                         pd_demod,
                         snr_est,
                         d.hedr_shift_hz,

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -215,13 +215,18 @@ impl SstvDecoder {
                             // the leading edge of the image data.
                             let residual = self.vis.take_residual_buffer();
                             let work_rate = f64::from(crate::resample::WORKING_SAMPLE_RATE_HZ);
-                            // PD modes pack 2 image rows per radio frame, so
-                            // the audio duration is `image_lines/2 *
-                            // line_seconds * rate`. Matches slowrx's
-                            // `Length = LineTime * NumLines/2 * 44100`
-                            // path in video.c:252 (for NumChans == 4).
+                            // Audio duration depends on whether the mode packs
+                            // 2 image rows per radio frame (PD) or 1 (Robot,
+                            // future Scottie/Martin). Mirrors slowrx's
+                            // video.c:251-254: `Length = LineTime * NumLines/2`
+                            // when `NumChans == 4` (PD), else
+                            // `Length = LineTime * NumLines`.
+                            let radio_frames_per_image = match spec.channel_layout {
+                                crate::modespec::ChannelLayout::PdYcbcr => spec.image_lines / 2,
+                                crate::modespec::ChannelLayout::RobotYuv => spec.image_lines,
+                            };
                             let nominal_samples =
-                                (f64::from(spec.image_lines / 2) * spec.line_seconds * work_rate)
+                                (f64::from(radio_frames_per_image) * spec.line_seconds * work_rate)
                                     as usize;
                             let target =
                                 ((nominal_samples as f64) * FINDSYNC_AUDIO_HEADROOM) as usize;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,6 +128,10 @@ mod tests_common {
 #[doc(hidden)]
 pub mod pd_test_encoder;
 
+#[cfg(any(test, feature = "test-support"))]
+#[doc(hidden)]
+pub mod robot_test_encoder;
+
 pub use crate::decoder::{SstvDecoder, SstvEvent};
 pub use crate::error::{Error, Result};
 pub use crate::image::SstvImage;
@@ -148,5 +152,8 @@ pub mod __test_support {
     pub mod mode_pd {
         pub use crate::mode_pd::ycbcr_to_rgb;
         pub use crate::pd_test_encoder::encode_pd;
+    }
+    pub mod mode_robot {
+        pub use crate::robot_test_encoder::encode_robot;
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,7 @@ pub mod decoder;
 pub mod error;
 pub mod image;
 pub mod mode_pd;
+pub mod mode_robot;
 pub mod modespec;
 pub mod resample;
 #[allow(dead_code)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,9 +7,12 @@
 //!
 //! ## Status
 //!
-//! `0.2.x` — V2.1 published with PD120, PD180, and PD240 decoding. The
-//! public API is `#[non_exhaustive]`-protected for additive growth as
-//! V2.x mode-family epics land. See
+//! `0.3.x` — V2.2 published. PD120/PD180/PD240 + Robot 24/36/72
+//! decoding from raw audio. PD120/PD180 validated against ARISS
+//! Dec-2017; Robot 36 validated against the ARISS Fram2 corpus
+//! (see `tests/ariss_fram2_validation.md`). The public API is
+//! `#[non_exhaustive]`-protected for additive growth as V2.x
+//! mode-family epics land. See
 //! <https://github.com/jasonherald/slowrx.rs/issues/9> for the V2 roadmap.
 //!
 //! ## Example

--- a/src/mode_pd.rs
+++ b/src/mode_pd.rs
@@ -392,7 +392,7 @@ pub(crate) fn decode_one_channel_into(
     spec: crate::modespec::ModeSpec,
     audio: &[f32],
     skip_samples: i64,
-    pair_seconds: f64,
+    time_offset_seconds: f64,
     rate_hz: f64,
     demod: &mut PdDemod,
     snr_est: &mut crate::snr::SnrEstimator,
@@ -402,12 +402,18 @@ pub(crate) fn decode_one_channel_into(
     let width = spec.line_pixels as usize;
 
     // Pixel sample times (slowrx video.c:140-142) — absolute audio indices.
-    // SINGLE `round()` over `(pair_seconds + chan_start_sec + (x +
+    // SINGLE `round()` over `(time_offset_seconds + chan_start_sec + (x +
     // 0.5) * pixel_secs) * rate`; matches slowrx exactly.
+    //
+    // `time_offset_seconds` is the time-base offset of the radio frame the
+    // caller is decoding: PD passes `pair_index * line_seconds`; Robot
+    // passes `line_index * line_seconds`. The helper itself is mode-
+    // agnostic — it only sees an additive seconds offset folded inside
+    // the single `round()`.
     let mut pixel_times: Vec<i64> = Vec::with_capacity(width);
     for x in 0..width {
-        let secs_in_pair = chan_start_sec + pixel_secs * (x as f64 + 0.5);
-        let abs = skip_samples + ((pair_seconds + secs_in_pair) * rate_hz).round() as i64;
+        let secs_in_frame = chan_start_sec + pixel_secs * (x as f64 + 0.5);
+        let abs = skip_samples + ((time_offset_seconds + secs_in_frame) * rate_hz).round() as i64;
         pixel_times.push(abs);
     }
 

--- a/src/mode_pd.rs
+++ b/src/mode_pd.rs
@@ -385,7 +385,7 @@ pub(crate) fn decode_pd_line_pair(
     clippy::cast_possible_wrap,
     clippy::too_many_arguments
 )]
-fn decode_one_channel_into(
+pub(crate) fn decode_one_channel_into(
     out: &mut [u8],
     chan_start_sec: f64,
     chan_bounds_abs: (i64, i64),

--- a/src/mode_robot.rs
+++ b/src/mode_robot.rs
@@ -34,26 +34,49 @@ pub(crate) fn decode_line(
     line_seconds_offset: f64,
     rate_hz: f64,
     image: &mut crate::image::SstvImage,
+    chroma_planes: Option<&mut [Vec<u8>; 2]>,
     demod: &mut crate::mode_pd::PdDemod,
     snr_est: &mut crate::snr::SnrEstimator,
     hedr_shift_hz: f64,
 ) {
     match mode {
-        SstvMode::Robot72 => decode_r72_line(
-            spec,
-            line_index,
-            audio,
-            skip_samples,
-            line_seconds_offset,
-            rate_hz,
-            image,
-            demod,
-            snr_est,
-            hedr_shift_hz,
-        ),
+        SstvMode::Robot72 => {
+            // R72 doesn't need chroma_planes — composes RGB in-place.
+            // Drop the param if the caller passed it.
+            let _ = chroma_planes;
+            decode_r72_line(
+                spec,
+                line_index,
+                audio,
+                skip_samples,
+                line_seconds_offset,
+                rate_hz,
+                image,
+                demod,
+                snr_est,
+                hedr_shift_hz,
+            );
+        }
         SstvMode::Robot24 | SstvMode::Robot36 => {
-            // Filled in V2.2 Phase 4 (R36/R24 chroma-planes plumbing).
-            unimplemented!("R36/R24 decoder lands in V2.2 Phase 4")
+            // chroma_planes is constructed in DecodingState ctor for
+            // every RobotYuv mode; absence here would indicate a
+            // dispatch bug, not a runtime error.
+            #[allow(clippy::expect_used)]
+            let planes = chroma_planes
+                .expect("R36/R24 require chroma_planes; DecodingState should populate them");
+            decode_r36_or_r24_line(
+                spec,
+                line_index,
+                audio,
+                skip_samples,
+                line_seconds_offset,
+                rate_hz,
+                image,
+                planes,
+                demod,
+                snr_est,
+                hedr_shift_hz,
+            );
         }
         _ => unreachable!("decode_line must be called with a Robot variant"),
     }
@@ -143,6 +166,159 @@ fn decode_r72_line(
 
     for x in 0..width_us {
         let rgb = crate::mode_pd::ycbcr_to_rgb(y[x], cr[x], cb[x]);
+        image.put_pixel(x as u32, line_index, rgb);
+    }
+}
+
+/// Decode one R36 or R24 radio line. Writes Y into image[`line_index`],
+/// writes own chroma into the appropriate plane in `chroma_planes`, and
+/// duplicates the chroma sample to the next row's slot in the same
+/// plane (bounds-guarded at the last image row).
+///
+/// Channel layout per slowrx `video.c:60-70` (R36/R24 case):
+///   `ChanLen[0]`   = `pixel_seconds` * width * 2   (Y allocated 2× pixel-time)
+///   `ChanLen[1]`   = `ChanLen[2]` = `pixel_seconds` * width   (chroma at 1×)
+///   `ChanStart[0]` = sync + porch
+///   `ChanStart[1]` = `ChanStart[0]` + `ChanLen[0]` + septr
+///   `ChanStart[2]` = `ChanStart[1]`   (chroma slot reused; actual channel
+///                                  determined by row parity per
+///                                  `video.c:182-191`)
+///
+/// Per slowrx `video.c:182-191`, the chroma channel is:
+///   - Cr (`chroma_planes[0]`) when `y % 2 == 0`
+///   - Cb (`chroma_planes[1]`) when `y % 2 == 1`
+///
+/// Per slowrx `video.c:421-425`, each chroma sample is duplicated to
+/// `Image[x][y+1][channel]`. When `y+1 >= image_lines`, slowrx C silently
+/// writes past the end (undefined); we explicitly guard.
+///
+/// RGB composition for row `line_index` reads:
+///   - Y from the local Y buffer (just decoded)
+///   - Cr from `chroma_planes[0][line_index * width + x]`. For even
+///     `line_index` this was just written above; for odd `line_index`
+///     this was written by the previous radio line's duplication
+///     (`line_index - 1`, even, duplicated forward).
+///   - Cb from `chroma_planes[1][line_index * width + x]`. For odd
+///     `line_index` this was just written above; for even `line_index`
+///     this was written by the previous radio line's duplication
+///     (`line_index - 1`, odd, duplicated forward), EXCEPT `line_index` 0
+///     has no previous line — Cb stays at zero-init (slowrx C does
+///     the same; visible artifact in the top row).
+#[allow(
+    clippy::cast_precision_loss,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    clippy::cast_possible_wrap,
+    clippy::too_many_arguments
+)]
+fn decode_r36_or_r24_line(
+    spec: ModeSpec,
+    line_index: u32,
+    audio: &[f32],
+    skip_samples: i64,
+    line_seconds_offset: f64,
+    rate_hz: f64,
+    image: &mut crate::image::SstvImage,
+    chroma_planes: &mut [Vec<u8>; 2],
+    demod: &mut crate::mode_pd::PdDemod,
+    snr_est: &mut crate::snr::SnrEstimator,
+    hedr_shift_hz: f64,
+) {
+    let sync_secs = spec.sync_seconds;
+    let porch_secs = spec.porch_seconds;
+    let pixel_secs = spec.pixel_seconds;
+    let septr_secs = spec.septr_seconds;
+    let width = spec.line_pixels;
+    let chan_len_y = f64::from(width) * pixel_secs * 2.0;
+    let chan_len_chroma = f64::from(width) * pixel_secs;
+
+    let chan_start_y = sync_secs + porch_secs;
+    let chan_start_chroma = chan_start_y + chan_len_y + septr_secs;
+
+    let width_us = width as usize;
+
+    let y_bounds_abs = {
+        let start_abs =
+            skip_samples + ((line_seconds_offset + chan_start_y) * rate_hz).round() as i64;
+        let end_abs = skip_samples
+            + ((line_seconds_offset + chan_start_y + chan_len_y) * rate_hz).round() as i64;
+        (start_abs, end_abs)
+    };
+    let chroma_bounds_abs = {
+        let start_abs =
+            skip_samples + ((line_seconds_offset + chan_start_chroma) * rate_hz).round() as i64;
+        let end_abs = skip_samples
+            + ((line_seconds_offset + chan_start_chroma + chan_len_chroma) * rate_hz).round()
+                as i64;
+        (start_abs, end_abs)
+    };
+
+    let mut y_buf = vec![0_u8; width_us];
+    let mut chroma_buf = vec![0_u8; width_us];
+
+    // Y channel — synthesize a temporary ModeSpec with doubled
+    // pixel_seconds so decode_one_channel_into reads at the correct
+    // R36/R24 Y spacing (pixel_seconds * 2 per pixel — slowrx
+    // video.c:60-70 R36/R24 case).
+    let mut spec_y = spec;
+    spec_y.pixel_seconds = pixel_secs * 2.0;
+
+    crate::mode_pd::decode_one_channel_into(
+        &mut y_buf,
+        chan_start_y,
+        y_bounds_abs,
+        spec_y,
+        audio,
+        skip_samples,
+        line_seconds_offset,
+        rate_hz,
+        demod,
+        snr_est,
+        hedr_shift_hz,
+    );
+
+    // Chroma channel — use spec's native pixel_seconds.
+    crate::mode_pd::decode_one_channel_into(
+        &mut chroma_buf,
+        chan_start_chroma,
+        chroma_bounds_abs,
+        spec,
+        audio,
+        skip_samples,
+        line_seconds_offset,
+        rate_hz,
+        demod,
+        snr_est,
+        hedr_shift_hz,
+    );
+
+    // Determine which chroma plane this line wrote into.
+    // Even rows write Cr (plane 0); odd rows write Cb (plane 1) — per
+    // slowrx `video.c:182-191`.
+    let chroma_plane_idx = (line_index % 2) as usize;
+
+    let line_off = (line_index as usize) * width_us;
+    let next_off = ((line_index + 1) as usize) * width_us;
+    let plane_len = chroma_planes[chroma_plane_idx].len();
+
+    // Write own chroma into the plane at this row.
+    chroma_planes[chroma_plane_idx][line_off..line_off + width_us].copy_from_slice(&chroma_buf);
+
+    // Duplicate to next row (bounds-guarded for last image row).
+    if next_off + width_us <= plane_len {
+        chroma_planes[chroma_plane_idx][next_off..next_off + width_us].copy_from_slice(&chroma_buf);
+    }
+
+    // Compose RGB. cr and cb come from the two chroma planes at the
+    // current row. For even line_index: cr is just-written own chroma;
+    // cb is duplicated-from-(line_index-1) (or zero-init at line 0).
+    // For odd line_index: cb is just-written own chroma; cr is
+    // duplicated-from-(line_index-1).
+    for x in 0..width_us {
+        let y = y_buf[x];
+        let cr = chroma_planes[0][line_off + x];
+        let cb = chroma_planes[1][line_off + x];
+        let rgb = crate::mode_pd::ycbcr_to_rgb(y, cr, cb);
         image.put_pixel(x as u32, line_index, rgb);
     }
 }

--- a/src/mode_robot.rs
+++ b/src/mode_robot.rs
@@ -1,0 +1,56 @@
+//! Robot-family mode decoder.
+//!
+//! Robot 24 / Robot 36: 2-channel layout per radio line — Y (full width,
+//! 2× pixel-time per channel allocation) followed by alternating Cr/Cb
+//! (Cr on even-indexed Y rows, Cb on odd, each chroma sample duplicated
+//! to the neighbor image row). Robot 72: 3-channel layout per radio
+//! line — Y, U, V each at full pixel-time. All three share
+//! [`crate::modespec::ChannelLayout::RobotYuv`] in the public API; the
+//! per-mode case split mirrors slowrx `video.c:60-101` (channel-time
+//! switch) and `:104-130` (`NumChans` switch).
+//!
+//! Translated from slowrx's `video.c` (Oona Räisänen, ISC License).
+//! Per-mode chroma layout: video.c lines 60-101, 178-209, 421-425.
+//! YUV→RGB matrix: video.c lines 446-451 (shared with PD; we re-use
+//! `mode_pd::ycbcr_to_rgb`). See `NOTICE.md` for full attribution.
+//!
+//! V2.2 stub — `decode_line` writes zeros pending Phase 3/4 fill-in.
+//! See `docs/superpowers/plans/2026-05-02-v2.2-robot.md`.
+
+use crate::modespec::{ModeSpec, SstvMode};
+
+/// Decode one Robot radio line into `image`. The R24/R36 path also
+/// writes duplicated chroma to the neighbor image row (with bounds
+/// guard) per slowrx `video.c:424-425`.
+///
+/// `line_index` is the 0-based image row this radio line emits Y for;
+/// `line_seconds_offset` is `f64::from(line_index) * spec.line_seconds`
+/// (un-rounded — the per-pixel time computation does the single
+/// `round()` to match slowrx `video.c:140-142`).
+///
+/// V2.2 stub — fills the row with zeros. Replaced by per-mode decode
+/// in Phases 3 and 4.
+#[allow(clippy::too_many_arguments, clippy::needless_pass_by_value)]
+pub(crate) fn decode_line(
+    spec: ModeSpec,
+    mode: SstvMode,
+    line_index: u32,
+    _audio: &[f32],
+    _skip_samples: i64,
+    _line_seconds_offset: f64,
+    _rate_hz: f64,
+    image: &mut crate::image::SstvImage,
+    _demod: &mut crate::mode_pd::PdDemod,
+    _snr_est: &mut crate::snr::SnrEstimator,
+    _hedr_shift_hz: f64,
+) {
+    debug_assert!(matches!(
+        mode,
+        SstvMode::Robot24 | SstvMode::Robot36 | SstvMode::Robot72
+    ));
+    // Stub: write zeros. Replaced in Phase 3 (R72) and Phase 4 (R36/R24)
+    // of the V2.2 implementation plan.
+    for x in 0..spec.line_pixels {
+        image.put_pixel(x, line_index, [0, 0, 0]);
+    }
+}

--- a/src/mode_robot.rs
+++ b/src/mode_robot.rs
@@ -13,9 +13,6 @@
 //! Per-mode chroma layout: video.c lines 60-101, 178-209, 421-425.
 //! YUV→RGB matrix: video.c lines 446-451 (shared with PD; we re-use
 //! `mode_pd::ycbcr_to_rgb`). See `NOTICE.md` for full attribution.
-//!
-//! V2.2 stub — `decode_line` writes zeros pending Phase 3/4 fill-in.
-//! See `docs/superpowers/plans/2026-05-02-v2.2-robot.md`.
 
 use crate::modespec::{ModeSpec, SstvMode};
 
@@ -27,30 +24,125 @@ use crate::modespec::{ModeSpec, SstvMode};
 /// `line_seconds_offset` is `f64::from(line_index) * spec.line_seconds`
 /// (un-rounded — the per-pixel time computation does the single
 /// `round()` to match slowrx `video.c:140-142`).
-///
-/// V2.2 stub — fills the row with zeros. Replaced by per-mode decode
-/// in Phases 3 and 4.
 #[allow(clippy::too_many_arguments, clippy::needless_pass_by_value)]
 pub(crate) fn decode_line(
     spec: ModeSpec,
     mode: SstvMode,
     line_index: u32,
-    _audio: &[f32],
-    _skip_samples: i64,
-    _line_seconds_offset: f64,
-    _rate_hz: f64,
+    audio: &[f32],
+    skip_samples: i64,
+    line_seconds_offset: f64,
+    rate_hz: f64,
     image: &mut crate::image::SstvImage,
-    _demod: &mut crate::mode_pd::PdDemod,
-    _snr_est: &mut crate::snr::SnrEstimator,
-    _hedr_shift_hz: f64,
+    demod: &mut crate::mode_pd::PdDemod,
+    snr_est: &mut crate::snr::SnrEstimator,
+    hedr_shift_hz: f64,
 ) {
-    debug_assert!(matches!(
-        mode,
-        SstvMode::Robot24 | SstvMode::Robot36 | SstvMode::Robot72
-    ));
-    // Stub: write zeros. Replaced in Phase 3 (R72) and Phase 4 (R36/R24)
-    // of the V2.2 implementation plan.
-    for x in 0..spec.line_pixels {
-        image.put_pixel(x, line_index, [0, 0, 0]);
+    match mode {
+        SstvMode::Robot72 => decode_r72_line(
+            spec,
+            line_index,
+            audio,
+            skip_samples,
+            line_seconds_offset,
+            rate_hz,
+            image,
+            demod,
+            snr_est,
+            hedr_shift_hz,
+        ),
+        SstvMode::Robot24 | SstvMode::Robot36 => {
+            // Filled in V2.2 Phase 4 (R36/R24 chroma-planes plumbing).
+            unimplemented!("R36/R24 decoder lands in V2.2 Phase 4")
+        }
+        _ => unreachable!("decode_line must be called with a Robot variant"),
+    }
+}
+
+/// Decode one R72 radio line into image[`line_index`].
+///
+/// R72 channel layout per slowrx `video.c:95-100` (default case for
+/// non-PD/non-Scottie/non-Robot-alt modes):
+///   `ChanLen[0..3]` = `pixel_seconds` * width   for each of Y, U, V
+///   `ChanStart[0]` = sync + porch
+///   `ChanStart[1]` = `ChanStart[0]` + `chan_len` + septr
+///   `ChanStart[2]` = `ChanStart[1]` + `chan_len` + septr
+///
+/// Reuses [`crate::mode_pd::decode_one_channel_into`] for per-channel
+/// FFT-based demod — that helper is mode-agnostic (reads
+/// `pixel_seconds` from `spec`, walks audio slice between channel
+/// bounds, fills a `&mut [u8]`).
+#[allow(
+    clippy::cast_precision_loss,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    clippy::cast_possible_wrap,
+    clippy::too_many_arguments
+)]
+fn decode_r72_line(
+    spec: ModeSpec,
+    line_index: u32,
+    audio: &[f32],
+    skip_samples: i64,
+    line_seconds_offset: f64,
+    rate_hz: f64,
+    image: &mut crate::image::SstvImage,
+    demod: &mut crate::mode_pd::PdDemod,
+    snr_est: &mut crate::snr::SnrEstimator,
+    hedr_shift_hz: f64,
+) {
+    let sync_secs = spec.sync_seconds;
+    let porch_secs = spec.porch_seconds;
+    let pixel_secs = spec.pixel_seconds;
+    let septr_secs = spec.septr_seconds;
+    let width = spec.line_pixels;
+    let chan_len = f64::from(width) * pixel_secs;
+
+    // R72 channel start times — translated from slowrx video.c:95-100
+    // (default case; R72 falls here, not in the named PD/Scottie/R36/R24
+    // cases).
+    let chan_starts_sec = [
+        sync_secs + porch_secs,                                     // Y
+        sync_secs + porch_secs + chan_len + septr_secs,             // U (Cr)
+        sync_secs + porch_secs + 2.0 * chan_len + 2.0 * septr_secs, // V (Cb)
+    ];
+
+    let width_us = width as usize;
+
+    // Channel sample-range bounds, computed once with a single
+    // `round()` per bound (matches slowrx video.c:140-142 to avoid
+    // per-pair rounding drift).
+    let chan_bounds_abs: [(i64, i64); 3] = std::array::from_fn(|i| {
+        let start_sec = chan_starts_sec[i];
+        let end_sec = start_sec + chan_len;
+        let start_abs = skip_samples + ((line_seconds_offset + start_sec) * rate_hz).round() as i64;
+        let end_abs = skip_samples + ((line_seconds_offset + end_sec) * rate_hz).round() as i64;
+        (start_abs, end_abs)
+    });
+
+    let mut y = vec![0_u8; width_us];
+    let mut cr = vec![0_u8; width_us];
+    let mut cb = vec![0_u8; width_us];
+
+    let buffers: [&mut [u8]; 3] = [&mut y, &mut cr, &mut cb];
+    for (chan_idx, buf) in buffers.into_iter().enumerate() {
+        crate::mode_pd::decode_one_channel_into(
+            buf,
+            chan_starts_sec[chan_idx],
+            chan_bounds_abs[chan_idx],
+            spec,
+            audio,
+            skip_samples,
+            line_seconds_offset,
+            rate_hz,
+            demod,
+            snr_est,
+            hedr_shift_hz,
+        );
+    }
+
+    for x in 0..width_us {
+        let rgb = crate::mode_pd::ycbcr_to_rgb(y[x], cr[x], cb[x]);
+        image.put_pixel(x as u32, line_index, rgb);
     }
 }

--- a/src/modespec.rs
+++ b/src/modespec.rs
@@ -3,12 +3,14 @@
 //! Translated from slowrx's `modespec.c` (Oona Räisänen, ISC License).
 //! See `NOTICE.md` for full attribution.
 //!
-//! Implemented as of V2.1 (0.2.0): PD120, PD180, PD240. Remaining V2 modes
-//! (Robot 36/72, Scottie 1/2/DX, Martin 1/2) are not yet present in the
-//! [`SstvMode`] enum or the lookup tables; each will land with its own PR.
+//! Implemented as of V2.2 (0.3.0): PD120, PD180, PD240, Robot 24, Robot 36,
+//! Robot 72. Remaining V2 modes (Scottie 1/2/DX, Martin 1/2) are not yet
+//! present in the [`SstvMode`] enum or the lookup tables; each will land
+//! with its own PR.
 
 /// SSTV operating mode. Implemented: [`SstvMode::Pd120`], [`SstvMode::Pd180`],
-/// [`SstvMode::Pd240`]. Additional V2 modes (Robot, Scottie, Martin) planned.
+/// [`SstvMode::Pd240`], [`SstvMode::Robot24`], [`SstvMode::Robot36`],
+/// [`SstvMode::Robot72`]. Additional V2 modes (Scottie, Martin) planned.
 #[non_exhaustive]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum SstvMode {
@@ -18,6 +20,12 @@ pub enum SstvMode {
     Pd180,
     /// PD-240 (640×496, ~240s per image)
     Pd240,
+    /// Robot 24 (320×240, ~24s per image)
+    Robot24,
+    /// Robot 36 (320×240, ~36s per image)
+    Robot36,
+    /// Robot 72 (320×240, ~72s per image)
+    Robot72,
 }
 
 /// Mode timing + layout table entry.
@@ -63,6 +71,12 @@ pub enum ChannelLayout {
     /// PD-family: Y(odd) → Cr → Cb → Y(even). One radio line carries
     /// two image rows; chroma is shared between paired rows.
     PdYcbcr,
+    /// Robot family: Y (single luma channel) plus chroma. R36/R24 carry
+    /// alternating Cr/Cb per radio line with each chroma sample
+    /// duplicated to the next image row; R72 carries Y/U/V sequentially
+    /// per line. The shape difference is mode-internal — see
+    /// `mode_robot::decode_line` for the per-mode dispatch.
+    RobotYuv,
 }
 
 /// Where the sync pulse sits within a radio line.
@@ -101,6 +115,9 @@ pub enum SyncPosition {
 #[must_use]
 pub fn lookup(vis_code: u8) -> Option<ModeSpec> {
     match vis_code {
+        0x04 => Some(ROBOT24),
+        0x08 => Some(ROBOT36),
+        0x0C => Some(ROBOT72),
         0x5F => Some(PD120),
         0x60 => Some(PD180),
         0x61 => Some(PD240),
@@ -119,11 +136,15 @@ pub fn for_mode(mode: SstvMode) -> ModeSpec {
         SstvMode::Pd120 => PD120,
         SstvMode::Pd180 => PD180,
         SstvMode::Pd240 => PD240,
+        SstvMode::Robot24 => ROBOT24,
+        SstvMode::Robot36 => ROBOT36,
+        SstvMode::Robot72 => ROBOT72,
     }
 }
 
 // Mode timing constants — translated row-for-row from slowrx's
-// modespec.c (PD120 lines 260-271, PD180 lines 286-297, PD240 lines 299-310).
+// modespec.c (PD120 lines 260-271, PD180 lines 286-297, PD240 lines 299-310,
+// R72 lines 130-141, R36 lines 143-154, R24 lines 156-167).
 
 const PD120: ModeSpec = ModeSpec {
     mode: SstvMode::Pd120,
@@ -166,6 +187,57 @@ const PD240: ModeSpec = ModeSpec {
     pixel_seconds: 0.000_382,
     septr_seconds: 0.0, // modespec.c: SeptrTime = 0e-3 for PD-family
     channel_layout: ChannelLayout::PdYcbcr,
+    sync_position: SyncPosition::LineStart,
+};
+
+const ROBOT24: ModeSpec = ModeSpec {
+    mode: SstvMode::Robot24,
+    vis_code: 0x04,
+    line_pixels: 320,
+    image_lines: 240,
+    // slowrx modespec.c:156-167 — R24 LineTime = 150e-3,
+    // PixelTime = 0.1375e-3, SyncTime = 9e-3, PorchTime = 3e-3,
+    // SeptrTime = 6e-3.
+    line_seconds: 0.150,
+    sync_seconds: 0.009,
+    porch_seconds: 0.003,
+    pixel_seconds: 0.000_137_5,
+    septr_seconds: 0.006,
+    channel_layout: ChannelLayout::RobotYuv,
+    sync_position: SyncPosition::LineStart,
+};
+
+const ROBOT36: ModeSpec = ModeSpec {
+    mode: SstvMode::Robot36,
+    vis_code: 0x08,
+    line_pixels: 320,
+    image_lines: 240,
+    // slowrx modespec.c:143-154 — R36 LineTime = 150e-3,
+    // PixelTime = 0.1375e-3, SyncTime = 9e-3, PorchTime = 3e-3,
+    // SeptrTime = 6e-3.  Identical timing to R24.
+    line_seconds: 0.150,
+    sync_seconds: 0.009,
+    porch_seconds: 0.003,
+    pixel_seconds: 0.000_137_5,
+    septr_seconds: 0.006,
+    channel_layout: ChannelLayout::RobotYuv,
+    sync_position: SyncPosition::LineStart,
+};
+
+const ROBOT72: ModeSpec = ModeSpec {
+    mode: SstvMode::Robot72,
+    vis_code: 0x0C,
+    line_pixels: 320,
+    image_lines: 240,
+    // slowrx modespec.c:130-141 — R72 LineTime = 300e-3,
+    // PixelTime = 0.2875e-3, SyncTime = 9e-3, PorchTime = 3e-3,
+    // SeptrTime = 4.7e-3.
+    line_seconds: 0.300,
+    sync_seconds: 0.009,
+    porch_seconds: 0.003,
+    pixel_seconds: 0.000_287_5,
+    septr_seconds: 0.0047,
+    channel_layout: ChannelLayout::RobotYuv,
     sync_position: SyncPosition::LineStart,
 };
 
@@ -220,12 +292,18 @@ mod tests {
     }
 
     #[test]
-    fn pd_modes_have_line_start_sync_position() {
+    fn all_v2_modes_have_line_start_sync_position() {
         // V2 carve-out: ModeSpec.sync_position lets V2.3 Scottie declare
-        // mid-line sync without retrofitting V1. PD120/PD180/PD240 all use
-        // line-start sync (slowrx video.c:88-92 places sync at the start of
-        // each line for PD modes).
-        for mode in [SstvMode::Pd120, SstvMode::Pd180, SstvMode::Pd240] {
+        // mid-line sync without retrofitting V1. PD/Robot/Martin all use
+        // line-start sync; Scottie is the V2.3 exception.
+        for mode in [
+            SstvMode::Pd120,
+            SstvMode::Pd180,
+            SstvMode::Pd240,
+            SstvMode::Robot24,
+            SstvMode::Robot36,
+            SstvMode::Robot72,
+        ] {
             let spec = for_mode(mode);
             assert_eq!(spec.sync_position, SyncPosition::LineStart);
         }
@@ -250,5 +328,60 @@ mod tests {
     #[test]
     fn for_mode_returns_pd240_spec() {
         assert_eq!(for_mode(SstvMode::Pd240).vis_code, 0x61);
+    }
+
+    #[test]
+    fn robot24_vis_code_resolves() {
+        let spec = lookup(0x04).expect("R24 VIS resolves");
+        assert_eq!(spec.mode, SstvMode::Robot24);
+        assert_eq!(spec.vis_code, 0x04);
+        assert_eq!(spec.line_pixels, 320);
+        assert_eq!(spec.image_lines, 240);
+        assert_eq!(spec.channel_layout, ChannelLayout::RobotYuv);
+        assert_eq!(spec.sync_position, SyncPosition::LineStart);
+        assert_eq!(spec.line_seconds, 0.150);
+        assert_eq!(spec.sync_seconds, 0.009);
+        assert_eq!(spec.porch_seconds, 0.003);
+        assert_eq!(spec.septr_seconds, 0.006);
+        assert_eq!(spec.pixel_seconds, 0.000_137_5);
+    }
+
+    #[test]
+    fn robot36_vis_code_resolves() {
+        let spec = lookup(0x08).expect("R36 VIS resolves");
+        assert_eq!(spec.mode, SstvMode::Robot36);
+        assert_eq!(spec.vis_code, 0x08);
+        assert_eq!(spec.line_pixels, 320);
+        assert_eq!(spec.image_lines, 240);
+        assert_eq!(spec.channel_layout, ChannelLayout::RobotYuv);
+        assert_eq!(spec.sync_position, SyncPosition::LineStart);
+        assert_eq!(spec.line_seconds, 0.150);
+        assert_eq!(spec.sync_seconds, 0.009);
+        assert_eq!(spec.porch_seconds, 0.003);
+        assert_eq!(spec.septr_seconds, 0.006);
+        assert_eq!(spec.pixel_seconds, 0.000_137_5);
+    }
+
+    #[test]
+    fn robot72_vis_code_resolves() {
+        let spec = lookup(0x0C).expect("R72 VIS resolves");
+        assert_eq!(spec.mode, SstvMode::Robot72);
+        assert_eq!(spec.vis_code, 0x0C);
+        assert_eq!(spec.line_pixels, 320);
+        assert_eq!(spec.image_lines, 240);
+        assert_eq!(spec.channel_layout, ChannelLayout::RobotYuv);
+        assert_eq!(spec.sync_position, SyncPosition::LineStart);
+        assert_eq!(spec.line_seconds, 0.300);
+        assert_eq!(spec.sync_seconds, 0.009);
+        assert_eq!(spec.porch_seconds, 0.003);
+        assert_eq!(spec.septr_seconds, 0.0047);
+        assert_eq!(spec.pixel_seconds, 0.000_287_5);
+    }
+
+    #[test]
+    fn for_mode_returns_robot_specs() {
+        assert_eq!(for_mode(SstvMode::Robot24).vis_code, 0x04);
+        assert_eq!(for_mode(SstvMode::Robot36).vis_code, 0x08);
+        assert_eq!(for_mode(SstvMode::Robot72).vis_code, 0x0C);
     }
 }

--- a/src/modespec.rs
+++ b/src/modespec.rs
@@ -63,8 +63,9 @@ pub struct ModeSpec {
     pub sync_position: SyncPosition,
 }
 
-/// Per-mode channel arrangement. PD-family modes use [`ChannelLayout::PdYcbcr`].
-/// Future V2 variants add their own values.
+/// Per-mode channel arrangement. PD-family modes use
+/// [`ChannelLayout::PdYcbcr`]; Robot family uses [`ChannelLayout::RobotYuv`].
+/// Future V2 mode families (Scottie, Martin) add their own values.
 #[non_exhaustive]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum ChannelLayout {
@@ -88,8 +89,9 @@ pub enum ChannelLayout {
 /// time, surfacing the V1 line-clock-advance assumption that sync ==
 /// line start.
 ///
-/// V1 + V2.1 only emit [`SyncPosition::LineStart`]; the `Scottie` variant
-/// lands with the V2.3 Scottie family epic.
+/// All currently-shipped modes (PD, Robot) emit
+/// [`SyncPosition::LineStart`]. The `Scottie` variant lands with the
+/// V2.3 Scottie family epic.
 #[non_exhaustive]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum SyncPosition {

--- a/src/robot_test_encoder.rs
+++ b/src/robot_test_encoder.rs
@@ -81,8 +81,7 @@ pub fn encode_robot(mode: SstvMode, ycrcb: &[[u8; 3]]) -> Vec<f32> {
     match mode {
         SstvMode::Robot72 => encode_r72(&mut out, &mut phase, &mut t, advance, &spec, ycrcb),
         SstvMode::Robot24 | SstvMode::Robot36 => {
-            // Filled in V2.2 Phase 4 (R36/R24 path).
-            unimplemented!("R36/R24 encoder lands in V2.2 Phase 4")
+            encode_r36_or_r24(&mut out, &mut phase, &mut t, advance, &spec, ycrcb);
         }
         _ => unreachable!(),
     }
@@ -128,6 +127,69 @@ fn encode_r72(
         for x in 0..w {
             let cb = ycrcb[(y * w + x) as usize][2];
             fill_to(out, lum_to_freq(cb), advance(t, spec.pixel_seconds), phase);
+        }
+    }
+}
+
+/// Robot 36 / Robot 24 channel layout per slowrx `video.c:60-70` (R36/R24 case):
+///   `ChanLen[0]` = `pixel_seconds` * width * 2   (Y allocated 2× per-channel time)
+///   `ChanLen[1]` = `ChanLen[2]` = `pixel_seconds` * width   (chroma at 1×)
+///   `ChanStart[0]` = sync + porch
+///   `ChanStart[1]` = `ChanStart[0]` + `ChanLen[0]` + septr
+///   `ChanStart[2]` = `ChanStart[1]`   (chroma channel time slot reused — actual
+///                                  channel determined by row parity)
+///
+/// Per radio line N, we emit:
+///   - Sync at `SYNC_HZ`
+///   - Porch at `PORCH_HZ`
+///   - Y for image row N at `pixel_seconds * 2` per pixel (so total Y
+///     duration = `pixel_seconds` * 2 * width = `ChanLen[0]`)
+///   - Septr at `PORCH_HZ`
+///   - Chroma for image row N at `pixel_seconds` per pixel: Cr if `N%2==0`,
+///     Cb if `N%2==1`
+#[allow(clippy::too_many_arguments)]
+fn encode_r36_or_r24(
+    out: &mut Vec<f32>,
+    phase: &mut f64,
+    t: &mut f64,
+    mut advance: impl FnMut(&mut f64, f64) -> usize,
+    spec: &crate::modespec::ModeSpec,
+    ycrcb: &[[u8; 3]],
+) {
+    let w = spec.line_pixels;
+    let h = spec.image_lines;
+    for y in 0..h {
+        // Sync + porch.
+        fill_to(out, SYNC_HZ, advance(t, spec.sync_seconds), phase);
+        fill_to(out, PORCH_HZ, advance(t, spec.porch_seconds), phase);
+
+        // Y channel — emit at `pixel_seconds * 2` per source pixel so
+        // the total Y allocation equals ChanLen[0] = pixel_seconds *
+        // width * 2 per slowrx video.c:60-70 (R36/R24 case).
+        for x in 0..w {
+            let lum = ycrcb[(y * w + x) as usize][0];
+            fill_to(
+                out,
+                lum_to_freq(lum),
+                advance(t, spec.pixel_seconds * 2.0),
+                phase,
+            );
+        }
+
+        // Septr between Y and chroma.
+        fill_to(out, PORCH_HZ, advance(t, spec.septr_seconds), phase);
+
+        // Chroma — Cr (ycrcb index 1) on even rows, Cb (ycrcb index 2)
+        // on odd. One sample per `pixel_seconds`.
+        let chroma_idx = if y % 2 == 0 { 1_usize } else { 2_usize };
+        for x in 0..w {
+            let chroma = ycrcb[(y * w + x) as usize][chroma_idx];
+            fill_to(
+                out,
+                lum_to_freq(chroma),
+                advance(t, spec.pixel_seconds),
+                phase,
+            );
         }
     }
 }

--- a/src/robot_test_encoder.rs
+++ b/src/robot_test_encoder.rs
@@ -128,6 +128,19 @@ fn encode_r72(
             let cb = ycrcb[(y * w + x) as usize][2];
             fill_to(out, lum_to_freq(cb), advance(t, spec.pixel_seconds), phase);
         }
+
+        // Pad to spec.line_seconds boundary. R72's per-line content
+        // (sync + porch + 3 channels + 2 septr) sums to ~297.4 ms but
+        // ModeSpec.line_seconds is 300 ms — the decoder advances at
+        // 300 ms per line. Without this pad, the synthetic audio drifts
+        // from the crate's own timing model and weakens the round-trip
+        // as a regression test. Fill the gap with PORCH_HZ (real radio
+        // emits a 1500 Hz tone during inter-line idle, not silence).
+        let line_end_target = f64::from(y + 1) * spec.line_seconds;
+        let pad_secs = line_end_target - *t;
+        if pad_secs > 0.0 {
+            fill_to(out, PORCH_HZ, advance(t, pad_secs), phase);
+        }
     }
 }
 

--- a/src/robot_test_encoder.rs
+++ b/src/robot_test_encoder.rs
@@ -1,0 +1,133 @@
+//! Synthetic Robot encoder for round-trip testing. Produces continuous-
+//! phase FM audio matching the encoder side of the SSTV protocol.
+//!
+//! Test-only — gated behind `cfg(any(test, feature = "test-support"))`.
+//! Lives in its own file so the production decoder stays under the
+//! 500-LOC ceiling.
+//!
+//! **R36/R24 round-trip constraint:** the source ycrcb buffer must have
+//! adjacent rows share chroma (`ycrcb[2k][1] == ycrcb[2k+1][1]` for Cr;
+//! `ycrcb[2k+1][2] == ycrcb[2k+2][2]` for Cb), because the decoder
+//! duplicates each chroma sample to the neighbor row (slowrx
+//! `video.c:424-425`). Source images that violate this constraint cannot
+//! round-trip losslessly. R72 has no such constraint (full per-line
+//! chroma).
+
+#![allow(
+    clippy::cast_precision_loss,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    clippy::cast_possible_wrap
+)]
+
+use crate::modespec::SstvMode;
+use crate::resample::WORKING_SAMPLE_RATE_HZ;
+use std::f64::consts::PI;
+
+const SYNC_HZ: f64 = 1200.0;
+const PORCH_HZ: f64 = 1500.0;
+const BLACK_HZ: f64 = 1500.0;
+const WHITE_HZ: f64 = 2300.0;
+
+fn lum_to_freq(lum: u8) -> f64 {
+    BLACK_HZ + (WHITE_HZ - BLACK_HZ) * f64::from(lum) / 255.0
+}
+
+/// Emit samples up to absolute sample index `target_n`, advancing phase.
+/// Cumulative-target pattern (matches `pd_test_encoder::fill_to`) so
+/// per-tone rounding doesn't compound across the line.
+fn fill_to(out: &mut Vec<f32>, freq_hz: f64, target_n: usize, phase: &mut f64) {
+    let dphi = 2.0 * PI * freq_hz / f64::from(WORKING_SAMPLE_RATE_HZ);
+    while out.len() < target_n {
+        out.push(phase.sin() as f32);
+        *phase += dphi;
+        if *phase > 2.0 * PI {
+            *phase -= 2.0 * PI;
+        }
+    }
+}
+
+/// Encode an image as Robot 24 / 36 / 72 audio. `ycrcb` is row-major
+/// `[Y, Cr, Cb]` triples of length `width * height`.
+///
+/// R72: emits Y / U / V sequentially per radio line, with septr between.
+/// R36/R24: emits Y / (Cr if y%2==0 else Cb) per radio line, with septr
+/// between Y and chroma. The decoder duplicates the chroma sample to
+/// the neighbor row, so the source ycrcb buffer must have adjacent rows
+/// share chroma (see file-level doc).
+#[must_use]
+#[doc(hidden)]
+#[allow(dead_code)]
+pub fn encode_robot(mode: SstvMode, ycrcb: &[[u8; 3]]) -> Vec<f32> {
+    assert!(matches!(
+        mode,
+        SstvMode::Robot24 | SstvMode::Robot36 | SstvMode::Robot72
+    ));
+    let spec = crate::modespec::for_mode(mode);
+    let w = spec.line_pixels;
+    let h = spec.image_lines;
+    assert_eq!(ycrcb.len() as u32, w * h);
+
+    let sr = f64::from(WORKING_SAMPLE_RATE_HZ);
+    let mut out = Vec::new();
+    let mut phase = 0.0_f64;
+
+    let mut t = 0.0_f64;
+    let advance = |t: &mut f64, secs: f64| -> usize {
+        *t += secs;
+        (*t * sr).round() as usize
+    };
+
+    match mode {
+        SstvMode::Robot72 => encode_r72(&mut out, &mut phase, &mut t, advance, &spec, ycrcb),
+        SstvMode::Robot24 | SstvMode::Robot36 => {
+            // Filled in V2.2 Phase 4 (R36/R24 path).
+            unimplemented!("R36/R24 encoder lands in V2.2 Phase 4")
+        }
+        _ => unreachable!(),
+    }
+
+    out
+}
+
+#[allow(clippy::too_many_arguments)]
+fn encode_r72(
+    out: &mut Vec<f32>,
+    phase: &mut f64,
+    t: &mut f64,
+    mut advance: impl FnMut(&mut f64, f64) -> usize,
+    spec: &crate::modespec::ModeSpec,
+    ycrcb: &[[u8; 3]],
+) {
+    let w = spec.line_pixels;
+    let h = spec.image_lines;
+    for y in 0..h {
+        // Sync + porch.
+        fill_to(out, SYNC_HZ, advance(t, spec.sync_seconds), phase);
+        fill_to(out, PORCH_HZ, advance(t, spec.porch_seconds), phase);
+
+        // Y channel.
+        for x in 0..w {
+            let lum = ycrcb[(y * w + x) as usize][0];
+            fill_to(out, lum_to_freq(lum), advance(t, spec.pixel_seconds), phase);
+        }
+
+        // Septr between Y and U (Cr).
+        fill_to(out, PORCH_HZ, advance(t, spec.septr_seconds), phase);
+
+        // U (Cr) channel.
+        for x in 0..w {
+            let cr = ycrcb[(y * w + x) as usize][1];
+            fill_to(out, lum_to_freq(cr), advance(t, spec.pixel_seconds), phase);
+        }
+
+        // Septr between U and V.
+        fill_to(out, PORCH_HZ, advance(t, spec.septr_seconds), phase);
+
+        // V (Cb) channel.
+        for x in 0..w {
+            let cb = ycrcb[(y * w + x) as usize][2];
+            fill_to(out, lum_to_freq(cb), advance(t, spec.pixel_seconds), phase);
+        }
+    }
+}

--- a/tests/ariss_fram2_validation.md
+++ b/tests/ariss_fram2_validation.md
@@ -15,11 +15,16 @@ dispatch.
 
    ```bash
    mkdir -p tests/fixtures/ariss-fram2
-   cd tests/fixtures/ariss-fram2
-   for n in 01 02 03 04 05 06 07 08 09 10 11 12; do
-     curl -O "https://ariss-usa.org/ARISS_SSTV/Fram2Test/Slide${n}.wav"
-     curl -O "https://ariss-usa.org/ARISS_SSTV/Fram2Test/Slide${n}-Robot-36-Color.jpg"
-   done
+   # Subshell so the `cd` doesn't leak into Step 2's `cargo build`.
+   (
+     cd tests/fixtures/ariss-fram2
+     for n in 01 02 03 04 05 06 07 08 09 10 11 12; do
+       # -f fail-on-HTTP-error (no bogus error-page files), -S show errors
+       # in -s mode, -L follow redirects, -O save with the URL's basename.
+       curl -fSLO "https://ariss-usa.org/ARISS_SSTV/Fram2Test/Slide${n}.wav"
+       curl -fSLO "https://ariss-usa.org/ARISS_SSTV/Fram2Test/Slide${n}-Robot-36-Color.jpg"
+     done
+   )
    ```
 
 2. Build slowrx-cli in release mode:

--- a/tests/ariss_fram2_validation.md
+++ b/tests/ariss_fram2_validation.md
@@ -1,0 +1,123 @@
+# ARISS Fram2 Real-Audio Validation Procedure
+
+The ARISS Fram2 mission (April 2025) used Robot 36 and ARISS-USA published 12
+reference WAV + JPG pairs for decoder validation:
+<https://ariss-usa.org/ARISS_SSTV/Fram2Test/>.
+
+This is the merge gate for V2.2 (Robot family decoding) and the regression
+net for any future change to `mode_robot.rs` or the `ChannelLayout::RobotYuv`
+dispatch.
+
+## Prerequisites
+
+1. Pull the 12 WAV + 12 JPG pairs into `tests/fixtures/ariss-fram2/`
+   (gitignored corpus — license unclear for redistribution):
+
+   ```bash
+   mkdir -p tests/fixtures/ariss-fram2
+   cd tests/fixtures/ariss-fram2
+   for n in 01 02 03 04 05 06 07 08 09 10 11 12; do
+     curl -O "https://ariss-usa.org/ARISS_SSTV/Fram2Test/Slide${n}.wav"
+     curl -O "https://ariss-usa.org/ARISS_SSTV/Fram2Test/Slide${n}-Robot-36-Color.jpg"
+   done
+   ```
+
+2. Build slowrx-cli in release mode:
+
+   ```bash
+   cargo build --release --features cli
+   ```
+
+## Run validation
+
+Decode all 12 WAVs and inspect each PNG against its reference JPG:
+
+```bash
+mkdir -p /tmp/fram2-validate
+for n in 01 02 03 04 05 06 07 08 09 10 11 12; do
+  ./target/release/slowrx-cli \
+    --input "tests/fixtures/ariss-fram2/Slide${n}.wav" \
+    --output "/tmp/fram2-validate/" 2>&1 | tail -2
+  # Rename so each output is identifiable
+  if [ -f "/tmp/fram2-validate/img-001-robot36.png" ]; then
+    mv "/tmp/fram2-validate/img-001-robot36.png" \
+       "/tmp/fram2-validate/Slide${n}-decoded.png"
+  fi
+done
+ls -la /tmp/fram2-validate/
+```
+
+Each WAV should produce: `1 VIS, 240 lines, 1 image(s)` and a PNG file.
+
+Open both directories in an image viewer and visually compare each
+`Slide${n}-decoded.png` against the reference
+`tests/fixtures/ariss-fram2/Slide${n}-Robot-36-Color.jpg`.
+
+## Acceptance criteria (visual match)
+
+For all 12 slides:
+
+1. **Recognizable image content.** The same scene appears in both —
+   subjects, text, shapes are identifiable.
+
+2. **Color accuracy within slowrx tolerances.** Hue and brightness
+   approximately match. Slight tonal drift is acceptable; obvious color
+   casts (everything blue / red / green) are NOT acceptable.
+
+3. **Geometric integrity.** Image dimensions are 320×240. The image
+   isn't distorted or shifted by many pixels. Slight slant (a few pixels
+   per line) is acceptable if the reference shows it too; large slant
+   is not.
+
+4. **No black/blank rows or columns.** Each row decoded should have
+   visible content. Occasional sync slips on noisy lines (1–2 per image)
+   are acceptable.
+
+If a slide fails any criterion above, do NOT merge V2.2. Investigate.
+
+## Common failure modes and where to look
+
+- **All 12 images upside-down or scrambled colors:** chroma channel
+  swap (Cr/Cb confusion) in `mode_robot::decode_r36_or_r24_line`. Check
+  the row-parity-to-chroma-channel mapping — slowrx C: even row → ch1
+  (Cr), odd row → ch2 (Cb).
+
+- **Pixel time off — image squished horizontally:** the `pixel_seconds * 2`
+  factor for the Y channel decode is wrong. Re-read slowrx
+  `video.c:60-70` R36/R24 case ChanLen[0] — should be PixelTime ×
+  Width × 2.
+
+- **Top row has wrong/missing color:** expected — image[0] never gets
+  Cb written (slowrx C does the same; chroma duplication propagates
+  forward only). If row 0 is solid green/blue, that's the zero-init Cb
+  showing through. Acceptable; documented in `mode_robot.rs::decode_r36_or_r24_line`.
+
+- **Decoder panics or crashes:** likely chroma-duplicate bounds guard
+  broken — `line_index + 1 == image_lines` should be a no-op. Check the
+  guard at `decode_r36_or_r24_line`.
+
+- **VIS not detected (`0 VIS`):** unlikely after V2.2 Phase 1 — but
+  re-run `cargo test --lib robot36_vis_code_resolves` to confirm the
+  modespec lookup is intact.
+
+## Pass/fail recording
+
+After validation, append a one-line note to `CHANGELOG.md` under the
+`[0.3.0]` section noting the date and the result. Example:
+
+> Validated against 12 ARISS Fram2 Robot 36 captures on 2026-05-XX —
+> all 12 produced visually-matching images.
+
+Or, if some failed and were fixed, document the iteration:
+
+> Validated against 12 ARISS Fram2 Robot 36 captures on 2026-05-XX
+> after one decoder fix (commit XXXXXXX).
+
+## Re-running this validation later
+
+Any change to `mode_robot.rs`, `mode_pd.rs::decode_one_channel_into`,
+`decoder.rs` dispatch, or `vis.rs` should re-run this procedure. The
+synthetic round-trip (`tests/roundtrip.rs`) is necessary but not
+sufficient — real-audio validation is the load-bearing check, per the
+project's "real-audio fixture match is a merge gate when fixtures are
+available" policy.

--- a/tests/ariss_fram2_validation.md
+++ b/tests/ariss_fram2_validation.md
@@ -92,6 +92,17 @@ If a slide fails any criterion above, do NOT merge V2.2. Investigate.
   forward only). If row 0 is solid green/blue, that's the zero-init Cb
   showing through. Acceptable; documented in `mode_robot.rs::decode_r36_or_r24_line`.
 
+- **Bottom half of every image is solid green / zero-init:** This was
+  the V2.2 Phase 5 surprise. Root cause: `target_audio_samples` formula
+  was unconditionally PD-style (`image_lines / 2 × line_seconds`),
+  which under-buffers Robot by half (Robot has no PD-style line
+  pairing). The decoder's find_sync triggered after only half the
+  audio was buffered; the bottom-half rows read past the end of
+  `d.audio` and got `Y=0`, which composes via `ycbcr_to_rgb(0,0,0)` to
+  the green `[0, 133, 0]` color. Fix: branch on `spec.channel_layout`
+  in `target_audio_samples` per slowrx C `video.c:251-254`. Landed in
+  commit `b0ad941`. If you see this again, the formula has regressed.
+
 - **Decoder panics or crashes:** likely chroma-duplicate bounds guard
   broken — `line_index + 1 == image_lines` should be a no-op. Check the
   guard at `decode_r36_or_r24_line`.

--- a/tests/ariss_fram2_validation.md
+++ b/tests/ariss_fram2_validation.md
@@ -33,21 +33,43 @@ dispatch.
 Decode all 12 WAVs and inspect each PNG against its reference JPG:
 
 ```bash
+set -e
 mkdir -p /tmp/fram2-validate
+# Clear any stale outputs from a previous run so a regressed re-run
+# can't look like 12/12 by leaving old PNGs in place.
+rm -f /tmp/fram2-validate/Slide*-decoded.png /tmp/fram2-validate/img-001-*.png
+
 for n in 01 02 03 04 05 06 07 08 09 10 11 12; do
-  ./target/release/slowrx-cli \
-    --input "tests/fixtures/ariss-fram2/Slide${n}.wav" \
-    --output "/tmp/fram2-validate/" 2>&1 | tail -2
-  # Rename so each output is identifiable
+  # Capture the CLI's stdout+stderr to a temp file so we can both display
+  # the last 2 lines AND check the exit status (piping through `tail`
+  # would mask the decoder's exit status).
+  log=$(mktemp)
+  if ! ./target/release/slowrx-cli \
+       --input "tests/fixtures/ariss-fram2/Slide${n}.wav" \
+       --output "/tmp/fram2-validate/" >"$log" 2>&1; then
+    echo "Slide${n}: slowrx-cli FAILED" >&2
+    tail -10 "$log" >&2
+    rm "$log"
+    exit 1
+  fi
+  tail -2 "$log"
+  rm "$log"
+  # Rename so each output is identifiable.
   if [ -f "/tmp/fram2-validate/img-001-robot36.png" ]; then
     mv "/tmp/fram2-validate/img-001-robot36.png" \
        "/tmp/fram2-validate/Slide${n}-decoded.png"
+  else
+    echo "Slide${n}: NO PNG PRODUCED" >&2
+    exit 1
   fi
 done
 ls -la /tmp/fram2-validate/
 ```
 
 Each WAV should produce: `1 VIS, 240 lines, 1 image(s)` and a PNG file.
+The script fails closed if any decode fails or any PNG is missing — a
+regressed re-run will exit non-zero, NOT silently leave stale PNGs that
+look like a 12/12 pass.
 
 Open both directories in an image viewer and visually compare each
 `Slide${n}-decoded.png` against the reference

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -145,7 +145,14 @@ fn run_robot_roundtrip(mode: SstvMode) {
     audio.extend(slowrx::__test_support::mode_robot::encode_robot(
         mode, &ycrcb,
     ));
-    audio.extend(std::iter::repeat_n(0.0_f32, 2048));
+    // R72 has ~2.6 ms per-line gap (line_seconds - actual content); over
+    // 240 lines that's ~624 ms = ~6.9k samples short of the decoder's
+    // target_audio_samples threshold (= image_lines × line_seconds).
+    // Pad enough to reach the threshold + a little group-delay headroom.
+    // R36/R24 have no per-line gap (their content fills line_seconds
+    // exactly) so this pad is harmless for them. PD's helper uses 2048;
+    // Robot needs more.
+    audio.extend(std::iter::repeat_n(0.0_f32, 8192));
 
     let mut d = SstvDecoder::new(WORKING_SAMPLE_RATE_HZ).expect("decoder");
     let events = d.process(&audio);

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -203,3 +203,13 @@ fn pd240_roundtrip() {
 fn robot72_roundtrip() {
     run_robot_roundtrip(SstvMode::Robot72);
 }
+
+#[test]
+fn robot36_roundtrip() {
+    run_robot_roundtrip(SstvMode::Robot36);
+}
+
+#[test]
+fn robot24_roundtrip() {
+    run_robot_roundtrip(SstvMode::Robot24);
+}

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -99,6 +99,91 @@ fn run_roundtrip(mode: SstvMode) {
     assert!(mean < 5.0, "{mode:?}: max_diff={max_diff} mean={mean:.2}");
 }
 
+/// Build a synthetic Robot test image: gradient luma + smooth chroma
+/// stripes designed so adjacent rows share chroma (required for R36/R24
+/// round-trip — see `robot_test_encoder.rs` doc; harmless for R72).
+#[allow(
+    clippy::cast_precision_loss,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss
+)]
+fn test_robot_image(mode: SstvMode) -> (u32, u32, Vec<[u8; 3]>) {
+    let spec = slowrx::for_mode(mode);
+    let w = spec.line_pixels;
+    let h = spec.image_lines;
+    let mut ycrcb = Vec::with_capacity((w * h) as usize);
+    for y in 0..h {
+        for x in 0..w {
+            let lum = ((f64::from(x)) / (f64::from(w)) * 255.0) as u8;
+            // Cr alternates every 4 rows (so adjacent even-odd Y row
+            // pairs share Cr — required for R36/R24 round-trip).
+            // Cb alternates every 4 rows offset by 1 (so adjacent
+            // odd-even pairs share Cb — also required for R36/R24).
+            let cr = if y % 4 < 2 { 200 } else { 56 };
+            let cb = if (y + 1) % 4 < 2 { 200 } else { 56 };
+            ycrcb.push([lum, cr, cb]);
+        }
+    }
+    (w, h, ycrcb)
+}
+
+#[allow(
+    clippy::cast_precision_loss,
+    clippy::cast_possible_wrap,
+    clippy::cast_sign_loss
+)]
+fn run_robot_roundtrip(mode: SstvMode) {
+    let (w, h, ycrcb) = test_robot_image(mode);
+
+    let vis_code = match mode {
+        SstvMode::Robot24 => 0x04,
+        SstvMode::Robot36 => 0x08,
+        SstvMode::Robot72 => 0x0C,
+        _ => unreachable!(),
+    };
+    let mut audio = slowrx::__test_support::vis::synth_vis(vis_code, 0.0);
+    audio.extend(slowrx::__test_support::mode_robot::encode_robot(
+        mode, &ycrcb,
+    ));
+    audio.extend(std::iter::repeat_n(0.0_f32, 2048));
+
+    let mut d = SstvDecoder::new(WORKING_SAMPLE_RATE_HZ).expect("decoder");
+    let events = d.process(&audio);
+
+    let img = events
+        .iter()
+        .find_map(|e| match e {
+            SstvEvent::ImageComplete {
+                image,
+                partial: false,
+            } => Some(image.clone()),
+            _ => None,
+        })
+        .expect("ImageComplete event");
+
+    assert_eq!(img.mode, mode);
+    assert_eq!(img.width, w);
+    assert_eq!(img.height, h);
+
+    let mut max_diff = 0_u8;
+    let mut sum_diff: u64 = 0;
+    let mut n: u64 = 0;
+    for (i, src) in ycrcb.iter().enumerate() {
+        let src_rgb = slowrx::__test_support::mode_pd::ycbcr_to_rgb(src[0], src[1], src[2]);
+        let dec = img.pixels[i];
+        for ch in 0..3 {
+            let d = (i32::from(src_rgb[ch]) - i32::from(dec[ch])).unsigned_abs() as u8;
+            if d > max_diff {
+                max_diff = d;
+            }
+            sum_diff += u64::from(d);
+            n += 1;
+        }
+    }
+    let mean = sum_diff as f64 / n as f64;
+    assert!(mean < 5.0, "{mode:?}: max_diff={max_diff} mean={mean:.2}");
+}
+
 #[test]
 fn pd120_roundtrip() {
     run_roundtrip(SstvMode::Pd120);
@@ -112,4 +197,9 @@ fn pd180_roundtrip() {
 #[test]
 fn pd240_roundtrip() {
     run_roundtrip(SstvMode::Pd240);
+}
+
+#[test]
+fn robot72_roundtrip() {
+    run_robot_roundtrip(SstvMode::Robot72);
 }


### PR DESCRIPTION
## Summary

- Adds **Robot 24, Robot 36, Robot 72** SSTV modes (VIS codes 0x04 / 0x08 / 0x0C). Timing constants byte-translated from slowrx `modespec.c:130-167`. R36/R24 use 2-channel layout (Y at 2× pixel-time + alternating Cr/Cb with neighbor-row duplication per slowrx `video.c:421-425`); R72 uses the simpler 3-channel sequential layout per `video.c:60-101` default case.
- Introduces the **first cross-mode-family dispatch refactor** in `decoder.rs`. PD path is byte-identical to V2.1 (zero PD120/180/240 regression risk).
- New **`src/mode_robot.rs`** decoder. Reuses `mode_pd::decode_one_channel_into` (visibility bumped to `pub(crate)`; parameter renamed from PD-specific `pair_seconds` to mode-agnostic `time_offset_seconds`) and `mode_pd::ycbcr_to_rgb`.
- New **`src/robot_test_encoder.rs`** synthetic encoder. Three new round-trip tests (`robot{24,36,72}_roundtrip`) at the same `mean < 5.0` threshold as PD.
- New **`chroma_planes: Option<[Vec<u8>; 2]>`** field on `DecodingState` for R36/R24's deferred RGB composition (own + duplicated-from-neighbor chroma).
- **Real-audio merge gate satisfied:** all 12 ARISS Fram2 reference WAVs decode to PNGs that visually match the 12 reference JPGs. Procedure committed at `tests/ariss_fram2_validation.md`.

## Bugs caught + fixed pre-merge

- **`mode_tag` in `slowrx_cli.rs` missing Robot arms** (V2.1 PD240 trap recurrence) — caught by Phase 2 spec reviewer, fixed in commit `f2e4716`.
- **`target_audio_samples` was unconditionally PD-style** (`image_lines / 2 × line_seconds`) — caused real-radio Robot to decode only the top half of every image. **Caught during Phase 5 Fram2 validation** (synthetic round-trip couldn't expose it). Fixed in commit `b0ad941`. Mirrors slowrx C `video.c:251-254` exactly.
- Final-reviewer follow-up: stale `src/lib.rs` Status block (V2.1 trap recurrence again), missing CHANGELOG `[#70]` link target, missing `target_audio_samples` history in the validation doc — all fixed in commit `c5477bf`.

## Known gaps tracked for future work

- **Faint vertical squiggle artifacts in real-radio output** (not in reference JPGs). Tracked at #71. Investigation paths: re-engage SNR-adaptive Hann selector (V1 #44), slowrx C cross-validation, sub-bin interpolation. Not blocking V2.2 — image content is correct.
- **R72 over-allocates 150 KiB chroma_planes** (M-1 from final review). Acceptable; proper fix needs broader DecodingState restructuring.
- **Robot 24 ships without R24-specific real-audio evidence**, inheriting R36's validation by structural identity (only mode tag + VIS code differ).
- **Robot 72 ships with synthetic-only coverage**; real-radio fixture pending — tracked at #70.

Spec: [`docs/superpowers/specs/2026-05-02-v2.2-robot-design.md`](docs/superpowers/specs/2026-05-02-v2.2-robot-design.md)
Plan: [`docs/superpowers/plans/2026-05-02-v2.2-robot.md`](docs/superpowers/plans/2026-05-02-v2.2-robot.md)

Closes #64 (V2.2 epic). Tracks #9 (V2 umbrella).

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features --locked` — all tests pass (94 lib unit + 6 round-trip + 1 cli + 1 doctest = 102 total; new: 3 Robot round-trips, 3 Robot VIS-detection tests, 4 Robot modespec tests, generalized `all_v2_modes_have_line_start_sync_position`)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`
- [x] `cargo llvm-cov --all-features --summary-only` — every library file ≥ 92 % line coverage. New files `mode_robot.rs` (99.48 %) and `robot_test_encoder.rs` (98.98 %) ship well above gate.
- [x] `cargo publish --dry-run --features cli --allow-dirty` — packages 23 files, 278.8 KiB → 84.3 KiB compressed, verifies clean.
- [x] **Real-audio Fram2 validation** — all 12 reference WAVs decode to visually-matching PNGs per `tests/ariss_fram2_validation.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added end-to-end support for Robot 24 / Robot 36 / Robot 72 SSTV decoding and image output, including CLI output tagging for Robot modes.

* **Documentation**
  * Updated README, CHANGELOG, specs/plans and intentional-deviations with Robot-family coverage, known timing/chroma caveats, and a real-audio validation guide.

* **Tests**
  * Added synthetic round-trip and VIS-detection tests for Robot modes and a real-audio validation procedure against ARISS Fram2 captures.

* **Chores**
  * Bumped package version to v0.3.0 and updated .gitignore to ignore local test fixtures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->