### PR TITLE
fix(0.3.1): three post-V2.2 follow-ups (chroma_planes, septr test, LineDecoded doc)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1] - 2026-05-02
+
+Patch release bundling three small follow-up items from V2.2 review
+cycles (no functional changes; pure cleanup).
+
+### Fixed
+
+- **`chroma_planes` over-allocation for R72.** `DecodingState` was
+  allocating ~150 KiB of cross-radio-line chroma side buffer for any
+  `ChannelLayout::RobotYuv` mode, but R72 composes RGB in-place and
+  never reads the planes. Now allocated only for R24/R36 (where chroma
+  duplication actually requires the side buffer). Saves ~150 KiB per
+  R72 decode.
+
+### Changed
+
+- **`pd_modes_have_zero_septr_seconds` test extended to cover Pd240.**
+  Pre-existing gap from V2.1 — the test was never extended after Pd240
+  was added. Robot has non-zero `septr_seconds` so the PD-family
+  invariant doesn't generalize to it; the test stays PD-specific.
+
+### Documentation
+
+- **`SstvEvent::LineDecoded` rustdoc** now documents the R36/R24
+  partial-chroma emission semantics: row 0's Cb is at zero-init when
+  LineDecoded fires (no previous radio line to duplicate from);
+  faithful to slowrx C's `calloc`'d image buffer behavior. Final
+  `ImageComplete` carries the populated buffer.
+
 ## [0.3.0] - 2026-05-02
 
 V2.2 — Robot family mode coverage. Adds Robot 24 (`SstvMode::Robot24`,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -707,7 +707,7 @@ checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "slowrx"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slowrx"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 rust-version = "1.85"
 description = "Pure-Rust SSTV (Slow-Scan TV) decoder library — a port of slowrx by Oona Räisänen"

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -112,17 +112,22 @@ struct DecodingState {
     target_audio_samples: usize,
     /// Per-mode chroma planes side buffer.
     ///
-    /// `None` for `ChannelLayout::PdYcbcr` (PD composes RGB in-place per
-    /// pair — see `mode_pd::decode_pd_line_pair`).
-    ///
-    /// `Some([cr_plane, cb_plane])` for `ChannelLayout::RobotYuv`. Each
-    /// plane is `image_lines * line_pixels` bytes, populated as radio
-    /// lines are decoded. R72 doesn't actually use these (composes RGB
-    /// in-place like PD), but R36/R24 need them: each radio line N
+    /// `Some([cr_plane, cb_plane])` for `SstvMode::Robot24` and
+    /// `SstvMode::Robot36`. Each plane is `image_lines * line_pixels`
+    /// bytes, populated as radio lines are decoded: each radio line N
     /// writes its own chroma + duplicates to the next row's chroma slot
     /// (slowrx `video.c:421-425`); RGB composition for row N reads the
     /// duplicated-from-N-1 chroma channel that the line N-1 decode
     /// wrote earlier.
+    ///
+    /// `None` for every other mode. PD composes RGB in-place per pair
+    /// (see `mode_pd::decode_pd_line_pair`); Robot 72 also composes
+    /// in-place (3-channel sequential — see
+    /// `mode_robot::decode_r72_line`), so it doesn't need the side
+    /// buffer either. `SstvMode` is `#[non_exhaustive]`; future modes
+    /// with cross-radio-line chroma state (e.g., Scottie in V2.3 if it
+    /// turns out to need similar plumbing) will need to extend the
+    /// constructor's match in `process` to opt in.
     chroma_planes: Option<[Vec<u8>; 2]>,
 }
 

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -33,6 +33,22 @@ pub enum SstvEvent {
         hedr_shift_hz: f64,
     },
     /// One scan line completed (callers may render incrementally).
+    ///
+    /// For PD and Robot 72: `pixels` is fully composed at emission time
+    /// (own Y/U/V or Y(odd)/Cr/Cb/Y(even) for the row).
+    ///
+    /// For Robot 36 / Robot 24: `pixels` reflects the image buffer state
+    /// at emission time, which has a transient cross-row dependency due
+    /// to chroma alternation. Each radio line writes its own Cr-or-Cb
+    /// AND duplicates that chroma to the NEXT image row. So row N is
+    /// emitted with: own Y, own Cr-or-Cb (per row parity), and the
+    /// OTHER chroma channel duplicated from the previous radio line.
+    /// Row 0 is the exception — its `Cb` channel is zero-init at
+    /// emission time (no row -1 to duplicate from), giving a transient
+    /// color cast on the very top row. Faithful to slowrx C, which
+    /// `calloc`'s its image buffer and never writes row 0's Cb.
+    /// `ImageComplete` carries the final populated state for all rows
+    /// `1..image_lines` and the same row-0 Cb-zero artifact.
     LineDecoded {
         /// Mode currently being decoded.
         mode: SstvMode,
@@ -240,13 +256,20 @@ impl SstvDecoder {
                                 sync_tracker: SyncTracker::new(detected.hedr_shift_hz),
                                 hedr_shift_hz: detected.hedr_shift_hz,
                                 target_audio_samples: target,
-                                chroma_planes: match spec.channel_layout {
-                                    crate::modespec::ChannelLayout::PdYcbcr => None,
-                                    crate::modespec::ChannelLayout::RobotYuv => {
+                                chroma_planes: match spec.mode {
+                                    SstvMode::Robot24 | SstvMode::Robot36 => {
                                         let n = (spec.image_lines as usize)
                                             * (spec.line_pixels as usize);
                                         Some([vec![0_u8; n], vec![0_u8; n]])
                                     }
+                                    // PD modes compose RGB per-pair in place. Robot 72 also composes
+                                    // in-place (3-channel sequential — see mode_robot::decode_r72_line),
+                                    // so it doesn't need chroma_planes either; only the R36/R24 chroma-
+                                    // alternation + duplication path requires the side buffer.
+                                    // SstvMode is #[non_exhaustive], so the wildcard arm is required;
+                                    // V2.3 will need to revisit if Scottie introduces similar cross-line
+                                    // state requirements (the spec.sync_position field is the trigger).
+                                    _ => None,
                                 },
                             }));
                             continue; // re-enter loop to process leftover audio

--- a/src/modespec.rs
+++ b/src/modespec.rs
@@ -289,8 +289,10 @@ mod tests {
         // modes it must be zero so chan_starts_sec is numerically unchanged.
         let pd120 = lookup(0x5F).expect("PD120");
         let pd180 = lookup(0x60).expect("PD180");
+        let pd240 = lookup(0x61).expect("PD240");
         assert_eq!(pd120.septr_seconds, 0.0);
         assert_eq!(pd180.septr_seconds, 0.0);
+        assert_eq!(pd240.septr_seconds, 0.0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Patch release bundling the three follow-up items the V2.2 review cycles flagged but didn't block on. Pure cleanup, no functional decoder changes.

### 1. `chroma_planes` over-allocation for R72 (V2.2 final review M-1)

`DecodingState` was allocating `Some([cr_plane, cb_plane])` (~150 KiB at 320×240) for any `ChannelLayout::RobotYuv` mode, but R72 composes RGB in-place and never reads the planes. Only R36/R24 need the side buffer for chroma-duplication state. Tightened the constructor to dispatch on `spec.mode` (matching `Robot24 | Robot36` only) instead of `spec.channel_layout`. Wildcard arm covers PD (`None`) and R72 (`None`); future modes default to `None` until they explicitly need cross-line chroma state.

Saves ~150 KiB per R72 decode. All 6 round-trips (PD120/180/240 + R24/36/72) still pass — verified locally.

### 2. `pd_modes_have_zero_septr_seconds` test extended for Pd240 (V2.1 final review M-3 carry-over)

Pre-existing gap from V2.1 — the test was never extended after Pd240 landed. The test asserts a PD-family-specific property (Robot has non-zero `septr_seconds`); it stays PD-only by design.

### 3. `LineDecoded` rustdoc note for R36/R24 partial-chroma emission (V2.2 P2 code review forward-looking)

Public-API consumers rendering each `LineDecoded` event live need to know that for R36/R24, row 0's Cb is at zero-init when LineDecoded fires (no row -1 to duplicate from — faithful to slowrx C's `calloc`'d image buffer). Final `ImageComplete` carries the populated state for rows 1..image_lines.

## Sequence

- **0.3.1 (this PR)** — these three follow-ups
- **0.3.2** — #71 (squiggle artifacts vs reference, parity with slowrx C)
- **0.3.3** — #70 (out-of-scope backlog)
- **0.4.0** — V2.3 Scottie family

Closes nothing on its own — V2.2 epic #64 already closed when PR #72 merged. This is residual cleanup.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features --locked` — all tests pass; **6 round-trips green** (PD120/180/240 + R24/36/72)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features` — clean
- [x] Verified R72 round-trip still passes after the chroma_planes change (its `let _ = chroma_planes;` correctly handles the new `None`)
- [x] Verified R24/R36 round-trips still pass (constructor's `Robot24 | Robot36` arm correctly populates `Some(...)`)

## Process notes

Two commits on the branch (matching V2.1's 0.2.1 patch shape): one fix commit bundling all three items, one chore(release) commit bumping Cargo.toml + CHANGELOG. Implementation followed the same `superpowers:subagent-driven-development` ceremony as V2.2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced excessive memory allocation for certain color-space configurations, lowering resource usage.

* **Documentation**
  * Clarified decoded-image output behavior across modes, including partial-chroma emission and row-zero initialization semantics.

* **Tests**
  * Extended test coverage to validate PD-family mode parameters for an additional format.

* **Chores**
  * Bumped package version to 0.3.1 and added an Unreleased/0.3.1 changelog entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->