### PR TITLE
feat(snr): bump FFT_LEN 256 → 1024 for 4× finer Hz/bin (0.3.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,76 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.3] - 2026-05-03
+
+Patch release bumping `crate::snr::FFT_LEN` from 256 to 1024 to give
+4× finer Hz/bin (10.77 vs 43.07) for the per-pixel demod and SNR
+estimator. Validated visually on the 12 ARISS Fram2 R36 reference
+WAVs as noticeably clearer pixel content vs. the 0.3.2 baseline. The
+squiggle artifacts ([#71]) are unaffected by this change — they're a
+separate concern, tracked through 0.3.5+.
+
+The pixel-diff comparator earmarked for 0.3.3 in [#70] moves to a
+later patch.
+
+[#70]: https://github.com/jasonherald/slowrx.rs/issues/70
+[#71]: https://github.com/jasonherald/slowrx.rs/issues/71
+
+### Changed
+
+- **`crate::snr::FFT_LEN`** bumped from 256 to 1024. The bump produces
+  two coupled DSP changes:
+  - **Per-pixel demod** gets 4× finer bin density only.
+    `crate::snr::HANN_LENS` is unchanged at slowrx-C-divided-by-4
+    (`[12, 16, 24, 32, 64, 128, 256]`), so the Hann is applied to the
+    first `HANN_LENS[idx]` samples of the FFT input and the rest is
+    zero-padded — time-domain support identical to slowrx C, only the
+    FFT bin density changes.
+  - **SNR estimator** gets a 4× longer Hann window. `hann_long =
+    build_hann(FFT_LEN)` scales with `FFT_LEN`, so the SNR estimator's
+    integration window grows from ~23 ms (= slowrx C) to ~93 ms. This
+    gives a cleaner SNR estimate and likely reduces window-selector
+    flip-flop beyond what the 0.3.2 hysteresis already delivers.
+- **`mode_pd::FFT_LEN`** is a re-export of `snr::FFT_LEN`, so it picks
+  up the new value automatically.
+- **`snr_bandwidth_correction_bins_match_slowrx`** test renamed to
+  `snr_bandwidth_correction_bins_at_finer_resolution` and re-asserted
+  with the post-bump bin counts (75 / 104 / 278). The test still
+  guards the `get_bin` floor-truncation math; it no longer asserts
+  slowrx-C-parity in `usize` terms.
+
+### Documentation
+
+- New `docs/intentional-deviations.md` entry: "FFT frequency
+  resolution exceeds slowrx C by 4×". Documents both coupled
+  deviations (per-pixel bin density and SNR-estimator window length),
+  the rationale (visibly clearer real-radio output), and three
+  triggers for revisiting.
+- In-source rustdoc comments referencing `FFT_LEN=256` updated to
+  `FFT_LEN=1024` (in `src/snr.rs` and `src/mode_pd.rs`). Stale claims
+  about `HANN_LENS[6]` matching `FFT_LEN` and `hann_long` being
+  shared with the bank were dropped — they're now different lengths
+  (256 and 1024 respectively).
+
+### Validation
+
+- All 6 synthetic round-trips (PD120/180/240, R24/36/72) pass at the
+  unchanged `mean < 5.0` per-pixel-RGB-diff threshold.
+- Real-audio Fram2 visual validation: all 12 slides reproduce the
+  experiment-branch "WAY clearer but still squiggles" finding versus
+  the 0.3.2 baseline.
+- Wall-clock decode of one Fram2 R36 slide: 0.614 s on v0.3.2 (avg
+  of 3 runs) → 1.223 s on 0.3.3 (~2× slower; negligible since R36
+  transmits over ~36 s).
+
+### Notes
+
+- The squiggle artifacts in real-radio Fram2 output ([#71]) are
+  reduced (per 0.3.2 hysteresis) but still present. The two new
+  diagnostic patterns observed during 0.3.2 validation
+  (black-background dependence, top/bottom asymmetry) motivate the
+  next investigation pass; they are 0.3.4+ work.
+
 ## [0.3.2] - 2026-05-02
 
 Patch release adding 1 dB SNR hysteresis to the adaptive Hann window

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -707,7 +707,7 @@ checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "slowrx"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slowrx"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2021"
 rust-version = "1.85"
 description = "Pure-Rust SSTV (Slow-Scan TV) decoder library — a port of slowrx by Oona Räisänen"

--- a/docs/intentional-deviations.md
+++ b/docs/intentional-deviations.md
@@ -349,3 +349,62 @@ Three triggers would prompt revisiting:
 3. **A future audit cross-validates pixel-by-pixel against slowrx C
    output on the same WAV** and finds slowrx's pure-threshold behavior
    matters in some specific way. Unlikely but possible.
+
+---
+
+## FFT frequency resolution exceeds slowrx C by 4×
+
+**Files:** `src/snr.rs::FFT_LEN`, `src/mode_pd.rs::FFT_LEN` ↔ slowrx `video.c::FFTLen`.
+**Tracking issue:** [#71](https://github.com/jasonherald/slowrx.rs/issues/71) (squiggle context).
+**Shipped in:** 0.3.3.
+
+### What slowrx does
+
+slowrx C uses `FFTLen = 1024` at `44_100` Hz, giving
+`44100 / 1024 ≈ 43.07` Hz/bin frequency resolution for the per-pixel
+demod and SNR estimator (`video.c:303-340, 369-395`).
+
+### What we do
+
+We use `FFT_LEN = 1024` at [`crate::resample::WORKING_SAMPLE_RATE_HZ`]
+= `11_025` Hz, giving `11025 / 1024 ≈ 10.77` Hz/bin —
+**4× finer than slowrx C**.
+
+`crate::snr::HANN_LENS` is unchanged at `[12, 16, 24, 32, 64, 128, 256]`
+(slowrx's `[48, 64, 96, 128, 256, 512, 1024]` divided by 4) so the
+time-domain analysis is identical to slowrx C. The FFT input is
+naturally zero-padded outside the Hann support, giving us 4× more
+output bins on the same windowed signal.
+
+### Why we deviated
+
+0.3.2 shipped a 1 dB SNR hysteresis band as a partial fix for the
+real-radio squiggle artifacts ([#71]). Hysteresis reduced but didn't
+eliminate the squiggles. While CodeRabbit reviewed PR #74, a
+parallel experiment branch tested bumping `FFT_LEN` to 1024. Result
+on the 12 ARISS Fram2 R36 reference WAVs: synthetic round-trips all
+passed at the unchanged `mean < 5.0` threshold, and visual inspection
+showed **noticeably clearer pixel content** vs. the 0.3.2 baseline
+(by-eye comparison; the user judged it "WAY clearer").
+
+The squiggle artifacts themselves were unchanged — that's a separate
+concern tracked in [#71]. The finer Hz/bin is a complementary DSP
+improvement that's worth shipping on its own.
+
+[#71]: https://github.com/jasonherald/slowrx.rs/issues/71
+
+### When to revisit
+
+1. **Squiggle root cause turns out to require coarser FFT.** Unlikely
+   given the 0.3.2 hypothesis (SNR-cadence flip-flop) was unaffected
+   by FFT_LEN. But if a future audit finds an FFT-resolution-dependent
+   artifact, this is the knob.
+2. **CPU cost becomes an issue.** The 4× FFT compute per call is
+   negligible at SSTV's per-pixel cadence. If a future profile shows
+   the per-pixel FFT dominating wall-clock time on resource-constrained
+   targets, consider reverting or adding a `cli`-feature-gated coarse
+   mode.
+3. **A future audit cross-validates pixel-by-pixel against slowrx C
+   output** and finds slowrx's `usize` bin counts matter in some
+   specific way. Unlikely — bandwidth integration is in Hz domain —
+   but possible.

--- a/docs/intentional-deviations.md
+++ b/docs/intentional-deviations.md
@@ -370,11 +370,31 @@ We use `FFT_LEN = 1024` at [`crate::resample::WORKING_SAMPLE_RATE_HZ`]
 = `11_025` Hz, giving `11025 / 1024 ≈ 10.77` Hz/bin —
 **4× finer than slowrx C**.
 
-`crate::snr::HANN_LENS` is unchanged at `[12, 16, 24, 32, 64, 128, 256]`
-(slowrx's `[48, 64, 96, 128, 256, 512, 1024]` divided by 4) so the
-time-domain analysis is identical to slowrx C. The FFT input is
-naturally zero-padded outside the Hann support, giving us 4× more
-output bins on the same windowed signal.
+The bump produces two coupled DSP changes:
+
+1. **Per-pixel demod (`mode_pd::PdDemod::pixel_freq`)**: 4× finer
+   bin density only. `HANN_LENS` is unchanged at
+   `[12, 16, 24, 32, 64, 128, 256]` (slowrx's
+   `[48, 64, 96, 128, 256, 512, 1024]` divided by 4) so the Hann is
+   applied to the first `HANN_LENS[idx]` samples of the FFT input
+   and the rest is zero-padded — time-domain support identical to
+   slowrx C, only the FFT bin density changes.
+2. **SNR estimator (`SnrEstimator::estimate`)**: the long Hann window
+   `hann_long = build_hann(FFT_LEN)` scales with `FFT_LEN`, so it
+   grows from 256 samples (~23 ms at 11_025 Hz, matching slowrx C) to
+   1024 samples (~93 ms, 4× longer than slowrx C). The SNR estimator
+   therefore integrates over a 4× longer time window. This is a
+   second, real deviation that comes "for free" with the FFT_LEN
+   bump and is desirable: the longer integration produces a cleaner
+   SNR estimate, which in turn reduces flip-flop in the
+   adaptive-Hann selector beyond what the 0.3.2 hysteresis already
+   delivers.
+
+Both effects were validated together on the parallel experiment
+branch and contribute to the "WAY clearer" visual finding on the
+12 ARISS Fram2 R36 reference WAVs. We do not attempt to decouple
+them — the longer SNR-estimator window is part of the package, not
+a regression to mitigate.
 
 ### Why we deviated
 

--- a/docs/superpowers/plans/2026-05-03-v0.3.3-fft-resolution.md
+++ b/docs/superpowers/plans/2026-05-03-v0.3.3-fft-resolution.md
@@ -1,0 +1,858 @@
+# 0.3.3 FFT Frequency Resolution Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bump `crate::snr::FFT_LEN` from 256 to 1024, giving 4× finer Hz/bin (10.77 vs 43.07). Validated visually on 12 ARISS Fram2 WAVs as "WAY clearer." Ship as `slowrx 0.3.3`.
+
+**Architecture:** Single source change in `src/snr.rs:20`. `HANN_LENS` unchanged at `[12, 16, 24, 32, 64, 128, 256]` so time-domain analysis is preserved identical to slowrx C. The FFT input is naturally zero-padded outside the Hann support (already handled — both SNR estimator and per-pixel demod explicitly zero-fill `fft_buf` before writing the windowed signal). One unit test (`snr_bandwidth_correction_bins_match_slowrx`) is renamed and re-asserted with the post-bump bin counts (slowrx-C-parity in `usize` is lost; Hz-domain bandwidth is preserved). Adjacent doc comments that bake in `256` as a literal value are refreshed.
+
+**Tech Stack:** Rust 2021 (MSRV 1.85), `rustfft`, `thiserror`. CI runs `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --all-features --locked`, `RUSTDOCFLAGS=-D warnings cargo doc --no-deps --all-features`. Release: `cargo publish --features cli --allow-dirty`. GitHub via `gh` CLI.
+
+**Spec reference:** `docs/superpowers/specs/2026-05-03-v0.3.3-fft-resolution-design.md`.
+**slowrx C reference (locally):** `original/slowrx/video.c` (FFT_LEN, bandwidth integration, Hann bank).
+
+**Working directory throughout:** `/data/source/slowrx.rs-v0.3.3-fft-resolution` (worktree on `feat/v0.3.3-fft-resolution`, branched from `main` at `v0.3.2` SHA `a90db8d`).
+
+**No-touch list:** `src/sync.rs::SYNC_FFT_LEN` (sync-detection FFT, separate concern; stays at 256). `src/vis.rs::FFT_LEN` (VIS-code detection FFT; stays at 512). `crate::snr::HANN_LENS` (the bank stays scaled to slowrx-C/4 in time-domain).
+
+---
+
+## Phase 1 — FFT_LEN bump + scaled test + doc refresh (single commit)
+
+All five pieces (constant change, test scaling/rename, in-source doc refresh, intentional-deviations entry, full-CI-gate verification) land as one logical commit. No partial states — the `usize` test depends on the new constant, and the deviation note documents what the constant change means.
+
+### Task 1.1: Update the bandwidth-correction test to assert post-bump bin counts
+
+**Files:**
+- Modify: `src/snr.rs` test `snr_bandwidth_correction_bins_match_slowrx` (around lines 480-540).
+
+The current test asserts FFT_LEN=256 bin counts (`video_plus_noise_bins = 20`, `noise_only_bins = 27`, `receiver_bins = 69`). At FFT_LEN=1024 / 11_025 Hz, `crate::get_bin` (floor truncation) yields:
+
+| Hz   | get_bin (FFT_LEN=1024, SR=11_025) |
+|------|------------------------------------|
+| 1500 | 139                                |
+| 2300 | 213                                |
+| 400  | 37                                 |
+| 800  | 74                                 |
+| 2700 | 250                                |
+| 3400 | 315                                |
+
+Therefore:
+
+- `video_plus_noise_bins` = 213 − 139 + 1 = **75**
+- `noise_only_bins` = (74 − 37 + 1) + (315 − 250 + 1) = 38 + 66 = **104**
+- `receiver_bins` = 315 − 37 = **278**
+- `Pnoise multiplier` = 278/104 ≈ 2.6731
+- `Psignal subtractor` = 75/104 ≈ 0.7212
+
+The 4× scaling is approximate (75 ≠ 80 = 4×20) because integer floor truncation has slightly different rounding behavior at finer resolution. This is fine — the test's regression-guard purpose (catch any drift in the bin-counting math) is preserved exactly.
+
+- [ ] **Step 1: Rewrite the test in place**
+
+Open `src/snr.rs` and locate the `snr_bandwidth_correction_bins_match_slowrx` test (around line 502). Replace it (and its rustdoc preamble) with:
+
+```rust
+    /// Verify the SNR-estimator bandwidth correction's bin counts at our
+    /// finer-than-slowrx-C frequency resolution. With `FFT_LEN=1024` at
+    /// `WORKING_SAMPLE_RATE_HZ=11_025` we get ~10.77 Hz/bin (4× finer
+    /// than slowrx C's `1024/44_100`). The integration ranges in Hz are
+    /// the same as slowrx C — `[1500, 2300]` for video and
+    /// `[400, 800] ∪ [2700, 3400]` for noise — but the `usize` bin
+    /// counts are higher in proportion to the resolution.
+    ///
+    /// At `FFT_LEN=1024, SR=11_025` (slowrx `GetBin` floor truncation):
+    ///
+    /// | Quantity                  | Expected                          |
+    /// |---------------------------|-----------------------------------|
+    /// | `video_plus_noise_bins`   | 213 − 139 + 1 = 75                |
+    /// | `noise_only_bins`         | (74−37+1) + (315−250+1) = 38+66 = 104 |
+    /// | `receiver_bins`           | 315 − 37 = 278                    |
+    /// | Pnoise multiplier         | 278/104 ≈ 2.6731                  |
+    /// | Psignal subtractor        | 75/104 ≈ 0.7212                   |
+    ///
+    /// These values differ from what `.round()` would give, so the test
+    /// is still a regression guard for the `get_bin` truncation in
+    /// `snr.rs::estimate`. It no longer asserts slowrx-C-parity in
+    /// `usize` terms (we deliberately exceed slowrx in frequency
+    /// resolution; see `docs/intentional-deviations.md`).
+    #[test]
+    fn snr_bandwidth_correction_bins_at_finer_resolution() {
+        let get_bin =
+            |hz: f64| crate::get_bin(hz, FFT_LEN, crate::resample::WORKING_SAMPLE_RATE_HZ);
+
+        let video_lo = get_bin(1500.0);
+        let video_hi = get_bin(2300.0);
+        let n_lo_a = get_bin(400.0);
+        let n_hi_a = get_bin(800.0);
+        let n_lo_b = get_bin(2700.0);
+        let n_hi_b = get_bin(3400.0);
+
+        let video_plus_noise_bins = video_hi - video_lo + 1;
+        let noise_only_bins = (n_hi_a - n_lo_a + 1) + (n_hi_b - n_lo_b + 1);
+        let receiver_bins = n_hi_b - n_lo_a;
+
+        assert_eq!(
+            video_plus_noise_bins, 75,
+            "video+noise bins: got {video_plus_noise_bins}"
+        );
+        assert_eq!(
+            noise_only_bins, 104,
+            "noise-only bins: got {noise_only_bins}"
+        );
+        assert_eq!(receiver_bins, 278, "receiver bins: got {receiver_bins}");
+
+        // Pnoise multiplier ≈ 2.6731 (FFT_LEN=1024) vs 2.5556 (FFT_LEN=256 / slowrx).
+        let pnoise_mult = receiver_bins as f64 / noise_only_bins as f64;
+        assert!(
+            (pnoise_mult - 278.0 / 104.0).abs() < 1e-9,
+            "Pnoise mult: {pnoise_mult}"
+        );
+
+        // Psignal subtractor ≈ 0.7212 (FFT_LEN=1024) vs 0.7407 (FFT_LEN=256 / slowrx).
+        let psignal_sub = video_plus_noise_bins as f64 / noise_only_bins as f64;
+        assert!(
+            (psignal_sub - 75.0 / 104.0).abs() < 1e-9,
+            "Psignal sub: {psignal_sub}"
+        );
+    }
+```
+
+- [ ] **Step 2: Run the renamed test — it should FAIL (FFT_LEN is still 256)**
+
+```bash
+cargo test --features test-support --lib snr_bandwidth_correction 2>&1 | tail -10
+```
+
+Expected: FAIL with assertion mismatch (e.g., `video+noise bins: got 20`). This is the intended TDD failing-test step — the test's new expectations encode the post-FFT_LEN-bump behavior; the bump in Task 1.2 makes them pass.
+
+### Task 1.2: Bump FFT_LEN and refresh in-source doc comments
+
+**Files:**
+- Modify: `src/snr.rs` lines 7-14 (module-level doc comment), line 20 (the constant), line 200 (`estimate` rustdoc), line 488 (test rustdoc — already covered by Task 1.1's rewrite).
+- Modify: `src/mode_pd.rs` line 77 (FFT_LEN-aliasing rustdoc), line 106 (`estimate_freq` rustdoc — `(= 256)` → `(= 1024)`), line 439 (PdDemod-init comment), line 699 (test comment).
+
+- [ ] **Step 1: Update `src/snr.rs` module-level doc**
+
+Replace the existing `## Working-rate scaling` block (lines 7-14) with:
+
+```rust
+//! ## Working-rate scaling
+//!
+//! slowrx operates at `44_100` Hz with `FFTLen = 1024` and Hann lengths
+//! `[48, 64, 96, 128, 256, 512, 1024]`. We operate at
+//! [`crate::resample::WORKING_SAMPLE_RATE_HZ`] = `11_025` Hz with
+//! `FFT_LEN = 1024` — same FFT length, **4× finer Hz/bin**
+//! (`11025/1024 ≈ 10.77` Hz/bin vs slowrx's `44100/1024 ≈ 43.07`
+//! Hz/bin). The Hann lengths stay at slowrx's lengths divided by 4
+//! (`[12, 16, 24, 32, 64, 128, 256]`) so the time-domain analysis is
+//! identical to slowrx C; the FFT input is naturally zero-padded
+//! outside the Hann support, giving us 4× more output bins on the
+//! same windowed signal. See
+//! `docs/intentional-deviations.md::"FFT frequency resolution exceeds
+//! slowrx C by 4×"` for rationale.
+```
+
+- [ ] **Step 2: Bump the constant**
+
+Replace line 20:
+
+```rust
+pub(crate) const FFT_LEN: usize = 256;
+```
+
+with:
+
+```rust
+pub(crate) const FFT_LEN: usize = 1024;
+```
+
+- [ ] **Step 3: Refresh other "256" mentions in `src/snr.rs`**
+
+Search for `256-sample` and `FFT_LEN=256` in `src/snr.rs` and update only the ones that mean **FFT_LEN** (not the Hann length 256, which stays). Specifically:
+
+- Line ~200 (in `estimate` rustdoc): `FFT a 256-sample window` → `FFT a 1024-sample window`.
+
+Leave intact:
+- Line 23: `[48, 64, 96, 128, 256, 512, 1024]` — that's slowrx's HANN_LENS, not FFT_LEN.
+- Line 26: `HANN_LENS: [usize; 7] = [12, 16, 24, 32, 64, 128, 256]` — our HANN_LENS, unchanged.
+- Line 88: `(64-sample window at 11_025 Hz; 256 in slowrx at 44_100 Hz)` — that's a Hann-length comparison, not FFT_LEN. Stays.
+- Line 360-361: `[48,64,96,128,256,512,1024] / 4` — Hann sanity assertion. Stays.
+
+- [ ] **Step 4: Refresh "256" mentions in `src/mode_pd.rs`**
+
+Locate and update:
+
+- Line 77 (rustdoc on `pub(crate) const FFT_LEN: usize = crate::snr::FFT_LEN;`):
+
+  ```text
+  /// `256/11025 Hz` = 43.07 Hz/bin, equal to slowrx's `1024/44100 Hz`.
+  ```
+
+  becomes:
+
+  ```text
+  /// `1024/11025 Hz` ≈ 10.77 Hz/bin — 4× finer than slowrx's `1024/44100 Hz`
+  /// = 43.07 Hz/bin (deliberate 0.3.3 divergence; see
+  /// `docs/intentional-deviations.md`).
+  ```
+
+- Line 106 (rustdoc on `estimate_freq`):
+
+  ```text
+  /// [`FFT_LEN`] (= 256), with leading/trailing zero-pad. Out-of-bounds
+  ```
+
+  becomes:
+
+  ```text
+  /// [`FFT_LEN`] (= 1024), with leading/trailing zero-pad. Out-of-bounds
+  ```
+
+- Line 439 (`prev_win_idx` comment in `decode_one_channel_into`):
+
+  ```text
+  // 256-sample window).
+  ```
+
+  becomes:
+
+  ```text
+  // 256-sample Hann window inside a 1024-sample FFT).
+  ```
+
+  (The "256" here refers to the Hann length at idx 4 — that's still 256. The clarification just disambiguates from FFT_LEN.)
+
+- Line 699 (test comment):
+
+  ```text
+  // 100 ms of pure tone at 1900 Hz; ample for FFT_LEN=256.
+  ```
+
+  becomes:
+
+  ```text
+  // 100 ms of pure tone at 1900 Hz; ample for FFT_LEN=1024.
+  ```
+
+- [ ] **Step 5: Run the bandwidth-correction test — it should now PASS**
+
+```bash
+cargo test --features test-support --lib snr_bandwidth_correction 2>&1 | tail -10
+```
+
+Expected: 1 passed.
+
+- [ ] **Step 6: Run the full lib test suite**
+
+```bash
+cargo test --features test-support --lib 2>&1 | grep -E "^test result"
+```
+
+Expected: every "ok", zero failed. If any test other than the renamed bandwidth-correction one breaks, that's a finding — investigate before proceeding. Most likely candidates if anything breaks: tests that hardcode FFT_LEN-derived values elsewhere. Per inspection during planning, none were found, but verify here.
+
+### Task 1.3: Verify all 6 synthetic round-trips still pass
+
+**Files:** None (verification only).
+
+The round-trip suite is the per-PR gate. The hysteresis change in 0.3.2 already shipped; this task confirms FFT_LEN=1024 doesn't regress the synthetic decoder.
+
+- [ ] **Step 1: Run all 6 round-trips**
+
+```bash
+cargo test --test roundtrip --features test-support 2>&1 | tail -10
+```
+
+Expected: 6 tests pass — pd120, pd180, pd240, robot24, robot36, robot72. Each must hold the existing `mean < 5.0` per-pixel-RGB-diff threshold.
+
+If any test fails, FFT_LEN=1024 has introduced a synthetic-corpus regression we didn't catch in the experiment branch. Investigate the failing mode's `mean` and `max_diff` values; if `mean` is borderline (e.g., 5.1) and the visual output looks fine, document and ask the user before relaxing the threshold. If `mean` is wildly worse, revert FFT_LEN and stop — there's a real bug.
+
+### Task 1.4: New `intentional-deviations.md` entry
+
+**Files:**
+- Modify: `docs/intentional-deviations.md` (append a new section at the bottom).
+
+- [ ] **Step 1: Append the new section**
+
+Open `docs/intentional-deviations.md`, locate the last `---` separator, and append:
+
+````markdown
+
+---
+
+## FFT frequency resolution exceeds slowrx C by 4×
+
+**Files:** `src/snr.rs::FFT_LEN`, `src/mode_pd.rs::FFT_LEN` ↔ slowrx `video.c::FFTLen`.
+**Tracking issue:** [#71](https://github.com/jasonherald/slowrx.rs/issues/71) (squiggle context).
+**Shipped in:** 0.3.3.
+
+### What slowrx does
+
+slowrx C uses `FFTLen = 1024` at `44_100` Hz, giving
+`44100 / 1024 ≈ 43.07` Hz/bin frequency resolution for the per-pixel
+demod and SNR estimator (`video.c:303-340, 369-395`).
+
+### What we do
+
+We use `FFT_LEN = 1024` at [`crate::resample::WORKING_SAMPLE_RATE_HZ`]
+= `11_025` Hz, giving `11025 / 1024 ≈ 10.77` Hz/bin —
+**4× finer than slowrx C**.
+
+`crate::snr::HANN_LENS` is unchanged at `[12, 16, 24, 32, 64, 128, 256]`
+(slowrx's `[48, 64, 96, 128, 256, 512, 1024]` divided by 4) so the
+time-domain analysis is identical to slowrx C. The FFT input is
+naturally zero-padded outside the Hann support, giving us 4× more
+output bins on the same windowed signal.
+
+### Why we deviated
+
+0.3.2 shipped a 1 dB SNR hysteresis band as a partial fix for the
+real-radio squiggle artifacts ([#71]). Hysteresis reduced but didn't
+eliminate the squiggles. While CodeRabbit reviewed PR #74, a
+parallel experiment branch tested bumping `FFT_LEN` to 1024. Result
+on the 12 ARISS Fram2 R36 reference WAVs: synthetic round-trips all
+passed at the unchanged `mean < 5.0` threshold, and visual inspection
+showed **noticeably clearer pixel content** vs. the 0.3.2 baseline
+(by-eye comparison; the user judged it "WAY clearer").
+
+The squiggle artifacts themselves were unchanged — that's a separate
+concern tracked in [#71]. The finer Hz/bin is a complementary DSP
+improvement that's worth shipping on its own.
+
+[#71]: https://github.com/jasonherald/slowrx.rs/issues/71
+
+### When to revisit
+
+1. **Squiggle root cause turns out to require coarser FFT.** Unlikely
+   given the 0.3.2 hypothesis (SNR-cadence flip-flop) was unaffected
+   by FFT_LEN. But if a future audit finds an FFT-resolution-dependent
+   artifact, this is the knob.
+2. **CPU cost becomes an issue.** The 4× FFT compute per call is
+   negligible at SSTV's per-pixel cadence (measured: <fill in Phase 2
+   measurement>). If a future profile shows the per-pixel FFT
+   dominating wall-clock time on resource-constrained targets,
+   consider reverting or adding a `cli`-feature-gated coarse mode.
+3. **A future audit cross-validates pixel-by-pixel against slowrx C
+   output** and finds slowrx's `usize` bin counts matter in some
+   specific way. Unlikely — bandwidth integration is in Hz domain —
+   but possible.
+````
+
+### Task 1.5: Run the full local CI gate
+
+**Files:** None (verification only).
+
+This is the V2.1 lesson — `cargo test` alone is not enough; the doc gate has caught CI failures we'd otherwise have missed.
+
+- [ ] **Step 1: Run all four gate commands**
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --all-targets --all-features -- -D warnings 2>&1 | tail -3
+cargo test --all-features --locked 2>&1 | grep -E "^test result"
+RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features 2>&1 | tail -3
+```
+
+All must pass. **Critical:** the doc gate must be clean — broken intra-doc links would block CI.
+
+If `cargo fmt --check` complains, run `cargo fmt --all` and re-verify.
+If clippy complains about `doc_markdown` on the new deviation entry, wrap the offending tokens (e.g., `max_diff`) in backticks.
+
+### Task 1.6: Commit Phase 1
+
+**Files:**
+- Add: `src/snr.rs`, `src/mode_pd.rs`, `docs/intentional-deviations.md`.
+
+- [ ] **Step 1: Stage and commit**
+
+```bash
+git add -- src/snr.rs src/mode_pd.rs docs/intentional-deviations.md
+git commit -m "$(cat <<'EOF'
+feat(snr): bump FFT_LEN 256 → 1024 for 4× finer Hz/bin
+
+Real-audio Fram2 visual validation in the parallel experiment branch
+showed noticeably clearer decoded pixel content with FFT_LEN=1024
+(10.77 Hz/bin) vs the 0.3.2 baseline (43.07 Hz/bin, equal to slowrx
+C). Synthetic round-trips all pass at the unchanged mean < 5.0
+threshold.
+
+HANN_LENS stays at [12, 16, 24, 32, 64, 128, 256] (slowrx C / 4) so
+time-domain analysis is identical to slowrx C; only the FFT output
+bin density changes. Both the SNR estimator and per-pixel demod
+already explicitly zero-fill fft_buf before each windowed write, so
+the larger zero-pad region needs no additional code change.
+
+Test scaling: the snr_bandwidth_correction_bins_match_slowrx test was
+renamed to snr_bandwidth_correction_bins_at_finer_resolution and its
+expected bin counts updated to the post-bump values. The test still
+serves its regression-guard purpose for the get_bin floor-truncation
+math; it no longer asserts slowrx-C-parity in usize terms.
+
+Squiggle artifacts (#71) are unaffected by this change — they're a
+separate concern. The two new diagnostic patterns observed during
+0.3.2 validation (black-background dependence, top/bottom asymmetry)
+are 0.3.4+ work.
+
+Documents the divergence in docs/intentional-deviations.md under
+"FFT frequency resolution exceeds slowrx C by 4×".
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+- [ ] **Step 2: Verify the commit succeeded**
+
+```bash
+git log --oneline -1
+```
+
+Expected: the commit hash + the first line of the message.
+
+---
+
+## Phase 2 — Real-audio Fram2 validation (manual)
+
+The merge gate per `feedback_real_audio_validation_gate.md`: when fixtures are available, the decoder must produce visually-matching output before merging.
+
+### Task 2.1: Build the release CLI
+
+**Files:** None.
+
+- [ ] **Step 1: Build**
+
+```bash
+cargo build --release --features cli 2>&1 | tail -3
+```
+
+Expected: `Finished release profile`.
+
+### Task 2.2: Decode all 12 Fram2 WAVs
+
+**Files:**
+- Output: `/tmp/fram2-v033/Slide{NN}-decoded.png` (NOT committed; scratch directory).
+
+The fixtures live at `/data/source/slowrx.rs/tests/fixtures/ariss-fram2/Slide{NN}.wav`.
+
+- [ ] **Step 1: Run the CLI for all 12 slides**
+
+```bash
+rm -rf /tmp/fram2-v033 && mkdir -p /tmp/fram2-v033
+for n in 01 02 03 04 05 06 07 08 09 10 11 12; do
+  mkdir -p "/tmp/fram2-v033/Slide${n}"
+  ./target/release/slowrx-cli \
+    -i "/data/source/slowrx.rs/tests/fixtures/ariss-fram2/Slide${n}.wav" \
+    -o "/tmp/fram2-v033/Slide${n}" \
+    --quiet 2>&1 | tail -1
+done
+```
+
+Expected: each invocation exits 0; no panics; each `Slide${n}` directory contains `img-001-robot36.png`.
+
+- [ ] **Step 2: Flatten output filenames for easier comparison**
+
+```bash
+cd /tmp/fram2-v033
+for n in 01 02 03 04 05 06 07 08 09 10 11 12; do
+  mv "Slide${n}/img-001-robot36.png" "Slide${n}-decoded.png"
+  rmdir "Slide${n}"
+done
+ls *.png
+```
+
+Expected: 12 PNG files at the top of `/tmp/fram2-v033/`.
+
+### Task 2.3: User visual confirmation gate
+
+**Files:** None.
+
+This is the merge gate. The implementer cannot pass it autonomously — it requires the user to look at the PNGs.
+
+- [ ] **Step 1: Surface the PNGs for visual review**
+
+Print the path so the user can open them in their image viewer:
+
+```bash
+echo "Visual review: /tmp/fram2-v033/Slide{01..12}-decoded.png"
+ls -la /tmp/fram2-v033/*.png
+```
+
+- [ ] **Step 2: Pause for user verdict**
+
+Ask the user: *"Please open the 12 PNGs at `/tmp/fram2-v033/` and confirm they reproduce the experiment-branch finding ('WAY clearer but still squiggles' vs the 0.3.2 baseline). Yes / no / something looks off."*
+
+Possible verdicts:
+
+- **Yes — looks like the experiment.** Proceed to Phase 3.
+- **No — looks worse than the experiment.** Investigate. The experiment branch was branched from pre-CR-fix `fix/v0.3.2-squiggle-hysteresis`; the current branch was rebased onto v0.3.2 (which lifts in the corrected ratcheting hysteresis). If the visual quality regressed, the corrected hysteresis may interact with FFT_LEN=1024 differently. Diff the two outputs; consider whether to revert the FFT_LEN bump or accept the change.
+- **Something looks off.** Get specifics from the user; address before proceeding.
+
+### Task 2.4: CPU/memory due-diligence (not gating)
+
+**Files:**
+- Scratch only: `/tmp/fram2-v033-perf.txt` (NOT committed).
+
+Document the cost of the 4× FFT compute. Not a merge gate, just data for the CHANGELOG.
+
+- [ ] **Step 1: Time one decode on `main` (v0.3.2) and one on the 0.3.3 branch**
+
+```bash
+# Pre-bump baseline (run from /data/source/slowrx.rs):
+cd /data/source/slowrx.rs
+cargo build --release --features cli 2>&1 | tail -1
+time ./target/release/slowrx-cli \
+  -i tests/fixtures/ariss-fram2/Slide01.wav \
+  -o /tmp/fram2-v033-perf-baseline \
+  --quiet
+
+# Post-bump (run from /data/source/slowrx.rs-v0.3.3-fft-resolution):
+cd /data/source/slowrx.rs-v0.3.3-fft-resolution
+time ./target/release/slowrx-cli \
+  -i /data/source/slowrx.rs/tests/fixtures/ariss-fram2/Slide01.wav \
+  -o /tmp/fram2-v033-perf-postbump \
+  --quiet
+```
+
+- [ ] **Step 2: Note the wall-clock delta in `/tmp/fram2-v033-perf.txt`**
+
+Format:
+
+```text
+0.3.3 FFT_LEN=1024 perf measurement — 2026-05-03
+
+Slide01 decode wall-clock:
+  v0.3.2 (FFT_LEN=256):  <fill>
+  0.3.3  (FFT_LEN=1024): <fill>
+  delta: <fill>
+
+Verdict: <negligible / noticeable / blocking>
+```
+
+This file feeds the CHANGELOG entry in Phase 3.
+
+---
+
+## Phase 3 — Release prep (CHANGELOG + Cargo.toml)
+
+### Task 3.1: Insert `[0.3.3]` CHANGELOG section
+
+**Files:**
+- Modify: `CHANGELOG.md` (insert between `[Unreleased]` and `[0.3.2]`).
+
+- [ ] **Step 1: Insert the new section**
+
+Open `CHANGELOG.md`. Insert between the existing `## [Unreleased]` and `## [0.3.2] - 2026-05-02`:
+
+````markdown
+## [Unreleased]
+
+## [0.3.3] - 2026-05-03
+
+Patch release bumping `crate::snr::FFT_LEN` from 256 to 1024 to give
+4× finer Hz/bin (10.77 vs 43.07) for the per-pixel demod and SNR
+estimator. Validated visually on the 12 ARISS Fram2 R36 reference
+WAVs as noticeably clearer pixel content vs. the 0.3.2 baseline. The
+squiggle artifacts ([#71]) are unaffected by this change — they're a
+separate concern, tracked through 0.3.5+.
+
+The pixel-diff comparator earmarked for 0.3.3 in [#70] moves to a
+later patch.
+
+[#70]: https://github.com/jasonherald/slowrx.rs/issues/70
+[#71]: https://github.com/jasonherald/slowrx.rs/issues/71
+
+### Changed
+
+- **`crate::snr::FFT_LEN`** bumped from 256 to 1024. `HANN_LENS` is
+  unchanged at slowrx-C-divided-by-4, so the time-domain analysis is
+  identical to slowrx C; only the FFT output bin density changes.
+  Both the SNR estimator and the per-pixel demod already explicitly
+  zero-fill `fft_buf` before each windowed write, so the larger
+  zero-pad region needs no additional handling.
+- **`mode_pd::FFT_LEN`** is a re-export of `snr::FFT_LEN`, so it
+  picks up the new value automatically.
+- **`snr_bandwidth_correction_bins_match_slowrx`** test renamed to
+  `snr_bandwidth_correction_bins_at_finer_resolution` and re-asserted
+  with the post-bump bin counts (75 / 104 / 278). The test still
+  guards the `get_bin` floor-truncation math; it no longer asserts
+  slowrx-C-parity in `usize` terms.
+
+### Documentation
+
+- New `docs/intentional-deviations.md` entry: "FFT frequency
+  resolution exceeds slowrx C by 4×". Documents the divergence,
+  the rationale (visibly clearer real-radio output), and three
+  triggers for revisiting.
+- In-source rustdoc comments referencing `FFT_LEN=256` updated to
+  `FFT_LEN=1024` (in `src/snr.rs` and `src/mode_pd.rs`). The Hann
+  bank's literal 256 (the longest Hann length, unchanged) is left
+  alone where context makes the meaning clear.
+
+### Validation
+
+- All 6 synthetic round-trips (PD120/180/240, R24/36/72) pass at the
+  unchanged `mean < 5.0` per-pixel-RGB-diff threshold.
+- Real-audio Fram2 visual validation: <fill in observation from
+  Phase 2 Task 2.3 — "all 12 slides reproduce the experiment-branch
+  'WAY clearer' verdict" / "10 of 12 reproduce; 2 show <X>" / etc.>.
+- Wall-clock decode of one Fram2 R36 slide on `main` (v0.3.2) vs.
+  this branch: <fill in from Phase 2 Task 2.4>.
+
+### Notes
+
+- The squiggle artifacts in real-radio Fram2 output ([#71]) are
+  reduced (per 0.3.2 hysteresis) but still present. The two new
+  diagnostic patterns observed during 0.3.2 validation
+  (black-background dependence, top/bottom asymmetry) motivate the
+  next investigation pass; they are 0.3.4+ work.
+````
+
+(Replace the `<fill in observation...>` and `<fill in from...>` placeholders with the actual findings from Phase 2 BEFORE running the cargo gate.)
+
+- [ ] **Step 2: Read back the inserted block**
+
+```bash
+head -60 CHANGELOG.md
+```
+
+Expected: the new `[0.3.3] - 2026-05-03` section sits between `[Unreleased]` and `[0.3.2] - 2026-05-02`. Date is `date -I`. The validation paragraph reflects empirical findings, not placeholders.
+
+### Task 3.2: Bump `Cargo.toml` to 0.3.3
+
+**Files:**
+- Modify: `Cargo.toml` line 3.
+
+- [ ] **Step 1: Update the version field**
+
+Replace:
+
+```toml
+version = "0.3.2"
+```
+
+with:
+
+```toml
+version = "0.3.3"
+```
+
+- [ ] **Step 2: Verify Cargo.lock updates**
+
+```bash
+cargo build --features cli 2>&1 | tail -3
+```
+
+Expected: builds. `Cargo.lock` will update its `[[package]] name = "slowrx"` entry's `version` to `"0.3.3"` automatically.
+
+### Task 3.3: Run the full CI gate one more time
+
+**Files:** None (verification only).
+
+- [ ] **Step 1: All four gate commands**
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --all-targets --all-features -- -D warnings 2>&1 | tail -3
+cargo test --all-features --locked 2>&1 | grep -E "^test result"
+RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features 2>&1 | tail -3
+```
+
+All must pass.
+
+### Task 3.4: Commit Phase 3
+
+**Files:**
+- Add: `CHANGELOG.md`, `Cargo.toml`, `Cargo.lock`.
+
+- [ ] **Step 1: Stage and commit**
+
+```bash
+git add -- CHANGELOG.md Cargo.toml Cargo.lock
+git commit -m "$(cat <<'EOF'
+chore(release): 0.3.3 — FFT_LEN=1024 for 4× finer Hz/bin
+
+Patch release bumping crate::snr::FFT_LEN from 256 to 1024. Validated
+visually on the 12 ARISS Fram2 R36 reference WAVs as noticeably
+clearer pixel content; synthetic round-trips pass at unchanged
+thresholds. Squiggle artifacts (#71) unaffected — separate concern.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+- [ ] **Step 2: Verify**
+
+```bash
+git log --oneline -3
+```
+
+Expected: 3 commits — the spec doc, Phase 1, and Phase 3.
+
+---
+
+## Phase 4 — Open PR + post-merge tag + publish
+
+### Task 4.1: Open the PR
+
+**Files:** None.
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+git push -u origin feat/v0.3.3-fft-resolution
+```
+
+- [ ] **Step 2: Open the PR via `gh`**
+
+```bash
+gh pr create \
+  --base main \
+  --head feat/v0.3.3-fft-resolution \
+  --title "feat(snr): bump FFT_LEN 256 → 1024 for 4× finer Hz/bin (0.3.3)" \
+  --body "$(cat <<'EOF'
+## Summary
+
+- Bump `crate::snr::FFT_LEN` from 256 to 1024 → 10.77 Hz/bin (4× finer than 0.3.2's 43.07 Hz/bin / slowrx C).
+- `HANN_LENS` unchanged → time-domain analysis identical to slowrx C; only the FFT output bin density changes.
+- Renamed `snr_bandwidth_correction_bins_match_slowrx` → `snr_bandwidth_correction_bins_at_finer_resolution` with post-bump bin counts.
+- New `intentional-deviations.md` entry: "FFT frequency resolution exceeds slowrx C by 4×".
+- Real-audio Fram2 visual validation: 12/12 slides reproduce the experiment-branch "WAY clearer" finding.
+- Squiggles (#71) unaffected — separate concern, tracked through 0.3.5+.
+
+## Test plan
+
+- [x] `cargo fmt --check` clean
+- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
+- [x] `cargo test --all-features --locked` — all unit + round-trip tests pass
+- [x] `RUSTDOCFLAGS=-D warnings cargo doc --no-deps --all-features` clean
+- [x] All 6 synthetic round-trips at unchanged `mean < 5.0`
+- [x] All 12 ARISS Fram2 WAVs decode without panic and reproduce the experiment-branch visual verdict
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: Print the PR URL**
+
+`gh pr create` prints the URL on success. Capture it for the user.
+
+### Task 4.2: Post-merge tag + publish
+
+**Note:** This task is BLOCKED until the user merges the PR. After merge:
+
+- [ ] **Step 1: Sync `main`**
+
+```bash
+cd /data/source/slowrx.rs
+git fetch --all --prune
+git checkout main
+git pull --ff-only
+git log --oneline -3
+```
+
+Expected: main now contains the merge commit + the two feature commits.
+
+- [ ] **Step 2: Re-run the CI gate on main**
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --all-targets --all-features -- -D warnings 2>&1 | tail -3
+cargo test --all-features --locked 2>&1 | grep -E "^test result"
+RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features 2>&1 | tail -3
+```
+
+All must pass.
+
+- [ ] **Step 3: Tag `v0.3.3`** (annotated, unsigned per project convention)
+
+```bash
+git tag -a v0.3.3 -m "$(cat <<'EOF'
+slowrx 0.3.3 — FFT_LEN=1024 for 4× finer Hz/bin
+
+Patch release bumping crate::snr::FFT_LEN from 256 to 1024 (10.77
+Hz/bin vs 43.07 Hz/bin in 0.3.2 / slowrx C). Validated visually on
+all 12 ARISS Fram2 R36 reference WAVs; synthetic round-trips pass
+at unchanged thresholds.
+
+HANN_LENS unchanged → time-domain analysis identical to slowrx C;
+only the FFT output bin density changes.
+
+Squiggle artifacts (#71) unaffected — separate concern.
+
+PR: #<fill in PR number>.
+EOF
+)"
+git push origin v0.3.3
+```
+
+- [ ] **Step 4: Publish to crates.io**
+
+```bash
+cargo publish --features cli --allow-dirty 2>&1 | tail -10
+```
+
+The `--allow-dirty` flag is the project's standard pattern (the `original/` reference clone is gitignored but cargo's strict-clean check flags it). Confirms with the user **before** running this step — `cargo publish` is irreversible.
+
+Expected: `Uploaded slowrx v0.3.3 to registry crates-io`.
+
+### Task 4.3: Cleanup
+
+**Files:** None.
+
+- [ ] **Step 1: Comment status on #71**
+
+```bash
+gh issue comment 71 --repo jasonherald/slowrx.rs --body "$(cat <<'EOF'
+## 0.3.3 status — finer FFT resolution shipped, squiggles unchanged
+
+`slowrx 0.3.3` (PR #<fill in>, tag `v0.3.3`, published to crates.io)
+shipped a 4× finer Hz/bin FFT resolution (10.77 vs 43.07). The
+synthetic round-trips pass at the same `mean < 5.0` threshold and the
+real-radio Fram2 output is noticeably clearer to the eye, but the
+**squiggle artifacts themselves are unchanged** — confirming the
+0.3.2 hypothesis that they're SNR-cadence-driven rather than
+FFT-resolution-driven.
+
+Squiggle work continues in 0.3.4+. The two new diagnostic patterns
+observed during 0.3.2 validation are the next leads:
+
+1. **Black-background dependence.** Squiggles are far more visible on
+   dark areas. Possibly related to peak-interpolation behavior at low
+   signal amplitude.
+2. **Top/bottom asymmetry.** Squiggles differ between the top, middle,
+   and bottom of the frame. Possibly a `find_sync` rate-correction
+   interaction at the temporal extremes.
+
+Leaving this issue open through the next investigation pass.
+EOF
+)"
+```
+
+- [ ] **Step 2: Remove the worktree**
+
+```bash
+cd /data/source/slowrx.rs
+git worktree remove /data/source/slowrx.rs-v0.3.3-fft-resolution
+git worktree list
+```
+
+Expected: only `/data/source/slowrx.rs main` remains.
+
+- [ ] **Step 3: Confirm the released version is fetchable**
+
+```bash
+cargo search slowrx 2>&1 | head -3
+```
+
+Expected: `slowrx = "0.3.3"`.
+
+---
+
+## Done criteria
+
+- All Phase 1, 2, 3, 4 tasks completed and checked off.
+- `crates.io/crates/slowrx` shows `0.3.3` as the latest version.
+- `git tag -l v0.3.3` exists and is pushed.
+- The Fram2 visual gate (Task 2.3) reproduced the experiment-branch verdict.
+- #71 has a status comment on the 0.3.3 outcome.

--- a/docs/superpowers/specs/2026-05-03-v0.3.3-fft-resolution-design.md
+++ b/docs/superpowers/specs/2026-05-03-v0.3.3-fft-resolution-design.md
@@ -96,6 +96,18 @@ remaining `FFT_LEN - HANN_LENS[idx]` samples are naturally zero (the
 buffer is fresh-zeroed each call). Time-domain analysis is identical
 to 0.3.2 and slowrx C; only the FFT output bin density changes.
 
+**Coupled SNR-estimator deviation (caught in Phase 1 code review).** The
+above zero-pad story holds for the per-pixel demod, where `HANN_LENS[idx] ≤
+256 < 1024 = FFT_LEN`. It does **not** hold for the SNR estimator: that
+component allocates `hann_long = build_hann(FFT_LEN)`, a Hann window
+that scales with `FFT_LEN`, so its time-domain support grows from
+~23 ms (= slowrx C, at FFT_LEN=256) to ~93 ms (FFT_LEN=1024). This is
+a second, intentional deviation: the longer integration window gives
+a cleaner SNR estimate and likely reduces window-selector flip-flop
+beyond what the 0.3.2 hysteresis already delivers. We do not attempt
+to decouple it — see the expanded `What we do` subsection in
+`docs/intentional-deviations.md` for the full rationale.
+
 No changes to `mode_pd::FFT_LEN` are needed — that constant aliases
 `crate::snr::FFT_LEN` indirectly through bin-arithmetic. Verify by
 inspection during implementation.

--- a/docs/superpowers/specs/2026-05-03-v0.3.3-fft-resolution-design.md
+++ b/docs/superpowers/specs/2026-05-03-v0.3.3-fft-resolution-design.md
@@ -1,0 +1,253 @@
+# slowrx.rs 0.3.3 — FFT Frequency Resolution Design Specification
+
+**Status:** Approved 2026-05-03. Ready for implementation planning via the
+[superpowers:writing-plans](https://github.com/anthropic-ai/superpowers) skill.
+
+**Goal:** Bump `crate::snr::FFT_LEN` from `256` to `1024` to give 4× finer
+Hz-per-bin frequency resolution (10.77 Hz/bin vs 43.07 Hz/bin), producing
+visibly clearer real-radio decoded output. Ship as `slowrx 0.3.3`.
+
+**Out of scope for this spec:**
+
+- Squiggle root-cause investigation. The two new diagnostic patterns
+  observed during 0.3.2 validation (black-background dependence,
+  top/bottom asymmetry) are 0.3.4+ work. See [#71].
+- Pixel-diff comparator vs reference JPGs — pushed to 0.3.4 or later.
+  See [#70].
+- Any change to `SNR_REESTIMATE_STRIDE`, `PIXEL_FFT_STRIDE`, or sub-pixel
+  FFT interpolation paths.
+- Any change to `HANN_LENS` (the Hann window-length bank). The bank
+  applies to the first 256 samples of the FFT input; the rest are zero-
+  padded. Time-domain analysis is preserved identical to slowrx C.
+
+[#70]: https://github.com/jasonherald/slowrx.rs/issues/70
+[#71]: https://github.com/jasonherald/slowrx.rs/issues/71
+
+## Context
+
+`slowrx 0.3.2` shipped a 1 dB SNR hysteresis band on the adaptive Hann
+selector to defeat the threshold flip-flop hypothesis from [#71]. Real-
+audio Fram2 visual validation showed the squiggle artifacts were
+**reduced but not eliminated** — hysteresis is a real DSP improvement
+but not the full root cause.
+
+While CodeRabbit reviewed PR #74, a parallel experiment branch tested
+bumping `FFT_LEN` from 256 to 1024 (4× finer Hz/bin). Result on the same
+12 ARISS Fram2 WAVs:
+
+- All 6 synthetic round-trips passed at the unchanged `mean < 5.0`
+  threshold.
+- Per-slide pixel diff vs 0.3.2 baseline ranged 4–6 % pixels changed,
+  with max diff up to 114–115 on a few slides.
+- User visual judgment: **"WAY clearer but still squiggles."**
+
+That last finding is the basis for this spec: 4× finer FFT frequency
+resolution is a real, complementary DSP improvement, separate from the
+squiggle problem. It's worth shipping on its own. The squiggles continue
+to be tracked in [#71].
+
+### Hz-per-bin context
+
+slowrx C uses `FFTLen = 1024` at `44_100` Hz, giving `44100 / 1024 ≈ 43.07`
+Hz/bin. Our 0.3.2 uses `FFT_LEN = 256` at `WORKING_SAMPLE_RATE_HZ = 11_025`
+Hz, giving `11025 / 256 ≈ 43.07` Hz/bin — bit-exact-resolution parity
+with slowrx C.
+
+`slowrx 0.3.3` deliberately diverges: `FFT_LEN = 1024` at `11_025` Hz
+gives `11025 / 1024 ≈ 10.77` Hz/bin, **4× finer than slowrx C**. This
+moves us out of strict "faithful translation" territory in the frequency
+domain (still arithmetically equivalent at every other DSP step) and
+into "exceeds reference."
+
+## Design
+
+### Architectural change
+
+Single source change in `src/snr.rs`:
+
+```rust
+// Was:
+pub(crate) const FFT_LEN: usize = 256;
+
+// Becomes:
+pub(crate) const FFT_LEN: usize = 1024;
+```
+
+The doc comment on `FFT_LEN` updates to reflect the new ratio:
+
+```rust
+//! ## Working-rate scaling
+//!
+//! slowrx operates at `44_100` Hz with `FFTLen = 1024`. We operate at
+//! [`crate::resample::WORKING_SAMPLE_RATE_HZ`] = `11_025` Hz with
+//! `FFT_LEN = 1024` — same FFT length, 4× finer Hz/bin
+//! (`11025/1024 ≈ 10.77` Hz/bin vs slowrx's `44100/1024 ≈ 43.07`
+//! Hz/bin). The Hann lengths stay at `[12, 16, 24, 32, 64, 128, 256]`
+//! (slowrx's `[48, 64, 96, 128, 256, 512, 1024]` divided by 4) so the
+//! time-domain analysis is identical to slowrx C; the FFT input is
+//! naturally zero-padded outside the Hann support, giving us 4× more
+//! output bins on the same windowed signal.
+```
+
+`HANN_LENS` is **unchanged**. The bank still has lengths
+`[12, 16, 24, 32, 64, 128, 256]`. Per-call: the Hann window is applied
+in-place to the first `HANN_LENS[idx]` samples of the FFT input; the
+remaining `FFT_LEN - HANN_LENS[idx]` samples are naturally zero (the
+buffer is fresh-zeroed each call). Time-domain analysis is identical
+to 0.3.2 and slowrx C; only the FFT output bin density changes.
+
+No changes to `mode_pd::FFT_LEN` are needed — that constant aliases
+`crate::snr::FFT_LEN` indirectly through bin-arithmetic. Verify by
+inspection during implementation.
+
+### Test scaling
+
+One existing unit test depends on FFT_LEN-derived bin counts:
+
+`snr.rs::tests::snr_bandwidth_correction_bins_match_slowrx`. The test
+asserts that the SNR estimator's bandwidth-correction bin counts (over
+the 200 Hz video band and the 1700 Hz noise band) match slowrx C's
+expected counts. With FFT_LEN=256 at 11_025 Hz we got 4 bins for video
+and ~39 for noise — same as slowrx C at 1024 at 44_100 Hz.
+
+With FFT_LEN=1024 at 11_025 Hz the bin counts grow 4×: ~16 bins for
+video, ~156 for noise.
+
+**Action:** rename to `snr_bandwidth_correction_bins_at_finer_resolution`
+and update the asserted constants. The test still serves its purpose
+(catch regressions in the bin-counting math) but no longer claims
+slowrx-C parity in `usize` terms; bandwidth in Hz is unchanged.
+
+### Documentation
+
+**A) New entry in `docs/intentional-deviations.md`:**
+`FFT frequency resolution exceeds slowrx C by 4×`. Standard four-
+subsection structure:
+
+- **What slowrx does:** `FFTLen = 1024` at `44_100` Hz → 43.07 Hz/bin.
+- **What we do:** `FFT_LEN = 1024` at `11_025` Hz → 10.77 Hz/bin
+  (4× finer). HANN_LENS unchanged at slowrx-C-divided-by-4 (time-
+  domain analysis preserved).
+- **Why we deviated:** real-audio Fram2 visual validation showed
+  visibly clearer pixel content with the finer Hz/bin. Synthetic
+  round-trips still pass at unchanged `mean < 5.0`. The squiggle
+  artifacts ([#71]) are not affected — they're a separate concern.
+- **When to revisit:** if a future audit cross-validates pixel-by-
+  pixel against slowrx C output and the finer resolution proves to
+  be the source of a divergence we care about, OR if CPU/memory cost
+  becomes an issue (unlikely; the 4× FFT compute is negligible at
+  per-pixel cadence).
+
+**B) Update the existing "Synthetic round-trip max_diff tolerance"
+entry** if the FFT_LEN bump shifts the boundary-pixel max_diff
+behavior. (The check was dropped in 0.3.2; we don't re-enable it.
+Just update the entry's "verified" numbers if they change.)
+
+### CHANGELOG
+
+`[0.3.3] - 2026-05-03` section before `[0.3.2]`. Sections:
+
+- **Changed** — `FFT_LEN` bumped from 256 to 1024 for 4× finer Hz/bin.
+- **Documentation** — new intentional-deviations entry.
+- **Validation** — round-trips pass at unchanged thresholds; Fram2
+  visual confirmation reproduces the experiment-branch finding.
+- **Notes** — squiggle artifacts ([#71]) still present; the two new
+  diagnostic patterns observed during 0.3.2 validation are 0.3.4+
+  work. The pixel-diff comparator earmarked for 0.3.3 in [#70] moves
+  to 0.3.4 or later.
+
+## Versioning
+
+`0.3.2 → 0.3.3`. Patch bump per semver. No public-API change; only the
+`pub(crate) const FFT_LEN` value moves, which crate-external consumers
+cannot observe.
+
+## Testing posture
+
+### Synthetic round-trip (per-PR gate)
+
+All 6 existing round-trips (`pd120`, `pd180`, `pd240`, `robot24`,
+`robot36`, `robot72`) must continue to pass at the unchanged `mean <
+5.0` per-pixel-RGB-diff threshold. The experiment branch already
+verified this; rebasing onto v0.3.2 (which lifts in the corrected
+ratcheting hysteresis) needs to reconfirm.
+
+### Unit tests
+
+- `snr_bandwidth_correction_bins_match_slowrx` → renamed to
+  `snr_bandwidth_correction_bins_at_finer_resolution` with the 4×
+  bin counts.
+- Existing 10 hysteresis tests, 6 round-trips, all other unit tests:
+  unchanged.
+
+### Real-audio merge gate
+
+Re-run the V2.2 Fram2 procedure (`tests/ariss_fram2_validation.md`)
+on the rebased branch. All 12 `Slide{NN}-decoded.png` files must:
+
+1. Decode without panic.
+2. Produce visually-acceptable output (the user has already validated
+   the pre-rebase experiment branch with "WAY clearer but still
+   squiggles" — this gate confirms the rebase doesn't regress that).
+
+By-eye comparison only. No quantitative threshold — the pixel-diff
+comparator that would let us assert this numerically is itself
+deferred to a future patch ([#70]).
+
+### CPU/memory due-diligence (not gating)
+
+Quick `time` measurement comparing wall-clock decode of one Fram2 WAV
+on `main` (v0.3.2) vs the 0.3.3 branch. Document the result in the
+CHANGELOG `Validation` section. Expected: a few hundred ms slower per
+slide; no concern at SSTV's per-pixel cadence.
+
+### Coverage gate
+
+`cargo llvm-cov` ≥ 92 % per-file maintained. The renamed bandwidth
+test still covers the same `corrected_db()` path; no coverage delta.
+
+## Risks
+
+1. **Rebase introduces a regression.** The experiment branch was
+   branched from `fix/v0.3.2-squiggle-hysteresis` *before* the round-1
+   CR fixes (CR4 algorithm rewrite) shipped. Rebasing onto v0.3.2
+   pulls in the corrected hysteresis. **Mitigation:** the real-audio
+   gate above re-decodes all 12 Fram2 WAVs post-rebase. If the
+   visually-clearer property holds, the rebase is fine. If it
+   regresses, investigate before opening a PR.
+
+2. **CPU cost is unexpectedly high.** Possible if the 4× FFT
+   dominates. **Mitigation:** the due-diligence measurement catches
+   this. Worst case we revert and do nothing for 0.3.3.
+
+3. **Some unit test we don't expect depends on FFT_LEN-derived
+   constants.** Possible but low-probability — the experiment branch
+   only had the one broken test. **Mitigation:** running the full
+   test suite is part of the CI gate; failures are caught early.
+
+## Out-of-scope (for clarity)
+
+- Re-engaging the per-pixel `max_diff` check that was dropped at #45.
+  Even though finer Hz/bin may make boundary pixels less violent, that
+  experiment is its own concern.
+- Adjusting `HANN_LENS` to slowrx C's full-resolution
+  `[48, 64, 96, 128, 256, 512, 1024]` (which would give us slowrx-C-
+  identical *time*-domain analysis paired with 4× finer freq). Worth
+  considering separately; not the smallest possible change.
+- Bumping `WORKING_SAMPLE_RATE_HZ` to 22_050 or 44_100. Different
+  axis of the same trade-off space; far larger blast radius.
+
+## Acceptance criteria
+
+`slowrx 0.3.3` ships when:
+
+1. `FFT_LEN = 1024`, `HANN_LENS` unchanged.
+2. Updated bandwidth-correction test passes.
+3. All 6 synthetic round-trips pass at unchanged thresholds.
+4. All 12 ARISS Fram2 WAVs decode without panic and produce visually-
+   acceptable output (user gate).
+5. New `intentional-deviations.md` entry committed.
+6. CHANGELOG `[0.3.3]` section committed.
+7. PR opened, CR review addressed, merged to main.
+8. `v0.3.3` annotated tag pushed; `cargo publish --features cli
+   --allow-dirty` succeeds.

--- a/src/mode_pd.rs
+++ b/src/mode_pd.rs
@@ -437,8 +437,10 @@ pub(crate) fn decode_one_channel_into(
     let mut stored_lum = vec![0_u8; sweep_len];
 
     // SNR is sticky across the sweep; slowrx initializes with `SNR = 0`
-    // (`video.c:36`) so the first `WinIdx` lookup uses index 4 (the
-    // 256-sample Hann window inside a 1024-sample FFT).
+    // (`video.c:36`) so the first `WinIdx` lookup uses index 4 (slowrx C's
+    // 256-sample Hann window; equivalently `HANN_LENS[4] = 64` samples
+    // in slowrx.rs at our 11_025 Hz working rate, applied inside a
+    // [`FFT_LEN`] = 1024 FFT with the rest zero-padded).
     let mut snr_db = 0.0_f64;
     let mut current_freq = 1500.0_f64 + hedr_shift_hz;
 

--- a/src/mode_pd.rs
+++ b/src/mode_pd.rs
@@ -74,7 +74,9 @@ pub fn ycbcr_to_rgb(y: u8, cr: u8, cb: u8) -> [u8; 3] {
 }
 
 /// FFT length used for per-pixel demod. Matches slowrx's bin spacing:
-/// `256/11025 Hz` = 43.07 Hz/bin, equal to slowrx's `1024/44100 Hz`.
+/// `1024/11025 Hz` ≈ 10.77 Hz/bin — 4× finer than slowrx's `1024/44100 Hz`
+/// = 43.07 Hz/bin (deliberate 0.3.3 divergence; see
+/// `docs/intentional-deviations.md`).
 pub(crate) const FFT_LEN: usize = crate::snr::FFT_LEN;
 
 /// Per-pixel demod context: holds an FFT plan + reusable buffers + the
@@ -103,7 +105,7 @@ impl PdDemod {
     /// Estimate the dominant tone frequency in a Hann-windowed FFT
     /// centered near `center_sample`. `win_idx` selects the Hann length
     /// from [`crate::snr::HANN_LENS`]; the FFT length stays fixed at
-    /// [`FFT_LEN`] (= 256), with leading/trailing zero-pad. Out-of-bounds
+    /// [`FFT_LEN`] (= 1024), with leading/trailing zero-pad. Out-of-bounds
     /// `audio` reads as silence. `hedr_shift_hz` shifts the peak-search
     /// range from `[1500, 2300]` Hz to `[1500 + hedr, 2300 + hedr]` Hz to
     /// follow a mistuned radio's pixel band.
@@ -436,7 +438,7 @@ pub(crate) fn decode_one_channel_into(
 
     // SNR is sticky across the sweep; slowrx initializes with `SNR = 0`
     // (`video.c:36`) so the first `WinIdx` lookup uses index 4 (the
-    // 256-sample window).
+    // 256-sample Hann window inside a 1024-sample FFT).
     let mut snr_db = 0.0_f64;
     let mut current_freq = 1500.0_f64 + hedr_shift_hz;
 
@@ -696,7 +698,7 @@ mod tests {
     #[test]
     fn pdfft_recovers_known_tone_within_5hz() {
         let mut d = PdDemod::new();
-        // 100 ms of pure tone at 1900 Hz; ample for FFT_LEN=256.
+        // 100 ms of pure tone at 1900 Hz; ample for FFT_LEN=1024.
         let audio = synth_tone(1900.0, 0.100);
         let center = (audio.len() / 2) as i64;
         let est = d.pixel_freq(&audio, center, 0.0, DEFAULT_WIN_IDX);

--- a/src/snr.rs
+++ b/src/snr.rs
@@ -11,13 +11,22 @@
 //! [`crate::resample::WORKING_SAMPLE_RATE_HZ`] = `11_025` Hz with
 //! `FFT_LEN = 1024` — same FFT length, **4× finer Hz/bin**
 //! (`11025/1024 ≈ 10.77` Hz/bin vs slowrx's `44100/1024 ≈ 43.07`
-//! Hz/bin). The Hann lengths stay at slowrx's lengths divided by 4
-//! (`[12, 16, 24, 32, 64, 128, 256]`) so the time-domain analysis is
-//! identical to slowrx C; the FFT input is naturally zero-padded
-//! outside the Hann support, giving us 4× more output bins on the
-//! same windowed signal. See
-//! `docs/intentional-deviations.md::"FFT frequency resolution exceeds
-//! slowrx C by 4×"` for rationale.
+//! Hz/bin). The bump produces two coupled DSP changes:
+//!
+//! - **Per-pixel demod**: `HANN_LENS` stays at slowrx's lengths divided
+//!   by 4 (`[12, 16, 24, 32, 64, 128, 256]`), so the Hann is applied
+//!   to the first `HANN_LENS[idx]` samples of the FFT input and the
+//!   rest is zero-padded. Time-domain support identical to slowrx C;
+//!   only the FFT bin density changes (4× more output bins on the
+//!   same windowed signal).
+//! - **SNR estimator**: `hann_long = build_hann(FFT_LEN)` scales with
+//!   `FFT_LEN`, so the SNR-estimator window grows from 256 samples
+//!   (~23 ms = slowrx C) to 1024 samples (~93 ms, 4× longer). This
+//!   gives a cleaner SNR estimate and is a desirable side-effect.
+//!
+//! See `docs/intentional-deviations.md::"FFT frequency resolution
+//! exceeds slowrx C by 4×"` for the full rationale and revisit
+//! triggers.
 
 use rustfft::{num_complex::Complex, FftPlanner};
 
@@ -26,9 +35,11 @@ use rustfft::{num_complex::Complex, FftPlanner};
 pub(crate) const FFT_LEN: usize = 1024;
 
 /// Hann-window lengths at the `11_025` Hz working rate (slowrx's
-/// `[48, 64, 96, 128, 256, 512, 1024]` divided by 4). Index 6 (length
-/// = `FFT_LEN`) is the "longest, lowest-SNR" window and is also reused
-/// by the SNR estimator. Translated from `video.c:54`.
+/// `[48, 64, 96, 128, 256, 512, 1024]` divided by 4). Index 6
+/// (length 256) is the "longest, lowest-SNR" window in the per-pixel
+/// demod's bank. The SNR estimator carries its own Hann window of
+/// length [`FFT_LEN`] = 1024 — see [`SnrEstimator`] for the size
+/// rationale. Translated from `video.c:54`.
 pub(crate) const HANN_LENS: [usize; 7] = [12, 16, 24, 32, 64, 128, 256];
 
 /// Pre-computed Hann window of length [`FFT_LEN`]. Used inside the

--- a/src/snr.rs
+++ b/src/snr.rs
@@ -9,15 +9,21 @@
 //! slowrx operates at `44_100` Hz with `FFTLen = 1024` and Hann lengths
 //! `[48, 64, 96, 128, 256, 512, 1024]`. We operate at
 //! [`crate::resample::WORKING_SAMPLE_RATE_HZ`] = `11_025` Hz with
-//! `FFT_LEN = 256` (a 4× reduction that preserves the same Hz-per-bin
-//! resolution: `44100/1024 ≈ 11025/256 ≈ 43.07` Hz/bin). The Hann lengths
-//! shrink by the same factor: `[12, 16, 24, 32, 64, 128, 256]`.
+//! `FFT_LEN = 1024` — same FFT length, **4× finer Hz/bin**
+//! (`11025/1024 ≈ 10.77` Hz/bin vs slowrx's `44100/1024 ≈ 43.07`
+//! Hz/bin). The Hann lengths stay at slowrx's lengths divided by 4
+//! (`[12, 16, 24, 32, 64, 128, 256]`) so the time-domain analysis is
+//! identical to slowrx C; the FFT input is naturally zero-padded
+//! outside the Hann support, giving us 4× more output bins on the
+//! same windowed signal. See
+//! `docs/intentional-deviations.md::"FFT frequency resolution exceeds
+//! slowrx C by 4×"` for rationale.
 
 use rustfft::{num_complex::Complex, FftPlanner};
 
 /// FFT length used for both per-pixel demod and SNR estimation. Must
 /// match [`crate::mode_pd::FFT_LEN`].
-pub(crate) const FFT_LEN: usize = 256;
+pub(crate) const FFT_LEN: usize = 1024;
 
 /// Hann-window lengths at the `11_025` Hz working rate (slowrx's
 /// `[48, 64, 96, 128, 256, 512, 1024]` divided by 4). Index 6 (length
@@ -197,7 +203,7 @@ pub(crate) fn window_idx_for_snr_with_hysteresis(snr_db: f64, prev_idx: usize) -
 /// pre-computed and reused on every estimate.
 ///
 /// Translated from `video.c:302-343`. Each `estimate` call mirrors one
-/// pass through that block: FFT a 256-sample window, integrate power
+/// pass through that block: FFT a 1024-sample window, integrate power
 /// over `[1500+hedr, 2300+hedr]` Hz (video band) and over
 /// `[400+hedr, 800+hedr] ∪ [2700+hedr, 3400+hedr]` Hz (noise band),
 /// apply the bandwidth correction in `video.c:336-338`, and return
@@ -482,24 +488,31 @@ mod tests {
         assert_eq!(build_hann(1), vec![0.0]);
     }
 
-    /// Verify SNR bandwidth-correction bin counts match slowrx's `GetBin`
-    /// truncation semantics (round-2 audit Finding 2/3).
+    /// Verify the SNR-estimator bandwidth correction's bin counts at our
+    /// finer-than-slowrx-C frequency resolution. With `FFT_LEN=1024` at
+    /// `WORKING_SAMPLE_RATE_HZ=11_025` we get ~10.77 Hz/bin (4× finer
+    /// than slowrx C's `1024/44_100`). The integration ranges in Hz are
+    /// the same as slowrx C — `[1500, 2300]` for video and
+    /// `[400, 800] ∪ [2700, 3400]` for noise — but the `usize` bin
+    /// counts are higher in proportion to the resolution.
     ///
-    /// At `FFT_LEN=256, SR=11025` with `hedr=0`:
+    /// At `FFT_LEN=1024, SR=11_025` (slowrx `GetBin` floor truncation):
     ///
-    /// | Quantity                    | Expected (slowrx `GetBin` trunc) |
-    /// |-----------------------------|----------------------------------|
-    /// | `video_plus_noise_bins`     | 53 − 34 + 1 = 20                |
-    /// | `noise_only_bins`           | (18−9+1) + (78−62+1) = 10+17 = 27 |
-    /// | `receiver_bins`             | 78 − 9 = 69                      |
-    /// | Pnoise multiplier      | 69/27 ≈ 2.5556                |
-    /// | Psignal subtractor     | 20/27 ≈ 0.7407                |
+    /// | Quantity                  | Expected                          |
+    /// |---------------------------|-----------------------------------|
+    /// | `video_plus_noise_bins`   | 213 − 139 + 1 = 75                |
+    /// | `noise_only_bins`         | (74−37+1) + (315−250+1) = 38+66 = 104 |
+    /// | `receiver_bins`           | 315 − 37 = 278                    |
+    /// | Pnoise multiplier         | 278/104 ≈ 2.6731                  |
+    /// | Psignal subtractor        | 75/104 ≈ 0.7212                   |
     ///
-    /// These values differ from what `.round()` would give (70/28 = 2.5 and
-    /// 19/28 ≈ 0.6786 respectively), so this test is a regression guard for
-    /// the `get_bin` truncation in `snr.rs::estimate`.
+    /// These values differ from what `.round()` would give, so the test
+    /// is still a regression guard for the `get_bin` truncation in
+    /// `snr.rs::estimate`. It no longer asserts slowrx-C-parity in
+    /// `usize` terms (we deliberately exceed slowrx in frequency
+    /// resolution; see `docs/intentional-deviations.md`).
     #[test]
-    fn snr_bandwidth_correction_bins_match_slowrx() {
+    fn snr_bandwidth_correction_bins_at_finer_resolution() {
         let get_bin =
             |hz: f64| crate::get_bin(hz, FFT_LEN, crate::resample::WORKING_SAMPLE_RATE_HZ);
 
@@ -515,26 +528,26 @@ mod tests {
         let receiver_bins = n_hi_b - n_lo_a;
 
         assert_eq!(
-            video_plus_noise_bins, 20,
+            video_plus_noise_bins, 75,
             "video+noise bins: got {video_plus_noise_bins}"
         );
         assert_eq!(
-            noise_only_bins, 27,
+            noise_only_bins, 104,
             "noise-only bins: got {noise_only_bins}"
         );
-        assert_eq!(receiver_bins, 69, "receiver bins: got {receiver_bins}");
+        assert_eq!(receiver_bins, 278, "receiver bins: got {receiver_bins}");
 
-        // Pnoise multiplier ≈ 2.5556 (slowrx) vs 2.5000 (with .round())
+        // Pnoise multiplier ≈ 2.6731 (FFT_LEN=1024) vs 2.5556 (FFT_LEN=256 / slowrx).
         let pnoise_mult = receiver_bins as f64 / noise_only_bins as f64;
         assert!(
-            (pnoise_mult - 69.0 / 27.0).abs() < 1e-9,
+            (pnoise_mult - 278.0 / 104.0).abs() < 1e-9,
             "Pnoise mult: {pnoise_mult}"
         );
 
-        // Psignal subtractor ≈ 0.7407 (slowrx) vs 0.6786 (with .round())
+        // Psignal subtractor ≈ 0.7212 (FFT_LEN=1024) vs 0.7407 (FFT_LEN=256 / slowrx).
         let psignal_sub = video_plus_noise_bins as f64 / noise_only_bins as f64;
         assert!(
-            (psignal_sub - 20.0 / 27.0).abs() < 1e-9,
+            (psignal_sub - 75.0 / 104.0).abs() < 1e-9,
             "Psignal sub: {psignal_sub}"
         );
     }

--- a/src/snr.rs
+++ b/src/snr.rs
@@ -42,8 +42,9 @@ pub(crate) const FFT_LEN: usize = 1024;
 /// rationale. Translated from `video.c:54`.
 pub(crate) const HANN_LENS: [usize; 7] = [12, 16, 24, 32, 64, 128, 256];
 
-/// Pre-computed Hann window of length [`FFT_LEN`]. Used inside the
-/// SNR estimator and as the longest-window entry of the bank.
+/// Build a Hann window of length `len`. Used for both the per-pixel
+/// demod's [`HannBank`] entries (lengths from [`HANN_LENS`]) and the
+/// [`SnrEstimator`]'s [`FFT_LEN`]-sample `hann_long`.
 #[allow(clippy::cast_precision_loss)]
 fn build_hann(len: usize) -> Vec<f32> {
     if len == 0 {


### PR DESCRIPTION
## Summary

- Bump `crate::snr::FFT_LEN` from 256 to 1024 → 10.77 Hz/bin (4× finer than 0.3.2's 43.07 Hz/bin / slowrx C).
- Two coupled DSP changes ship together (intentional, both desirable):
  - **Per-pixel demod**: 4× finer bin density only. `HANN_LENS` unchanged at slowrx-C-divided-by-4; Hann fills first ≤256 samples of the 1024 FFT, rest zero-padded → time-domain support identical to slowrx C.
  - **SNR estimator**: `hann_long = build_hann(FFT_LEN)` scales with `FFT_LEN`, so the SNR-estimator window grows from ~23 ms (= slowrx C) to ~93 ms. Cleaner SNR estimate; likely reduces window-selector flip-flop beyond the 0.3.2 hysteresis.
- Renamed `snr_bandwidth_correction_bins_match_slowrx` → `snr_bandwidth_correction_bins_at_finer_resolution` with post-bump bin counts (75 / 104 / 278). Hz-domain bandwidth is preserved; only the `usize` counts change.
- New `intentional-deviations.md` entry: "FFT frequency resolution exceeds slowrx C by 4×". Documents both coupled deviations.
- Stale rustdoc claims fixed: `HANN_LENS[6]` no longer claimed to equal `FFT_LEN`; `build_hann` helper rustdoc rewritten; `prev_win_idx` cold-start comment disambiguates slowrx C's 256-sample Hann from `HANN_LENS[4] = 64`.
- Real-audio Fram2 visual validation: all 12 slides reproduce the experiment-branch "WAY clearer but still squiggles" verdict.
- Wall-clock perf cost: 0.614 s → 1.223 s per Slide01 decode (~2× slower; negligible vs R36's ~36 s transmit cadence).
- Squiggles ([#71]) unaffected — separate concern, tracked through 0.3.5+.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo test --all-features --locked` — 104 lib + 6 round-trip + 1 doctest all pass
- [x] `RUSTDOCFLAGS=-D warnings cargo doc --no-deps --all-features` clean (new intra-doc links resolve)
- [x] All 6 synthetic round-trips at unchanged `mean < 5.0`
- [x] All 12 ARISS Fram2 WAVs decode without panic and reproduce the experiment-branch visual verdict (user-confirmed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Version 0.3.3 Release

* **Improvements**
  * Significantly enhanced frequency resolution in signal demodulation, providing 4× finer detail for clearer signal analysis and visualization.
  * Validated on real-world signal recordings with improved visual clarity.

* **Documentation**
  * Added comprehensive documentation describing frequency resolution enhancements and intentional implementation deviations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->