### PR TITLE
feat(scottie): V2.3 — Scottie family (S1, S2, DX) — 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,76 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-05-04
+
+Minor release adding the Scottie family — Scottie 1, Scottie 2,
+Scottie DX. All three at 320×256, GBR color encoding, with **mid-line
+sync** (sync sits between B and R within each radio line, not at
+line start). Synthetic round-trip-validated; real-radio Scottie
+capture validation is async ([#65]).
+
+[#65]: https://github.com/jasonherald/slowrx.rs/issues/65
+
+### Added
+
+- **`SstvMode::Scottie1`** (VIS `0x3C`), **`Scottie2`** (`0x38`),
+  **`ScottieDx`** (`0x4C`).
+- **`ChannelLayout::RgbSequential`** — three-channel RGB layout per
+  radio line. Shared with V2.4 Martin.
+- **`SyncPosition::Scottie`** — sync between B and R, the V2.1
+  forcing-function variant cashed in.
+- Three new `ModeSpec` consts: `SCOTTIE1`, `SCOTTIE2`, `SCOTTIE_DX`.
+  Values transcribed from slowrx C `modespec.c:91-128`.
+- New module `crate::mode_scottie` with `decode_line`. Mid-line-sync
+  handling lives entirely inside this module; the substantive
+  changes outside it are a `find_sync` branch (next item) and a
+  Scottie DX–only Hann-window-index bump in
+  `mode_pd::decode_one_channel_into`.
+- New module `crate::scottie_test_encoder` (gated behind
+  `cfg(any(test, feature = "test-support"))`). Synthetic encoder for
+  round-trip testing.
+
+### Changed
+
+- **`crate::sync::find_sync`** gains a `SyncPosition::Scottie`
+  branch. PD/Robot/Martin land at line-start sync; Scottie's sync is
+  mid-line, so after the existing `s = (xmax/700) · LineTime −
+  SyncTime` formula we apply `s = s − chan_len/2 + 2·porch` to bring
+  `skip_samples` back to the start of line 0's content. This is
+  exactly the slowrx C `sync.c:123-125` correction the V2.1
+  `SyncPosition` carve-out anticipated. PD/Robot/Martin behavior is
+  unchanged (`SyncPosition::LineStart` keeps the existing formula).
+- **`crate::mode_pd::decode_one_channel_into`** post-adjusts the
+  Hann window index by `+1` when `spec.mode == ScottieDx && idx <
+  6`, matching slowrx C `video.c:367` (longer integration for SDX's
+  1.08 ms pixel time). Applied after the hysteresis selector tracks
+  the un-bumped SNR-derived index, so the bump doesn't compound
+  across pixels. No-op for non-SDX modes.
+- **`decoder.rs`** dispatch grows an `RgbSequential` arm; the
+  `target_audio_samples` match arm gains `RgbSequential =>
+  spec.image_lines` (one radio line per image row, like Robot).
+
+### Validation
+
+- Three new synthetic round-trips (`scottie1_roundtrip`,
+  `scottie2_roundtrip`, `scottie_dx_roundtrip`) pass at unchanged
+  `mean < 5.0` per-pixel-RGB-diff threshold.
+- All 6 existing round-trips (PD120/180/240, Robot24/36/72) continue
+  to pass at the same threshold — regression net intact.
+- Coverage ≥ 92% per-file maintained.
+
+### Notes
+
+- Mid-line sync was V2.1's forcing-function carve-out;
+  `SyncPosition::Scottie` makes it explicit at dispatch time so
+  future modes can't accidentally inherit a line-start assumption.
+- Real-radio Scottie capture validation is async (no reference WAVs
+  available yet). The pixel-diff comparator earmarked in [#70] is
+  still pending. Squiggle work ([#71]) remains parked.
+
+[#70]: https://github.com/jasonherald/slowrx.rs/issues/70
+[#71]: https://github.com/jasonherald/slowrx.rs/issues/71
+
 ## [0.3.3] - 2026-05-03
 
 Patch release bumping `crate::snr::FFT_LEN` from 256 to 1024 to give

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -707,7 +707,7 @@ checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "slowrx"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slowrx"
-version = "0.3.3"
+version = "0.4.0"
 edition = "2021"
 rust-version = "1.85"
 description = "Pure-Rust SSTV (Slow-Scan TV) decoder library — a port of slowrx by Oona Räisänen"

--- a/docs/superpowers/plans/2026-05-04-v0.4.0-scottie.md
+++ b/docs/superpowers/plans/2026-05-04-v0.4.0-scottie.md
@@ -19,7 +19,8 @@
 - **No backwards-compatibility shims.** Just add the new variants outright.
 
 **No-touch list (must not be modified):**
-- `src/sync.rs`, `src/vis.rs`, `src/snr.rs::FFT_LEN`, `src/snr.rs::HANN_LENS` — no changes expected. The `src/snr.rs::window_idx_for_snr` rustdoc gets a small text refresh in Phase 4 (the "Scottie not yet supported" stub goes away) but no behavior change.
+- `src/vis.rs`, `src/snr.rs::FFT_LEN`, `src/snr.rs::HANN_LENS` — no changes expected. The `src/snr.rs::window_idx_for_snr` rustdoc gets a small text refresh in Phase 4 (the "Scottie not yet supported" stub goes away) but no behavior change.
+- `src/sync.rs` — the spec authorizes a `find_sync` change here per the "May require changes to sync.rs" carve-out, since the V2.1 `SyncPosition` forcing-function exists precisely to surface mid-line-sync handling. Phase 3 added the `SyncPosition::Scottie` branch; PD/Robot/Martin (`SyncPosition::LineStart`) behavior is unchanged.
 - Existing 6 round-trips (PD120/180/240, R24/36/72) must continue to pass at unchanged `mean < 5.0` thresholds — regression net.
 
 ---

--- a/docs/superpowers/plans/2026-05-04-v0.4.0-scottie.md
+++ b/docs/superpowers/plans/2026-05-04-v0.4.0-scottie.md
@@ -1,0 +1,1175 @@
+# 0.4.0 V2.3 Scottie Family Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add decoder support for Scottie 1 / Scottie 2 / Scottie DX as a single 0.4.0 release. Mid-line sync (sync sits between B and R within each radio line). GBR color encoding. Single PR shipping all three modes plus the `ChannelLayout::RgbSequential` infrastructure (which Martin V2.4 will reuse).
+
+**Architecture:** New `src/mode_scottie.rs` (≤ 500 LOC) with `decode_line` containing the mid-line idiosyncrasy. New `ChannelLayout::RgbSequential` and `SyncPosition::Scottie` enum variants. Three new `SstvMode` variants + three `ModeSpec` consts in `src/modespec.rs` (values from `original/slowrx/modespec.c:91-128`). `decoder.rs` gets one new dispatch arm and one new `target_audio_samples` match arm. New `src/scottie_test_encoder.rs` (mirrors `robot_test_encoder.rs`). Three new round-trip tests.
+
+**Tech Stack:** Rust 2021 (MSRV 1.85), `rustfft`, `thiserror`. CI runs `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --all-features --locked`, `RUSTDOCFLAGS=-D warnings cargo doc --no-deps --all-features`. Release: `cargo publish --features cli --allow-dirty`. GitHub via `gh` CLI.
+
+**Spec reference:** `docs/superpowers/specs/2026-05-04-v0.4.0-scottie-design.md` (committed on this branch as `09bdd2c`).
+**slowrx C reference (locally):** `original/slowrx/modespec.c:91-128` (Scottie ModeSpec consts), `original/slowrx/video.c:72-79` (mid-line ChanStart computation), `video.c:367` (SDX Hann bump), `video.c:440-444` (GBR storage convention).
+
+**Working directory:** `/data/source/slowrx.rs-v0.4.0-scottie` (worktree on `feat/v0.4.0-scottie`, branched from `main` at v0.3.3 SHA `3e349de`).
+
+**Project conventions:**
+- **No GPG signing** of commits or tags. Use plain `git commit`.
+- **Full local CI gate** before each commit: `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test --all-features --locked`, `RUSTDOCFLAGS=-D warnings cargo doc --no-deps --all-features`. The doc gate has caught CI failures we'd otherwise have missed.
+- **No backwards-compatibility shims.** Just add the new variants outright.
+
+**No-touch list (must not be modified):**
+- `src/sync.rs`, `src/vis.rs`, `src/snr.rs::FFT_LEN`, `src/snr.rs::HANN_LENS` — no changes expected. The `src/snr.rs::window_idx_for_snr` rustdoc gets a small text refresh in Phase 4 (the "Scottie not yet supported" stub goes away) but no behavior change.
+- Existing 6 round-trips (PD120/180/240, R24/36/72) must continue to pass at unchanged `mean < 5.0` thresholds — regression net.
+
+---
+
+## Phase 1 — Foundations: enum variants + ModeSpec + dispatch (single commit)
+
+Compile-clean scaffolding lands first. The new module `mode_scottie.rs` ships as a stub returning silence, which the round-trips in Phase 3 will replace. Splitting modespec/decoder/lib.rs from `mode_scottie::decode_line` lets Phase 1 be a small, type-system-only change that keeps the build green.
+
+### Task 1.1: Add `SstvMode` variants, `ChannelLayout::RgbSequential`, `SyncPosition::Scottie`, three `ModeSpec` consts, and lookup arms
+
+**Files:**
+- Modify: `src/modespec.rs` enum definitions (lines ~16-100), `for_vis_code` (~100-130), `for_mode` (~136-150), and append three `ModeSpec` consts at the end of the consts block.
+
+- [ ] **Step 1: Add the new enum variants**
+
+In `src/modespec.rs`, add to `pub enum SstvMode`:
+
+```rust
+pub enum SstvMode {
+    // ... existing variants ...
+    /// Scottie 1 — VIS `0x3C`, 320×256 GBR, 0.4320 ms/pixel.
+    Scottie1,
+    /// Scottie 2 — VIS `0x38`, 320×256 GBR, 0.2752 ms/pixel.
+    Scottie2,
+    /// Scottie DX — VIS `0x4C`, 320×256 GBR, 1.08053 ms/pixel.
+    /// slowrx applies a +1 Hann-window-index bump in the per-pixel
+    /// demod when this mode is active (see `mode_scottie::decode_line`).
+    ScottieDx,
+}
+```
+
+Add to `pub enum ChannelLayout`:
+
+```rust
+/// Sequential single-line RGB layout — three channels per radio
+/// line. Used by Scottie (G→B→R, sync mid-line) and Martin (G→B→R,
+/// sync at line start).
+RgbSequential,
+```
+
+Add to `pub enum SyncPosition`:
+
+```rust
+/// Sync pulse between B and R within each radio line. Scottie family.
+Scottie,
+```
+
+- [ ] **Step 2: Add three `ModeSpec` consts**
+
+After the existing `ROBOT72` const, append:
+
+```rust
+/// Scottie 1. slowrx `modespec.c:91-102`.
+pub const SCOTTIE1: ModeSpec = ModeSpec {
+    mode: SstvMode::Scottie1,
+    name: "Scottie 1",
+    short_name: "S1",
+    vis_code: 0x3C,
+    sync_seconds: 9e-3,
+    porch_seconds: 1.5e-3,
+    septr_seconds: 1.5e-3,
+    pixel_seconds: 0.4320e-3,
+    line_seconds: 428.38e-3,
+    line_pixels: 320,
+    image_lines: 256,
+    line_height: 1,
+    channel_layout: ChannelLayout::RgbSequential,
+    sync_position: SyncPosition::Scottie,
+};
+
+/// Scottie 2. slowrx `modespec.c:104-115`.
+pub const SCOTTIE2: ModeSpec = ModeSpec {
+    mode: SstvMode::Scottie2,
+    name: "Scottie 2",
+    short_name: "S2",
+    vis_code: 0x38,
+    sync_seconds: 9e-3,
+    porch_seconds: 1.5e-3,
+    septr_seconds: 1.5e-3,
+    pixel_seconds: 0.2752e-3,
+    line_seconds: 277.692e-3,
+    line_pixels: 320,
+    image_lines: 256,
+    line_height: 1,
+    channel_layout: ChannelLayout::RgbSequential,
+    sync_position: SyncPosition::Scottie,
+};
+
+/// Scottie DX. slowrx `modespec.c:117-128`.
+pub const SCOTTIE_DX: ModeSpec = ModeSpec {
+    mode: SstvMode::ScottieDx,
+    name: "Scottie DX",
+    short_name: "SDX",
+    vis_code: 0x4C,
+    sync_seconds: 9e-3,
+    porch_seconds: 1.5e-3,
+    septr_seconds: 1.5e-3,
+    pixel_seconds: 1.08053e-3,
+    line_seconds: 1050.3e-3,
+    line_pixels: 320,
+    image_lines: 256,
+    line_height: 1,
+    channel_layout: ChannelLayout::RgbSequential,
+    sync_position: SyncPosition::Scottie,
+};
+```
+
+(Field order may differ slightly — match the existing `PD120` / `ROBOT72` const layout exactly. Verify by reading `modespec.rs` around line 152-243 first.)
+
+- [ ] **Step 3: Add `for_mode` lookup arms**
+
+Inside `pub fn for_mode(mode: SstvMode) -> ModeSpec`, add three arms:
+
+```rust
+SstvMode::Scottie1 => SCOTTIE1,
+SstvMode::Scottie2 => SCOTTIE2,
+SstvMode::ScottieDx => SCOTTIE_DX,
+```
+
+- [ ] **Step 4: Add `for_vis_code` lookup arms**
+
+Find the existing `for_vis_code` table/match. Add:
+
+```rust
+0x3C => Some(SCOTTIE1),
+0x38 => Some(SCOTTIE2),
+0x4C => Some(SCOTTIE_DX),
+```
+
+(Or the equivalent if the lookup is a static array indexed by VIS code rather than a match.)
+
+- [ ] **Step 5: Refresh `SyncPosition::LineStart` rustdoc**
+
+Around line 93, the `LineStart` rustdoc says "All currently-shipped modes (PD, Robot) emit `SyncPosition::LineStart`. The `Scottie` variant lands with the V2.3 Scottie family epic." Replace with:
+
+```rust
+/// Sync pulse at the start of each radio line. PD, Robot, Martin.
+/// Scottie family uses [`SyncPosition::Scottie`] instead.
+LineStart,
+```
+
+- [ ] **Step 6: Add unit tests for the three new `ModeSpec` consts**
+
+In the existing `mod tests` block in `src/modespec.rs`, add three tests mirroring the `robot72` test pattern:
+
+```rust
+#[test]
+fn scottie1_modespec() {
+    let spec = for_mode(SstvMode::Scottie1);
+    assert_eq!(spec.mode, SstvMode::Scottie1);
+    assert_eq!(spec.vis_code, 0x3C);
+    assert_eq!(spec.line_pixels, 320);
+    assert_eq!(spec.image_lines, 256);
+    assert_eq!(spec.channel_layout, ChannelLayout::RgbSequential);
+    assert_eq!(spec.sync_position, SyncPosition::Scottie);
+    assert!((spec.pixel_seconds - 0.4320e-3).abs() < 1e-9);
+    assert!((spec.line_seconds - 428.38e-3).abs() < 1e-9);
+}
+
+#[test]
+fn scottie2_modespec() {
+    let spec = for_mode(SstvMode::Scottie2);
+    assert_eq!(spec.mode, SstvMode::Scottie2);
+    assert_eq!(spec.vis_code, 0x38);
+    assert!((spec.pixel_seconds - 0.2752e-3).abs() < 1e-9);
+    assert!((spec.line_seconds - 277.692e-3).abs() < 1e-9);
+    assert_eq!(spec.channel_layout, ChannelLayout::RgbSequential);
+    assert_eq!(spec.sync_position, SyncPosition::Scottie);
+}
+
+#[test]
+fn scottie_dx_modespec() {
+    let spec = for_mode(SstvMode::ScottieDx);
+    assert_eq!(spec.mode, SstvMode::ScottieDx);
+    assert_eq!(spec.vis_code, 0x4C);
+    assert!((spec.pixel_seconds - 1.08053e-3).abs() < 1e-9);
+    assert!((spec.line_seconds - 1050.3e-3).abs() < 1e-9);
+    assert_eq!(spec.channel_layout, ChannelLayout::RgbSequential);
+    assert_eq!(spec.sync_position, SyncPosition::Scottie);
+}
+
+#[test]
+fn scottie_vis_codes_resolve() {
+    assert_eq!(for_vis_code(0x3C).unwrap().mode, SstvMode::Scottie1);
+    assert_eq!(for_vis_code(0x38).unwrap().mode, SstvMode::Scottie2);
+    assert_eq!(for_vis_code(0x4C).unwrap().mode, SstvMode::ScottieDx);
+}
+```
+
+- [ ] **Step 7: Compile + run modespec tests**
+
+```bash
+cargo test --features test-support --lib modespec 2>&1 | grep -E "^test result|FAIL"
+```
+
+Expected: every `modespec::tests::scottie*` test passes. The build won't fully compile yet because `decoder.rs` and other call sites have non-exhaustive matches that need updating in Task 1.2 — if the lib build fails with `non-exhaustive patterns: ChannelLayout::RgbSequential not covered`, that's expected; proceed to Task 1.2.
+
+### Task 1.2: Add `decoder.rs` dispatch arm + `target_audio_samples` match arm + stub `mode_scottie::decode_line`
+
+**Files:**
+- Create: `src/mode_scottie.rs` (stub).
+- Modify: `src/lib.rs` (add `pub mod mode_scottie;`).
+- Modify: `src/decoder.rs` lines 245-248 (target_audio_samples match) and lines 386-455 (decode-loop dispatch).
+
+- [ ] **Step 1: Create the stub `src/mode_scottie.rs`**
+
+```rust
+//! Scottie-family mode decoder (Scottie 1, Scottie 2, Scottie DX).
+//!
+//! Three-channel sequential RGB layout per radio line, with sync sitting
+//! between the B and R channels (mid-line). This is the V2.3 mid-line-
+//! sync forcing-function — `decoder.rs`'s line-clock advance and
+//! `find_sync`'s detection both stay generic; the mid-line idiosyncrasy
+//! lives entirely inside [`decode_line`].
+//!
+//! Translated from slowrx's `video.c:72-79` (Scottie ChanStart layout)
+//! and `video.c:367` (SDX Hann-bump). slowrx GBR storage convention
+//! (`video.c:440-444`) is bypassed: we write RGB directly.
+//!
+//! ```text
+//! Scottie radio line layout:
+//!   [septr][ G pixels ][septr][ B pixels ][SYNC][porch][ R pixels ]
+//!     ^                                       ^
+//!     |                                       |
+//!     line start                              find_sync detects this
+//!                                             (mid-line)
+//! ```
+//!
+//! See `NOTICE.md` for full slowrx attribution.
+
+use crate::modespec::{ModeSpec, SstvMode};
+
+/// Decode one Scottie radio line into `image`. Reads G, B from before
+/// the sync (negative offsets relative to sync_time) and R from after,
+/// composing RGB in place.
+///
+/// `line_index` is the 0-based image row this radio line emits;
+/// `line_seconds_offset` is `f64::from(line_index) * spec.line_seconds`
+/// (un-rounded — the per-pixel time computation does the single
+/// `round()` to match slowrx `video.c:140-142`).
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn decode_line(
+    spec: ModeSpec,
+    line_index: u32,
+    audio: &[f32],
+    skip_samples: i64,
+    line_seconds_offset: f64,
+    rate_hz: f64,
+    image: &mut crate::image::SstvImage,
+    demod: &mut crate::mode_pd::PdDemod,
+    snr_est: &mut crate::snr::SnrEstimator,
+    hedr_shift_hz: f64,
+) {
+    // STUB — Phase 3 implements this. For now write zeros so the
+    // build links and the round-trip will fail at the diff-mean check
+    // (giving us the TDD red).
+    let _ = (spec, line_index, audio, skip_samples, line_seconds_offset,
+             rate_hz, image, demod, snr_est, hedr_shift_hz);
+}
+
+#[cfg(test)]
+mod tests {
+    // Tests land in Phase 3 alongside the implementation.
+}
+```
+
+- [ ] **Step 2: Register the module in `src/lib.rs`**
+
+Add to `lib.rs`:
+
+```rust
+pub mod mode_scottie;
+```
+
+(Match the visibility of the existing `pub mod mode_pd;` / `pub mod mode_robot;` lines — likely `pub` for public, or `pub(crate)` if those are crate-private. Check the existing pattern.)
+
+- [ ] **Step 3: Add `target_audio_samples` match arm in `decoder.rs`**
+
+Around line 245-248, the existing match becomes:
+
+```rust
+let radio_frames_per_image = match spec.channel_layout {
+    crate::modespec::ChannelLayout::PdYcbcr => spec.image_lines / 2,
+    crate::modespec::ChannelLayout::RobotYuv => spec.image_lines,
+    crate::modespec::ChannelLayout::RgbSequential => spec.image_lines,
+};
+```
+
+Scottie is one radio line per image row, same as Robot.
+
+- [ ] **Step 4: Add decode-loop dispatch arm in `decoder.rs`**
+
+After the existing `RobotYuv` arm (around line 455), add:
+
+```rust
+crate::modespec::ChannelLayout::RgbSequential => {
+    // Scottie family. Mid-line sync handling lives inside
+    // mode_scottie::decode_line. No chroma_planes — RGB is composed
+    // in-place per line (no deferred chroma like R36/R24).
+    for line in 0..d.spec.image_lines {
+        let line_seconds_offset = f64::from(line) * d.spec.line_seconds;
+        crate::mode_scottie::decode_line(
+            d.spec,
+            line,
+            &d.audio,
+            skip,
+            line_seconds_offset,
+            rate,
+            &mut d.image,
+            pd_demod,
+            snr_est,
+            d.hedr_shift_hz,
+        );
+        let start = (line as usize) * line_pixels;
+        let end = start + line_pixels;
+        out.push(SstvEvent::LineDecoded {
+            mode: d.mode,
+            line_index: line,
+            pixels: d.image.pixels[start..end].to_vec(),
+        });
+    }
+}
+```
+
+- [ ] **Step 5: Run the full lib test suite**
+
+```bash
+cargo test --features test-support --lib 2>&1 | grep -E "^test result|FAIL"
+```
+
+Expected: all existing tests pass, plus the four new modespec tests from Task 1.1. The stub `decode_line` doesn't run yet — only the type-system surface is exercised here.
+
+### Task 1.3: Run full local CI gate + commit Phase 1
+
+- [ ] **Step 1: Full CI gate**
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --all-targets --all-features -- -D warnings 2>&1 | tail -3
+cargo test --all-features --locked 2>&1 | grep -E "^test result"
+RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features 2>&1 | tail -3
+```
+
+All four must pass. If `cargo fmt --check` complains, run `cargo fmt --all` and re-verify. If clippy complains, fix the offending tokens (most likely `unused_variables` on the stub `decode_line`'s parameters — handled by the `let _ = (...);` line above).
+
+- [ ] **Step 2: Commit Phase 1**
+
+```bash
+git add -- src/modespec.rs src/lib.rs src/decoder.rs src/mode_scottie.rs
+git commit -m "$(cat <<'EOF'
+feat(scottie): scaffolding — modespec + dispatch + decode_line stub
+
+Phase 1 of V2.3 Scottie. Adds the type-system surface for Scottie
+1/2/DX with a stub mode_scottie::decode_line that returns silence
+(round-trip will fail until Phase 3 implements the demodulation).
+
+- src/modespec.rs: three new SstvMode variants (Scottie1, Scottie2,
+  ScottieDx), ChannelLayout::RgbSequential (shared with V2.4 Martin),
+  SyncPosition::Scottie. Three new ModeSpec consts (SCOTTIE1,
+  SCOTTIE2, SCOTTIE_DX) transcribed from slowrx C modespec.c:91-128.
+  Lookup arms in for_mode + for_vis_code. Four new modespec unit
+  tests (one per mode + a VIS-code resolution test).
+- src/decoder.rs: ChannelLayout match arms for target_audio_samples
+  (RgbSequential => spec.image_lines, same as Robot) and the
+  decode-loop dispatch (calls mode_scottie::decode_line per radio
+  line, like Robot). No chroma_planes — Scottie composes RGB
+  in-place.
+- src/mode_scottie.rs: stub decode_line + module-level rustdoc with
+  the layout diagram and a pointer to slowrx C.
+- src/lib.rs: registers the new module.
+- src/modespec.rs::SyncPosition::LineStart rustdoc refreshed:
+  the "Scottie variant lands with V2.3" stub is replaced with a
+  forward reference to SyncPosition::Scottie.
+
+CI gate clean. Existing 6 round-trips still pass. The stub
+decode_line is wired into the dispatch but doesn't yet decode —
+Phase 3 lands the demodulation.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+- [ ] **Step 3: Verify**
+
+```bash
+git log --oneline -3
+```
+
+Expected: 2 commits on the branch (the spec doc + Phase 1).
+
+---
+
+## Phase 2 — Synthetic encoder (single commit)
+
+The encoder produces FM audio matching the Scottie line layout so the round-trips in Phase 3 have a known-good signal to decode. Mirrors `src/robot_test_encoder.rs`'s shape exactly.
+
+### Task 2.1: Create `src/scottie_test_encoder.rs`
+
+**Files:**
+- Create: `src/scottie_test_encoder.rs`.
+- Modify: `src/lib.rs` (gate the module behind `cfg(any(test, feature = "test-support"))`).
+
+- [ ] **Step 1: Read the existing `robot_test_encoder.rs` for the pattern**
+
+Run:
+```bash
+cat src/robot_test_encoder.rs | head -60
+```
+
+Note the `fill_to`, `lum_to_freq`, `WORKING_SAMPLE_RATE_HZ` import, the cumulative-target pattern, and the per-line loop structure. Mirror this in `scottie_test_encoder.rs`.
+
+- [ ] **Step 2: Write `src/scottie_test_encoder.rs`**
+
+```rust
+//! Synthetic Scottie encoder for round-trip testing. Produces
+//! continuous-phase FM audio matching the encoder side of the SSTV
+//! protocol for Scottie 1, Scottie 2, and Scottie DX.
+//!
+//! Test-only — gated behind `cfg(any(test, feature = "test-support"))`.
+//!
+//! **Line layout per radio line:**
+//!
+//! ```text
+//! [septr 1500 Hz][G pixels 1500-2300 Hz][septr 1500 Hz]
+//! [B pixels 1500-2300 Hz][SYNC 1200 Hz][porch 1500 Hz]
+//! [R pixels 1500-2300 Hz]
+//! ```
+//!
+//! Total per line = 2·SeptrTime + 2·ImgWidth·PixelTime + SyncTime +
+//! PorchTime + ImgWidth·PixelTime = LineTime exactly.
+
+#![allow(
+    clippy::cast_precision_loss,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    clippy::cast_possible_wrap
+)]
+
+use crate::modespec::{self, SstvMode};
+use crate::resample::WORKING_SAMPLE_RATE_HZ;
+use std::f64::consts::PI;
+
+const SYNC_HZ: f64 = 1200.0;
+const PORCH_HZ: f64 = 1500.0;
+const SEPTR_HZ: f64 = 1500.0;
+const BLACK_HZ: f64 = 1500.0;
+const WHITE_HZ: f64 = 2300.0;
+
+fn lum_to_freq(lum: u8) -> f64 {
+    BLACK_HZ + (WHITE_HZ - BLACK_HZ) * f64::from(lum) / 255.0
+}
+
+/// Emit samples up to absolute sample index `target_n`, advancing phase.
+/// Cumulative-target pattern (matches `robot_test_encoder::fill_to`) so
+/// per-tone rounding doesn't compound across the line.
+fn fill_to(out: &mut Vec<f32>, freq_hz: f64, target_n: usize, phase: &mut f64) {
+    let dphi = 2.0 * PI * freq_hz / f64::from(WORKING_SAMPLE_RATE_HZ);
+    while out.len() < target_n {
+        out.push(phase.sin() as f32);
+        *phase += dphi;
+        if *phase > 2.0 * PI {
+            *phase -= 2.0 * PI;
+        }
+    }
+}
+
+/// Encode an image as Scottie 1 / 2 / DX audio. `rgb` is row-major,
+/// 320 pixels wide × 256 rows tall × 3 bytes (R, G, B) per pixel.
+/// Returns f32 PCM at [`WORKING_SAMPLE_RATE_HZ`] (11_025 Hz).
+pub fn encode_scottie(mode: SstvMode, rgb: &[[u8; 3]]) -> Vec<f32> {
+    let spec = modespec::for_mode(mode);
+    assert_eq!(rgb.len(), (spec.line_pixels as usize) * (spec.image_lines as usize),
+        "Scottie encoder: RGB buffer must be {} × {} pixels",
+        spec.line_pixels, spec.image_lines);
+
+    let mut out: Vec<f32> = Vec::new();
+    let mut phase = 0.0_f64;
+    let rate = f64::from(WORKING_SAMPLE_RATE_HZ);
+    let line_pixels = spec.line_pixels as usize;
+
+    for y in 0..(spec.image_lines as usize) {
+        let line_start_sec = (y as f64) * spec.line_seconds;
+        let mut t = line_start_sec;
+
+        // Septr 1
+        t += spec.septr_seconds;
+        fill_to(&mut out, SEPTR_HZ, (t * rate) as usize, &mut phase);
+
+        // G channel
+        for x in 0..line_pixels {
+            t += spec.pixel_seconds;
+            let g = rgb[y * line_pixels + x][1];
+            fill_to(&mut out, lum_to_freq(g), (t * rate) as usize, &mut phase);
+        }
+
+        // Septr 2
+        t += spec.septr_seconds;
+        fill_to(&mut out, SEPTR_HZ, (t * rate) as usize, &mut phase);
+
+        // B channel
+        for x in 0..line_pixels {
+            t += spec.pixel_seconds;
+            let b = rgb[y * line_pixels + x][2];
+            fill_to(&mut out, lum_to_freq(b), (t * rate) as usize, &mut phase);
+        }
+
+        // Sync (mid-line)
+        t += spec.sync_seconds;
+        fill_to(&mut out, SYNC_HZ, (t * rate) as usize, &mut phase);
+
+        // Porch
+        t += spec.porch_seconds;
+        fill_to(&mut out, PORCH_HZ, (t * rate) as usize, &mut phase);
+
+        // R channel
+        for x in 0..line_pixels {
+            t += spec.pixel_seconds;
+            let r = rgb[y * line_pixels + x][0];
+            fill_to(&mut out, lum_to_freq(r), (t * rate) as usize, &mut phase);
+        }
+
+        // Pad to full line_seconds boundary (defensive — if our
+        // arithmetic rounded down, top-up to the line boundary).
+        let line_end_target = ((y as f64 + 1.0) * spec.line_seconds * rate) as usize;
+        fill_to(&mut out, PORCH_HZ, line_end_target, &mut phase);
+    }
+
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lum_to_freq_endpoints() {
+        assert!((lum_to_freq(0) - BLACK_HZ).abs() < 1e-9);
+        assert!((lum_to_freq(255) - WHITE_HZ).abs() < 1e-9);
+    }
+
+    #[test]
+    fn scottie1_encode_total_length() {
+        let rgb = vec![[128u8; 3]; 320 * 256];
+        let audio = encode_scottie(SstvMode::Scottie1, &rgb);
+        let spec = modespec::for_mode(SstvMode::Scottie1);
+        let expected_len = (spec.line_seconds * f64::from(spec.image_lines)
+            * f64::from(WORKING_SAMPLE_RATE_HZ)) as usize;
+        // Allow 1-sample rounding slack at end-of-image.
+        assert!(audio.len() >= expected_len);
+        assert!(audio.len() <= expected_len + 1);
+    }
+}
+```
+
+- [ ] **Step 3: Register the module in `src/lib.rs`**
+
+Add (gated like the other test encoders):
+
+```rust
+#[cfg(any(test, feature = "test-support"))]
+pub mod scottie_test_encoder;
+```
+
+Match the existing `pd_test_encoder` / `robot_test_encoder` registration style exactly — read those lines first to confirm.
+
+- [ ] **Step 4: Run encoder unit tests**
+
+```bash
+cargo test --features test-support --lib scottie_test_encoder 2>&1 | grep -E "^test result|FAIL"
+```
+
+Expected: 2 tests pass (`lum_to_freq_endpoints`, `scottie1_encode_total_length`).
+
+- [ ] **Step 5: Full lib test suite (regression)**
+
+```bash
+cargo test --features test-support --lib 2>&1 | grep -E "^test result|FAIL"
+```
+
+Expected: every "ok", zero failed.
+
+### Task 2.2: Run full local CI gate + commit Phase 2
+
+- [ ] **Step 1: Full CI gate**
+
+(Same four commands as Phase 1 Task 1.3 Step 1.)
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add -- src/scottie_test_encoder.rs src/lib.rs
+git commit -m "$(cat <<'EOF'
+feat(scottie): synthetic test encoder
+
+Phase 2 of V2.3 Scottie. New src/scottie_test_encoder.rs mirrors
+the shape of robot_test_encoder.rs: encodes an RGB image to
+continuous-phase FM audio per the Scottie line layout
+(septr → G → septr → B → sync → porch → R per radio line, with
+sync sitting mid-line between B and R).
+
+Two unit tests — endpoints of lum_to_freq and total audio length
+for one Scottie 1 image.
+
+Module is gated behind cfg(any(test, feature = "test-support")) per
+the existing test-encoder convention.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Phase 3 — `decode_line` implementation + round-trip green (single commit)
+
+The substantive DSP work. Ends with all 9 round-trips green (6 existing + 3 new). The Phase 1 stub returned silence; Phase 3 replaces it with the demodulation that matches the encoder.
+
+### Task 3.1: Write three failing round-trip tests
+
+**Files:**
+- Modify: `tests/roundtrip.rs` (append three new tests).
+
+- [ ] **Step 1: Read the existing `tests/roundtrip.rs` for the pattern**
+
+```bash
+head -100 tests/roundtrip.rs
+grep -nA 20 "robot72_roundtrip\|robot36_roundtrip" tests/roundtrip.rs | head -60
+```
+
+Mirror the existing `robot72_roundtrip` test structure exactly. The pattern: build an RGB image, encode via `*_test_encoder`, drive the audio through the public decoder, compare per-pixel mean diff.
+
+- [ ] **Step 2: Append three Scottie round-trip tests**
+
+```rust
+#[test]
+fn scottie1_roundtrip() {
+    let rgb = generate_test_image(320, 256);
+    let audio = slowrx::scottie_test_encoder::encode_scottie(
+        slowrx::modespec::SstvMode::Scottie1, &rgb);
+    let decoded = decode_full(&audio);
+    let mean_diff = pixel_mean_diff(&rgb, &decoded);
+    assert!(mean_diff < 5.0,
+        "Scottie 1 round-trip: mean diff {mean_diff} ≥ 5.0");
+}
+
+#[test]
+fn scottie2_roundtrip() {
+    let rgb = generate_test_image(320, 256);
+    let audio = slowrx::scottie_test_encoder::encode_scottie(
+        slowrx::modespec::SstvMode::Scottie2, &rgb);
+    let decoded = decode_full(&audio);
+    let mean_diff = pixel_mean_diff(&rgb, &decoded);
+    assert!(mean_diff < 5.0,
+        "Scottie 2 round-trip: mean diff {mean_diff} ≥ 5.0");
+}
+
+#[test]
+fn scottie_dx_roundtrip() {
+    let rgb = generate_test_image(320, 256);
+    let audio = slowrx::scottie_test_encoder::encode_scottie(
+        slowrx::modespec::SstvMode::ScottieDx, &rgb);
+    let decoded = decode_full(&audio);
+    let mean_diff = pixel_mean_diff(&rgb, &decoded);
+    assert!(mean_diff < 5.0,
+        "Scottie DX round-trip: mean diff {mean_diff} ≥ 5.0");
+}
+```
+
+(Adjust function names to match the existing `tests/roundtrip.rs` helpers — `generate_test_image`, `decode_full`, `pixel_mean_diff` are placeholder names. Use whatever the file actually defines.)
+
+- [ ] **Step 3: Run the failing tests**
+
+```bash
+cargo test --test roundtrip --features test-support scottie 2>&1 | tail -10
+```
+
+Expected: 3 tests fail (the stub `decode_line` returns silence, so the decoded image is all-zero and the mean diff is much larger than 5.0). This is the TDD red.
+
+### Task 3.2: Implement `mode_scottie::decode_line`
+
+**Files:**
+- Modify: `src/mode_scottie.rs` (replace the stub with the demodulation).
+
+- [ ] **Step 1: Replace the stub with the implementation**
+
+```rust
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn decode_line(
+    spec: ModeSpec,
+    line_index: u32,
+    audio: &[f32],
+    skip_samples: i64,
+    line_seconds_offset: f64,
+    rate_hz: f64,
+    image: &mut crate::image::SstvImage,
+    demod: &mut crate::mode_pd::PdDemod,
+    snr_est: &mut crate::snr::SnrEstimator,
+    hedr_shift_hz: f64,
+) {
+    let line_pixels = spec.line_pixels as usize;
+    let pixel_secs = spec.pixel_seconds;
+
+    // Channel base offsets within the radio line (relative to
+    // line_seconds_offset). Mirrors slowrx C video.c:72-79.
+    let g_start = spec.septr_seconds;
+    let b_start = g_start + (line_pixels as f64) * pixel_secs + spec.septr_seconds;
+    let r_start = b_start + (line_pixels as f64) * pixel_secs
+        + spec.sync_seconds + spec.porch_seconds;
+
+    // Per-channel local Hann selector state. Initialized to longest
+    // window (idx 6) per the V2.2 cold-start convention. The hysteresis
+    // selector ratchets one band per call.
+    let mut g_win_idx = crate::snr::HANN_LENS.len() - 1;
+    let mut b_win_idx = g_win_idx;
+    let mut r_win_idx = g_win_idx;
+
+    let is_sdx = spec.mode == SstvMode::ScottieDx;
+
+    for x in 0..line_pixels {
+        let g_t = line_seconds_offset + g_start + (x as f64 + 0.5) * pixel_secs;
+        let b_t = line_seconds_offset + b_start + (x as f64 + 0.5) * pixel_secs;
+        let r_t = line_seconds_offset + r_start + (x as f64 + 0.5) * pixel_secs;
+
+        let g = pixel_at(audio, skip_samples, g_t, rate_hz, demod, snr_est,
+                         &mut g_win_idx, is_sdx, hedr_shift_hz);
+        let b = pixel_at(audio, skip_samples, b_t, rate_hz, demod, snr_est,
+                         &mut b_win_idx, is_sdx, hedr_shift_hz);
+        let r = pixel_at(audio, skip_samples, r_t, rate_hz, demod, snr_est,
+                         &mut r_win_idx, is_sdx, hedr_shift_hz);
+
+        image.set_pixel(x as u32, line_index, [r, g, b]);
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn pixel_at(
+    audio: &[f32],
+    skip_samples: i64,
+    t_seconds: f64,
+    rate_hz: f64,
+    demod: &mut crate::mode_pd::PdDemod,
+    snr_est: &mut crate::snr::SnrEstimator,
+    prev_win_idx: &mut usize,
+    is_sdx: bool,
+    hedr_shift_hz: f64,
+) -> u8 {
+    // Single round() to match slowrx video.c:140-142.
+    let center_sample = skip_samples + (t_seconds * rate_hz).round() as i64;
+
+    // SNR re-estimate (sticky across the line; the hysteresis selector
+    // does its own update internally).
+    let snr_db = snr_est.estimate(audio, center_sample, hedr_shift_hz);
+
+    let mut win_idx = crate::snr::window_idx_for_snr_with_hysteresis(snr_db, *prev_win_idx);
+    // SDX bumps the selector up by one when not already saturated
+    // (slowrx C video.c:367).
+    if is_sdx && win_idx < 6 {
+        win_idx += 1;
+    }
+    *prev_win_idx = win_idx;
+
+    let freq_hz = demod.pixel_freq(audio, center_sample, hedr_shift_hz, win_idx);
+    freq_to_lum(freq_hz)
+}
+
+fn freq_to_lum(freq_hz: f64) -> u8 {
+    // slowrx maps [1500, 2300] Hz → [0, 255] lum, clipped.
+    let lum = (freq_hz - 1500.0) * 255.0 / 800.0;
+    lum.clamp(0.0, 255.0) as u8
+}
+```
+
+(Function signatures and helpers may need adjustment — `pixel_freq`, `set_pixel`, `estimate` are the actual existing API points; verify each exists with the expected signature before pasting. If any differs, adapt the call site. The structure — three channels, per-channel `prev_win_idx` state, SDX `+1` bump, single `round()` per pixel time — is what must hold.)
+
+- [ ] **Step 2: Run the Scottie round-trips**
+
+```bash
+cargo test --test roundtrip --features test-support scottie 2>&1 | tail -10
+```
+
+Expected: at least Scottie 1 passes. Scottie 2 and SDX may need tuning. If S1 fails:
+- Check that `r_start`, `b_start`, `g_start` formulas match slowrx C exactly. Re-read `original/slowrx/video.c:72-79`.
+- Check that `freq_to_lum` clamps correctly at boundaries.
+- Check that `set_pixel`'s expected channel order is `[r, g, b]`, not `[g, b, r]` (the GBR risk from the spec).
+- If the diff is huge (> 50), structural bug. If diff is ~10-15, tuning issue (Hann selector or pixel time rounding).
+
+### Task 3.3: Verify all 6 existing round-trips still pass
+
+**Files:** None (regression check only).
+
+- [ ] **Step 1: Full round-trip suite**
+
+```bash
+cargo test --test roundtrip --features test-support 2>&1 | tail -15
+```
+
+Expected: 9 tests pass (6 existing PD + Robot, plus 3 new Scottie). All at unchanged thresholds.
+
+If any existing test broke: the new dispatch arm or `target_audio_samples` arm interacted with the existing flow incorrectly. Most likely candidate: the V2.2 `target_audio_samples` formula was wrong for one of PD/Robot when the new arm landed. Diagnose by running the failing test in isolation and comparing against `main`.
+
+### Task 3.4: Run full local CI gate + commit Phase 3
+
+- [ ] **Step 1: Full CI gate**
+
+(Four standard commands.)
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add -- src/mode_scottie.rs tests/roundtrip.rs
+git commit -m "$(cat <<'EOF'
+feat(scottie): decode_line implementation — Scottie 1/2/DX green
+
+Phase 3 of V2.3 Scottie. Replaces the Phase 1 stub with the actual
+mid-line-sync demodulation:
+
+- Per-pixel `pixel_at` helper computes the absolute audio sample
+  position with a single round() (slowrx video.c:140-142 style),
+  re-estimates SNR sticky across the channel, calls the hysteresis
+  selector for the Hann index, and demodulates.
+- Three channels per radio line at offsets g_start = septr_seconds,
+  b_start = g_start + line_pixels·pixel_seconds + septr_seconds,
+  r_start = b_start + line_pixels·pixel_seconds + sync_seconds +
+  porch_seconds. R is post-sync; G + B are pre-sync (negative
+  relative offsets). The line_seconds_offset = line_index ·
+  line_seconds is positive, so absolute audio offsets stay
+  positive after the V2.1 sync_position rebase.
+- Per-channel prev_win_idx state (3 instances, all initialized to
+  HANN_LENS.len() - 1 per the V2.2/0.3.2 cold-start convention).
+- SDX-specific Hann bump: when spec.mode == ScottieDx && idx < 6,
+  bump idx += 1 after the hysteresis selector returns. Matches
+  slowrx C video.c:367.
+- RGB written directly via image.set_pixel(x, line_index, [r, g, b]).
+  No intermediate slowrx-style GBR storage (and no associated
+  re-ordering bug risk).
+
+Three new round-trip tests in tests/roundtrip.rs (scottie1,
+scottie2, scottie_dx) all pass at unchanged mean < 5.0. Existing 6
+round-trips still pass — the RgbSequential dispatch arm is additive.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Phase 4 — Documentation cleanup (single commit)
+
+Loose-end docs that were forward-references in earlier phases. None of these block functionality; they're hygiene.
+
+### Task 4.1: Update `src/snr.rs::window_idx_for_snr` rustdoc
+
+**Files:**
+- Modify: `src/snr.rs` lines 80-96 (the `window_idx_for_snr` rustdoc).
+
+Currently says "We don't yet support Scottie modes, so that branch is omitted; once the SDX decoder lands it will pass `is_sdx: bool` or call a separate selector." Replace with:
+
+```rust
+/// slowrx also bumps the index up by one for Scottie DX (`Mode == SDX`)
+/// when `WinIdx < 6`. The Scottie family decoder applies that bump
+/// post-hoc inside [`crate::mode_scottie::decode_line`] (matching
+/// slowrx C `video.c:367` exactly), so the bare `window_idx_for_snr`
+/// — and the hysteresis variant — stay mode-agnostic.
+```
+
+### Task 4.2: Update `src/lib.rs` Status / Implemented block
+
+**Files:**
+- Modify: `src/lib.rs` (the top-level rustdoc that lists implemented modes).
+
+Find the existing list (likely "Implemented: PD120, PD180, PD240, Robot24, Robot36, Robot72. Additional V2 modes (Scottie, Martin) planned." or similar) and update to include Scottie 1, Scottie 2, Scottie DX in the implemented list. Martin remains in "planned."
+
+### Task 4.3: Run full local CI gate + commit Phase 4
+
+- [ ] **Step 1: CI gate**
+- [ ] **Step 2: Commit**
+
+```bash
+git add -- src/snr.rs src/lib.rs src/modespec.rs
+git commit -m "$(cat <<'EOF'
+docs(scottie): clean up forward-references after Scottie ships
+
+Phase 4 of V2.3 Scottie. Three rustdoc updates that should match
+the implementation now that decode_line is green:
+
+- src/snr.rs::window_idx_for_snr rustdoc: drop the "Scottie not yet
+  supported" stub. Now correctly states that the SDX +1 bump lives
+  in mode_scottie::decode_line, so the bare selector stays
+  mode-agnostic.
+- src/lib.rs Status / Implemented: list Scottie 1/2/DX alongside
+  PD and Robot. Martin remains in "planned."
+
+(SyncPosition::LineStart rustdoc was already updated in Phase 1.)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Phase 5 — Release prep (single commit)
+
+### Task 5.1: Insert CHANGELOG `[0.4.0] - 2026-05-04`
+
+**Files:**
+- Modify: `CHANGELOG.md`.
+
+Insert between the existing `## [Unreleased]` and `## [0.3.3] - 2026-05-03`:
+
+```markdown
+## [Unreleased]
+
+## [0.4.0] - 2026-05-04
+
+Minor release adding the Scottie family — Scottie 1, Scottie 2,
+Scottie DX. All three at 320×256, GBR color encoding, with mid-line
+sync (sync sits between B and R within each radio line). Synthetic
+round-trip-validated; real-radio Scottie capture validation is async
+([#65]).
+
+[#65]: https://github.com/jasonherald/slowrx.rs/issues/65
+
+### Added
+
+- **`SstvMode::Scottie1`** (VIS `0x3C`), **`Scottie2`** (`0x38`),
+  **`ScottieDx`** (`0x4C`).
+- **`ChannelLayout::RgbSequential`** — three-channel RGB layout per
+  radio line. Shared with V2.4 Martin.
+- **`SyncPosition::Scottie`** — sync between B and R, the V2.1
+  forcing-function variant cashed in.
+- Three new `ModeSpec` consts: `SCOTTIE1`, `SCOTTIE2`, `SCOTTIE_DX`.
+  Values transcribed from slowrx C `modespec.c:91-128`.
+- New module `crate::mode_scottie` with `decode_line`. Mid-line-sync
+  handling lives entirely inside this module — `decoder.rs` and
+  `sync.rs` are unchanged beyond a new dispatch arm.
+- New module `crate::scottie_test_encoder` (gated behind
+  `cfg(any(test, feature = "test-support"))`). Synthetic encoder for
+  round-trip testing.
+
+### Changed
+
+- **`decoder.rs`** dispatch grows an `RgbSequential` arm; the
+  `target_audio_samples` match arm gains `RgbSequential =>
+  spec.image_lines` (one radio line per image row, like Robot).
+- **`SstvMode`** is `#[non_exhaustive]` so the new variants are
+  additive in the public API. Public consumers using exhaustive
+  matches will need a new arm.
+
+### Validation
+
+- Three new synthetic round-trips (Scottie1, Scottie2, ScottieDx)
+  pass at unchanged `mean < 5.0` per-pixel-RGB-diff threshold.
+- All 6 existing round-trips (PD120/180/240, Robot24/36/72) continue
+  to pass at the same threshold — regression net intact.
+- Coverage ≥ 92% per-file maintained.
+
+### Notes
+
+- Mid-line sync was V2.1's forcing-function carve-out;
+  `SyncPosition::Scottie` makes it explicit at dispatch time so future
+  modes can't accidentally inherit a line-start assumption.
+- Slowrx C's SDX-specific Hann-window-index `+1` bump
+  (`video.c:367`) is faithfully replicated inside
+  `mode_scottie::decode_line`. Not documented as an intentional
+  deviation — we track slowrx exactly here.
+```
+
+### Task 5.2: Bump `Cargo.toml` to `0.4.0`
+
+**Files:**
+- Modify: `Cargo.toml`.
+
+Replace `version = "0.3.3"` with `version = "0.4.0"`.
+
+```bash
+cargo build --features cli 2>&1 | tail -3
+```
+
+Expected: `Finished dev profile`. Cargo.lock auto-updates.
+
+### Task 5.3: Run full CI gate + commit Phase 5
+
+- [ ] **Step 1: CI gate**
+- [ ] **Step 2: Commit**
+
+```bash
+git add -- CHANGELOG.md Cargo.toml Cargo.lock
+git commit -m "$(cat <<'EOF'
+chore(release): 0.4.0 — V2.3 Scottie family (S1, S2, DX)
+
+Minor release adding the Scottie family. Mid-line-sync handling
+landed via SyncPosition::Scottie and ChannelLayout::RgbSequential
+(Martin V2.4 will reuse the latter). Synthetic round-trip-validated;
+all 9 round-trips pass at unchanged mean < 5.0.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Phase 6 — Open PR + post-merge tag + publish
+
+### Task 6.1: Push + open PR
+
+- [ ] **Step 1: Push**
+
+```bash
+git push -u origin feat/v0.4.0-scottie
+```
+
+- [ ] **Step 2: Open PR**
+
+```bash
+gh pr create --base main --head feat/v0.4.0-scottie \
+  --title "feat(scottie): V2.3 — Scottie family (S1, S2, DX) — 0.4.0" \
+  --body "$(cat <<'EOF'
+## Summary
+
+- Adds Scottie 1 (VIS `0x3C`), Scottie 2 (`0x38`), and Scottie DX (`0x4C`) decoders.
+- `ChannelLayout::RgbSequential` and `SyncPosition::Scottie` enum variants. Mid-line sync (sync between B and R within each radio line) is implemented entirely inside `mode_scottie::decode_line` — `decoder.rs` and `sync.rs` are unchanged beyond a new dispatch arm.
+- SDX-specific Hann-window-index `+1` bump (slowrx C `video.c:367`) applied post-hoc in `mode_scottie::decode_line`; the bare `window_idx_for_snr` and its hysteresis variant stay mode-agnostic.
+- Three new synthetic round-trips (`scottie1_roundtrip`, `scottie2_roundtrip`, `scottie_dx_roundtrip`) pass at unchanged `mean < 5.0`. All 6 existing round-trips still pass — regression net intact.
+
+## Test plan
+
+- [x] `cargo fmt --check` clean
+- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
+- [x] `cargo test --all-features --locked` — all 9 round-trips pass plus the new modespec / encoder unit tests
+- [x] `RUSTDOCFLAGS=-D warnings cargo doc --no-deps --all-features` clean
+- [x] Coverage ≥ 92% per-file
+
+## Out of scope
+
+- Real-radio Scottie validation — async, no fixtures available.
+- V2.4 Martin family — separate epic ([#66]).
+- Pixel-diff comparator ([#70]) and squiggle work ([#71]) — both still pending.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+### Task 6.2: Post-merge — tag + publish
+
+**Note:** Blocked until the user merges the PR.
+
+- [ ] **Step 1: Sync main**
+
+```bash
+cd /data/source/slowrx.rs
+git fetch --all --prune
+git checkout main
+git pull --ff-only
+```
+
+- [ ] **Step 2: Re-run CI gate on main**
+
+(Same four commands.)
+
+- [ ] **Step 3: Tag `v0.4.0`** (annotated, unsigned)
+
+```bash
+git tag -a v0.4.0 -m "$(cat <<'EOF'
+slowrx 0.4.0 — V2.3 Scottie family (S1, S2, DX)
+
+Minor release adding three decoder modes: Scottie 1 (VIS 0x3C),
+Scottie 2 (0x38), Scottie DX (0x4C). All three at 320×256, GBR
+color encoding, with mid-line sync (sync sits between B and R
+within each radio line, not at line start).
+
+The mid-line-sync work cashes in V2.1's SyncPosition forcing-function
+carve-out — making sync placement explicit at dispatch time
+prevented hidden line-start assumptions from breaking Scottie.
+
+Synthetic round-trip-validated; 9 round-trips pass at mean < 5.0.
+Real-radio Scottie validation is async (no reference WAVs available
+yet).
+
+PR: #<fill in>.
+EOF
+)"
+git push origin v0.4.0
+```
+
+- [ ] **Step 4: Publish to crates.io**
+
+After explicit user confirmation (this is irreversible):
+
+```bash
+cargo publish --features cli --allow-dirty 2>&1 | tail -10
+```
+
+Expected: `Uploaded slowrx v0.4.0 to registry crates-io`.
+
+### Task 6.3: Cleanup
+
+- [ ] **Step 1: Comment status on epic #65**
+
+```bash
+gh issue comment 65 --repo jasonherald/slowrx.rs --body "$(cat <<'EOF'
+## V2.3 shipped — slowrx 0.4.0
+
+`slowrx 0.4.0` (PR #<fill in>, tag `v0.4.0`, published to crates.io)
+ships the Scottie family — Scottie 1, Scottie 2, Scottie DX. All
+three decoders pass synthetic round-trips at the unchanged
+`mean < 5.0` threshold; the existing 6 PD + Robot round-trips
+continue to pass.
+
+The mid-line-sync work landed via `SyncPosition::Scottie`,
+`ChannelLayout::RgbSequential`, and a new `mode_scottie::decode_line`
+that handles negative offsets relative to sync internally.
+`decoder.rs` and `sync.rs` were unchanged beyond a new dispatch arm
+— the V2.1 forcing-function carve-out paid off.
+
+Real-radio Scottie capture validation remains async — no reference
+WAVs are available yet.
+
+Closing this issue.
+EOF
+)"
+gh issue close 65 --repo jasonherald/slowrx.rs
+```
+
+- [ ] **Step 2: Remove the worktree**
+
+```bash
+cd /data/source/slowrx.rs
+git worktree remove /data/source/slowrx.rs-v0.4.0-scottie
+git worktree list
+```
+
+- [ ] **Step 3: Confirm crates.io has 0.4.0**
+
+```bash
+cargo search slowrx 2>&1 | head -3
+```
+
+Expected: `slowrx = "0.4.0"`.
+
+---
+
+## Done criteria
+
+- All 9 round-trips green at unchanged `mean < 5.0` thresholds.
+- `crates.io/crates/slowrx` shows `0.4.0` as latest.
+- `git tag -l v0.4.0` exists and is pushed.
+- Epic #65 closed with a status comment.
+- Worktree removed.

--- a/docs/superpowers/specs/2026-05-04-v0.4.0-scottie-design.md
+++ b/docs/superpowers/specs/2026-05-04-v0.4.0-scottie-design.md
@@ -1,0 +1,396 @@
+# slowrx.rs 0.4.0 — V2.3 Scottie Family Design Specification
+
+**Status:** Approved 2026-05-04. Ready for implementation planning via the
+[superpowers:writing-plans](https://github.com/anthropic-ai/superpowers) skill.
+
+**Goal:** Add decoder support for the Scottie family — Scottie 1
+(`0x3C`), Scottie 2 (`0x38`), Scottie DX (`0x4C`). All three at 320×256,
+GBR color encoding, with **mid-line sync** (sync between B and R within
+each radio line, not at line start). Ship as `slowrx 0.4.0`.
+
+**Out of scope for this spec:**
+
+- Real-radio Scottie capture validation. The epic ([#65]) explicitly
+  flags this as async — no fixtures are available yet, and synthetic
+  round-trip is the merge gate for 0.4.0.
+- Martin family (M1/M2). Tracked in V2.4 / [#66] / 0.5.0. Reuses
+  `ChannelLayout::RgbSequential` from this spec but has its own
+  per-channel timing, so the work doesn't share much beyond the enum
+  variant.
+- Pixel-diff comparator vs reference JPGs. Still tracked in [#70];
+  unblocks when real-radio fixtures arrive for any future mode.
+- Squiggle work — [#71] is parked.
+
+[#65]: https://github.com/jasonherald/slowrx.rs/issues/65
+[#66]: https://github.com/jasonherald/slowrx.rs/issues/66
+[#70]: https://github.com/jasonherald/slowrx.rs/issues/70
+[#71]: https://github.com/jasonherald/slowrx.rs/issues/71
+
+## Context
+
+`slowrx 0.3.x` shipped PD (V1) and Robot family (V2.2) with frequency-
+resolution and SNR-hysteresis improvements (V2.x patches). V2.3 is the
+next decoder family on the roadmap. Per the epic spec ([#65]):
+
+> **DSP delta from V1:**
+> - New chroma layout: RGB sequential per line (G, B, R per slowrx
+>   convention).
+> - **Sync placement is mid-line** (between channels), not line-start.
+>   This is the V2 risk flagged in the spec — V2.1 will have already
+>   added the `sync_position` field to `ModeSpec`; this epic uses
+>   `SyncPosition::Scottie` (or similar) to make the mid-line placement
+>   explicit.
+
+V2.1's `SyncPosition::LineStart` carve-out was the forcing function:
+making the sync position explicit at dispatch time prevents
+hidden-line-start assumptions from breaking Scottie. V2.3 cashes that
+in.
+
+### Why mid-line sync matters
+
+slowrx C `video.c:72-79` gives the Scottie line layout (using slowrx's
+notation):
+
+```text
+case S1: case S2: case SDX:
+  ChanLen[0..2]   = PixelTime * ImgWidth     // each channel: 320 pixels
+  ChanStart[0]    = SeptrTime                // G starts at SeptrTime
+  ChanStart[1]    = ChanStart[0] + ChanLen[0] + SeptrTime    // B
+  ChanStart[2]    = ChanStart[1] + ChanLen[1] + SyncTime + PorchTime  // R
+```
+
+Reading this as a timeline within one radio line:
+
+```text
+[septr][ G pixels ][septr][ B pixels ][SYNC][porch][ R pixels ]
+   ^                                     ^
+   |                                     |
+   line start (just after prev R)        sync N (find_sync detects this)
+```
+
+The sync N pulse sits between B and R *within the same line N*. So
+when `find_sync` reports `sync_time = T`:
+
+- R pixels of line N are at audio offsets `[T + SyncTime + PorchTime,
+  T + SyncTime + PorchTime + ImgWidth·PixelTime]` (positive offsets).
+- B pixels of line N are at offsets `[T - SeptrTime - ImgWidth·PixelTime,
+  T - SeptrTime]` (**negative offsets**).
+- G pixels of line N are at offsets `[T - 2·SeptrTime - 2·ImgWidth·PixelTime,
+  T - 2·SeptrTime - ImgWidth·PixelTime]` (negative offsets).
+
+PD and Robot only ever look forward from sync. Scottie looks both
+backward and forward. The forcing-function `SyncPosition::Scottie`
+makes the existing line-start assumptions in `decoder.rs` and
+`sync.rs` surface where they exist — if any do.
+
+## Design
+
+### Architectural change
+
+**A) New `SstvMode` variants and lookup table arms in
+`src/modespec.rs`:**
+
+```rust
+pub enum SstvMode {
+    // ... existing ...
+    Scottie1,
+    Scottie2,
+    ScottieDx,
+}
+
+// New ChannelLayout variant (Martin V2.4 will reuse this).
+pub enum ChannelLayout {
+    PdYcbcr,
+    RobotYuv,
+    RgbSequential,
+}
+
+// New SyncPosition variant.
+pub enum SyncPosition {
+    LineStart,
+    Scottie,
+}
+```
+
+Three new `ModeSpec` consts with values transcribed from
+`original/slowrx/modespec.c:91-128`:
+
+| Mode    | VIS  | PixelTime | LineTime    | Width | Height | SyncTime | PorchTime | SeptrTime |
+|---------|------|-----------|-------------|-------|--------|----------|-----------|-----------|
+| S1      | 0x3C | 0.4320 ms | 428.38 ms   | 320   | 256    | 9 ms     | 1.5 ms    | 1.5 ms    |
+| S2      | 0x38 | 0.2752 ms | 277.692 ms  | 320   | 256    | 9 ms     | 1.5 ms    | 1.5 ms    |
+| SDX     | 0x4C | 1.08053 ms| 1050.3 ms   | 320   | 256    | 9 ms     | 1.5 ms    | 1.5 ms    |
+
+All three: `ChannelLayout::RgbSequential`, `SyncPosition::Scottie`.
+Existing `for_vis_code` and `for_mode` lookups gain three arms each.
+
+**B) New module `src/mode_scottie.rs` (≤ 500 LOC).** One entry point:
+
+```rust
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn decode_line(
+    spec: ModeSpec,
+    line_index: u32,
+    audio: &[f32],
+    skip_samples: i64,
+    line_seconds_offset: f64,
+    rate_hz: f64,
+    image: &mut crate::image::SstvImage,
+    demod: &mut crate::mode_pd::PdDemod,
+    snr_est: &mut crate::snr::SnrEstimator,
+    hedr_shift_hz: f64,
+)
+```
+
+Same signature as `mode_robot::decode_line` minus `chroma_planes`
+(Scottie composes RGB in-place per line — no deferred planes). Internal
+flow:
+
+1. Compute the three channel base times relative to
+   `line_seconds_offset` (which is `line_index * spec.line_seconds`):
+   - `t_g = line_seconds_offset + SeptrTime` — wait, this is relative
+     to *line start*, not sync. The decoder's `sync_seconds` IS the
+     sync time, so `line_start_seconds = sync_seconds - (2·SeptrTime +
+     2·ImgWidth·PixelTime)` for Scottie. **All three channel times are
+     positive offsets from `line_start_seconds`** — the negative-offset
+     view is equivalent but easier to reason about as "line N starts
+     before sync N for Scottie."
+2. Write G, B, R pixels by calling `demod.pixel_freq` per pixel (same
+   pattern as `mode_pd::decode_one_channel_into`), with bin-frequency
+   → 8-bit luma via slowrx's `(freq - 1500) * 255/800` mapping clipped
+   to `[0, 255]`.
+3. Compose RGB in place: `image.set_pixel(x, line_index, [r, g, b])`.
+4. SDX-specific Hann adjustment: post-process the
+   `window_idx_for_snr_with_hysteresis` return value with
+   `if spec.mode == SstvMode::ScottieDx && idx < 6 { idx + 1 }`.
+   Matches slowrx C `video.c:367` exactly.
+
+**C) Dispatch arm in `src/decoder.rs`:**
+
+The existing `radio_frames_per_image` match (line 245-248) gets an
+`RgbSequential => spec.image_lines` arm — Scottie has one radio line
+per image row, like Robot72. The V2.2 `target_audio_samples` bug
+(`image_lines/2` was PD-only) is now well-understood and the
+`channel_layout`-keyed match makes Scottie's correct value impossible
+to miss.
+
+The decode-loop dispatch (around line 387) gets:
+
+```rust
+crate::modespec::ChannelLayout::RgbSequential => {
+    crate::mode_scottie::decode_line(spec, line_index, audio,
+        skip_samples, line_seconds_offset, rate_hz, image,
+        &mut demod, &mut snr_est, hedr_shift_hz);
+}
+```
+
+**D) `lib.rs` adds `pub mod mode_scottie;`.**
+
+### Mid-line sync handling
+
+The Scottie line layout has G + B *before* sync and R *after*. The
+implementation contains this entirely inside `mode_scottie::decode_line`
+— it computes its own `line_start_seconds = line_seconds_offset` (a
+function of `line_index`, deterministic per the line clock the
+controller already maintains) and adds positive offsets for each
+channel. From the controller's perspective the contract is unchanged:
+"give me line N's worth of pixels, indexed by `line_index`."
+
+The only thing that changes at the dispatch level is which sync
+locks-on to which radio line. `find_sync` already detects sync pulses
+without caring about line layout — it locks onto the rising edge.
+Whether that edge sits at the start of the line (PD/Robot) or in the
+middle (Scottie) is a per-mode interpretation that lives in the
+mode handler.
+
+**First-line audio buffer extent.** Line 0's G pixels are at radio
+timeline offset `+SeptrTime`, but sync 0 sits at `2·SeptrTime +
+2·ImgWidth·PixelTime` after line 0's start (~280 ms for S1/S2,
+~694 ms for SDX). When sync 0 is detected, decoding line 0's G
+requires reading audio from ~280 / 694 ms *before* the sync detection
+point. The controller's existing audio buffer must extend back at
+least that far. **Verified during implementation:** the existing
+buffer behavior is checked against an SDX-sized pre-sync window;
+if it's insufficient, the spec authorizes lengthening it as part of
+this epic's scope (existing risk #1). Worst case fallback: the
+`pixel_freq` call returns silence on out-of-bounds reads and pixels
+go black — non-fatal but visible.
+
+**SDX Hann bump (slowrx parity, not a deviation).** slowrx C
+`video.c:367` specifically:
+
+```c
+// Minimum winlength can be doubled for Scottie DX
+if (Mode == SDX && WinIdx < 6) WinIdx++;
+```
+
+We thread this in by post-adjusting the
+`window_idx_for_snr_with_hysteresis` return value inside
+`mode_scottie::decode_line`. Existing rustdoc on `window_idx_for_snr`
+in `src/snr.rs` already mentions this — the comment that "Scottie
+modes are not yet supported" updates to reflect the V2.3 ship.
+
+### Test scaffolding
+
+**`src/scottie_test_encoder.rs`.** Same shape as
+`src/robot_test_encoder.rs`. Synthesizes FM-tone audio for a known
+image per the Scottie layout: per radio line, emit `[septr][G pixels]
+[septr][B pixels][sync][porch][R pixels]` at the modespec timings.
+Sync tone at 1200 Hz, porch/septr at 1500 Hz, pixel tones in
+`[1500, 2300]` Hz per the standard SSTV mapping.
+
+Reused: `crate::test_audio::TestAudioBuilder` (or equivalent
+infrastructure if it exists; mirrors what robot_test_encoder.rs does).
+
+**Three new round-trips in `tests/roundtrip.rs`:**
+
+```rust
+#[test] fn scottie1_roundtrip() { ... }
+#[test] fn scottie2_roundtrip() { ... }
+#[test] fn scottie_dx_roundtrip() { ... }
+```
+
+Per-pixel-RGB-diff `mean < 5.0` threshold, same as PD/Robot. All three
+must pass to merge.
+
+### Documentation
+
+**A) CHANGELOG `[0.4.0] - 2026-05-04` section** before `[Unreleased]`
+becomes the next placeholder above. Sections:
+
+- **Added:** `SstvMode::Scottie1`, `Scottie2`, `ScottieDx`;
+  `ChannelLayout::RgbSequential`; `SyncPosition::Scottie`. Three
+  `ModeSpec` consts. New module `crate::mode_scottie`.
+- **Changed:** `decoder.rs` dispatch grows an `RgbSequential` arm.
+  No public-API removal.
+- **Validation:** 3 new synthetic round-trips green at unchanged
+  `mean < 5.0`. Coverage ≥ 92% per-file.
+- **Notes:** Real-radio Scottie validation is async. Squiggle work
+  ([#71]) and pixel-diff comparator ([#70]) still pending.
+
+**B) In-source rustdoc:**
+
+- `mode_scottie.rs` module-level doc with the layout diagram and a
+  pointer to slowrx C `video.c:72-79` for the mid-line origin.
+- Update `src/modespec.rs::SyncPosition::LineStart`'s rustdoc claim
+  about "All currently-shipped modes (PD, Robot)" — replace
+  `(PD, Robot)` with `(PD, Robot, Martin — Scottie uses
+  SyncPosition::Scottie)`.
+- Update `src/snr.rs::window_idx_for_snr` rustdoc — the
+  Scottie-not-yet-supported comment is stale; replace with the SDX
+  Hann-bump rationale and a pointer to `mode_scottie::decode_line`
+  for where it's applied.
+- Update `src/lib.rs` "Status" / "Implemented" block to list Scottie
+  alongside PD and Robot.
+
+**C) No new `intentional-deviations.md` entry.** The implementation
+tracks slowrx C exactly. If anything diverges during execution
+(e.g., a parity bug audit surfaces an SDX-specific edge case slowrx
+handles differently), a new entry lands then.
+
+## Versioning
+
+`0.3.3 → 0.4.0`. **Minor bump** per semver — adding three public
+`SstvMode` enum variants and one `ChannelLayout` variant is an
+additive API change. The new `SyncPosition::Scottie` variant is also
+additive but `SyncPosition` is `#[non_exhaustive]` so it doesn't
+require a minor bump on its own (existing match-arms still compile;
+default arms for non-exhaustive enums are required by the compiler).
+However, the public API growth from the new modes is enough to trigger
+the minor bump regardless.
+
+## Testing posture
+
+### Synthetic round-trip (per-PR gate)
+
+Existing 6 round-trips (PD120/180/240, Robot24/36/72) plus 3 new
+(Scottie1/2/DX) — all 9 must pass at the unchanged `mean < 5.0`
+per-pixel-RGB-diff threshold.
+
+### Unit tests
+
+The new `mode_scottie.rs` and `scottie_test_encoder.rs` get unit-test
+coverage for any non-trivial helper functions (e.g., the GBR→RGB
+re-ordering, the SDX Hann bump). Total lib test count grows from
+104 to ~115-120 expected.
+
+### Coverage gate
+
+`cargo llvm-cov` ≥ 92 % per-file maintained for the new files. The
+existing per-file gate stays.
+
+### Real-audio validation
+
+**Out of scope.** No Scottie reference WAVs are available. If a
+Scottie-format real capture surfaces (e.g., from another satellite
+pass), it lands as an async follow-up like the ARISS Fram2 corpus
+did for V2.2.
+
+## Risks
+
+1. **Mid-line sync surfaces a hidden line-start assumption in
+   `decoder.rs` or `sync.rs`.** This is the V2.1 carve-out's intent
+   — to make any such assumption explicit. If found, the spec
+   authorizes fixes in V2.3 scope. Mitigation: implement
+   `mode_scottie::decode_line` first against a known-good
+   `scottie_test_encoder` audio buffer, run the round-trip; failures
+   flag the assumption to fix.
+
+2. **SDX Hann bump interaction with the 0.3.2 hysteresis.** The
+   `window_idx_for_snr_with_hysteresis` selector ratchets one band
+   per call. Post-adjusting the result by `+1` for SDX could in
+   principle interact with the convergence (e.g., cold-start at idx
+   6 with SDX would never see idx 6 because every selector call
+   would bump to 7… but max idx is 6 by definition, so the `+1`
+   guard `idx < 6` saturates it). Mitigation: the slowrx C `+1` is
+   applied to the *baseline* lookup, not the hysteresis output; the
+   guard `WinIdx < 6` is in slowrx itself. Unit-test the bump on
+   the SDX boundary (idx 5 → 6, idx 6 stays).
+
+3. **GBR re-ordering bug.** slowrx writes G to `Image[*][*][0]`,
+   B to `Image[*][*][1]`, R to `Image[*][*][2]`, then re-orders to
+   RGB at output (`video.c:440-444`):
+   ```c
+   case GBR:
+     p[0] = Image[tx][y][2];  // R
+     p[1] = Image[tx][y][0];  // G
+     p[2] = Image[tx][y][1];  // B
+   ```
+   We need to either match slowrx's storage convention (and
+   re-order at image emit) or store in RGB order from the start.
+   The latter is simpler and avoids translation bugs. Mitigation:
+   write directly to `image.set_pixel(x, y, [r, g, b])` from
+   per-channel demodulated values; no intermediate
+   slowrx-style storage.
+
+4. **`target_audio_samples` correctness for Scottie.** The V2.2
+   bug (`image_lines/2` PD-only) was fixed by a `channel_layout`
+   match. The new `RgbSequential` arm is `spec.image_lines` (one
+   radio line per image row). Mitigation: the match is exhaustive
+   after this PR — the compiler enforces an arm per variant; we
+   can't accidentally fall through to the wrong formula.
+
+## Acceptance criteria
+
+`slowrx 0.4.0` ships when:
+
+1. Three new `SstvMode` variants + `ChannelLayout::RgbSequential` +
+   `SyncPosition::Scottie` + three `ModeSpec` consts in
+   `src/modespec.rs`. VIS lookup arms green.
+2. New module `src/mode_scottie.rs` with `decode_line`. New module
+   `src/scottie_test_encoder.rs`. Both registered in `src/lib.rs`.
+3. `decoder.rs` `RgbSequential` dispatch arm + `target_audio_samples`
+   match arm.
+4. Three new round-trip tests in `tests/roundtrip.rs` all pass at
+   `mean < 5.0`.
+5. All existing 6 round-trips continue to pass at unchanged
+   thresholds (regression net).
+6. CI gate clean: `cargo fmt --check`, `cargo clippy -- -D warnings`,
+   `cargo test --all-features --locked`,
+   `RUSTDOCFLAGS=-D warnings cargo doc --no-deps --all-features`.
+7. Coverage ≥ 92% per-file.
+8. CHANGELOG `[0.4.0]` section committed; `Cargo.toml` bumped to
+   `0.4.0`.
+9. PR opened, CR review addressed, merged to main.
+10. `v0.4.0` annotated tag pushed (unsigned per project convention);
+    `cargo publish --features cli --allow-dirty` succeeds.

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -244,7 +244,10 @@ impl SstvDecoder {
                             // `Length = LineTime * NumLines`.
                             let radio_frames_per_image = match spec.channel_layout {
                                 crate::modespec::ChannelLayout::PdYcbcr => spec.image_lines / 2,
-                                crate::modespec::ChannelLayout::RobotYuv => spec.image_lines,
+                                // Robot (RobotYuv) and Scottie (RgbSequential)
+                                // both pack one image row per radio line.
+                                crate::modespec::ChannelLayout::RobotYuv
+                                | crate::modespec::ChannelLayout::RgbSequential => spec.image_lines,
                             };
                             let nominal_samples =
                                 (f64::from(radio_frames_per_image) * spec.line_seconds * work_rate)
@@ -440,6 +443,33 @@ impl SstvDecoder {
                         rate,
                         &mut d.image,
                         d.chroma_planes.as_mut(),
+                        pd_demod,
+                        snr_est,
+                        d.hedr_shift_hz,
+                    );
+                    let start = (line as usize) * line_pixels;
+                    let end = start + line_pixels;
+                    out.push(SstvEvent::LineDecoded {
+                        mode: d.mode,
+                        line_index: line,
+                        pixels: d.image.pixels[start..end].to_vec(),
+                    });
+                }
+            }
+            crate::modespec::ChannelLayout::RgbSequential => {
+                // Scottie family. Mid-line sync handling lives inside
+                // mode_scottie::decode_line. No chroma_planes — RGB is composed
+                // in-place per line (no deferred chroma like R36/R24).
+                for line in 0..d.spec.image_lines {
+                    let line_seconds_offset = f64::from(line) * d.spec.line_seconds;
+                    crate::mode_scottie::decode_line(
+                        d.spec,
+                        line,
+                        &d.audio,
+                        skip,
+                        line_seconds_offset,
+                        rate,
+                        &mut d.image,
                         pd_demod,
                         snr_est,
                         d.hedr_shift_hz,

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -121,12 +121,11 @@ struct DecodingState {
     /// wrote earlier.
     ///
     /// `None` for every other mode. PD composes RGB in-place per pair
-    /// (see `mode_pd::decode_pd_line_pair`); Robot 72 also composes
-    /// in-place (3-channel sequential — see
-    /// `mode_robot::decode_r72_line`), so it doesn't need the side
-    /// buffer either. `SstvMode` is `#[non_exhaustive]`; future modes
-    /// with cross-radio-line chroma state (e.g., Scottie in V2.3 if it
-    /// turns out to need similar plumbing) will need to extend the
+    /// (see `mode_pd::decode_pd_line_pair`); Robot 72 and Scottie 1/2/DX
+    /// also compose RGB in-place per radio line (see
+    /// `mode_robot::decode_r72_line` and `mode_scottie::decode_line`).
+    /// `SstvMode` is `#[non_exhaustive]`; any future mode that does
+    /// need cross-radio-line chroma state will need to extend the
     /// constructor's match in `process` to opt in.
     chroma_planes: Option<[Vec<u8>; 2]>,
 }
@@ -270,13 +269,13 @@ impl SstvDecoder {
                                             * (spec.line_pixels as usize);
                                         Some([vec![0_u8; n], vec![0_u8; n]])
                                     }
-                                    // PD modes compose RGB per-pair in place. Robot 72 also composes
-                                    // in-place (3-channel sequential — see mode_robot::decode_r72_line),
-                                    // so it doesn't need chroma_planes either; only the R36/R24 chroma-
-                                    // alternation + duplication path requires the side buffer.
-                                    // SstvMode is #[non_exhaustive], so the wildcard arm is required;
-                                    // V2.3 will need to revisit if Scottie introduces similar cross-line
-                                    // state requirements (the spec.sync_position field is the trigger).
+                                    // PD modes compose RGB per-pair in place. Robot 72 and Scottie
+                                    // 1/2/DX also compose RGB in-place per radio line (see
+                                    // mode_robot::decode_r72_line, mode_scottie::decode_line); only
+                                    // the R36/R24 chroma-alternation + duplication path requires the
+                                    // side buffer. SstvMode is #[non_exhaustive], so the wildcard arm
+                                    // is required; future modes with cross-line chroma state would
+                                    // need to opt in here.
                                     _ => None,
                                 },
                             }));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,11 +7,14 @@
 //!
 //! ## Status
 //!
-//! `0.3.x` — V2.2 published. PD120/PD180/PD240 + Robot 24/36/72
-//! decoding from raw audio. PD120/PD180 validated against ARISS
-//! Dec-2017; Robot 36 validated against the ARISS Fram2 corpus
-//! (see `tests/ariss_fram2_validation.md`). The public API is
-//! `#[non_exhaustive]`-protected for additive growth as V2.x
+//! `0.4.x` — V2.3 published. PD120/PD180/PD240 + Robot 24/36/72 +
+//! Scottie 1 / Scottie 2 / Scottie DX decoding from raw audio.
+//! PD120/PD180 validated against ARISS Dec-2017; Robot 36 validated
+//! against the ARISS Fram2 corpus (see
+//! `tests/ariss_fram2_validation.md`). Scottie family is synthetic
+//! round-trip-validated only — no Scottie reference WAVs available.
+//! Martin family (M1, M2) is the next planned epic. The public API
+//! is `#[non_exhaustive]`-protected for additive growth as V2.x
 //! mode-family epics land. See
 //! <https://github.com/jasonherald/slowrx.rs/issues/9> for the V2 roadmap.
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,6 +136,10 @@ pub mod pd_test_encoder;
 #[doc(hidden)]
 pub mod robot_test_encoder;
 
+#[cfg(any(test, feature = "test-support"))]
+#[doc(hidden)]
+pub mod scottie_test_encoder;
+
 pub use crate::decoder::{SstvDecoder, SstvEvent};
 pub use crate::error::{Error, Result};
 pub use crate::image::SstvImage;
@@ -159,5 +163,8 @@ pub mod __test_support {
     }
     pub mod mode_robot {
         pub use crate::robot_test_encoder::encode_robot;
+    }
+    pub mod mode_scottie {
+        pub use crate::scottie_test_encoder::encode_scottie;
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,7 @@ pub mod error;
 pub mod image;
 pub mod mode_pd;
 pub mod mode_robot;
+pub mod mode_scottie;
 pub mod modespec;
 pub mod resample;
 #[allow(dead_code)]

--- a/src/mode_pd.rs
+++ b/src/mode_pd.rs
@@ -505,7 +505,9 @@ pub(crate) fn decode_one_channel_into(
             // integration window. Applied AFTER the hysteresis selector so
             // `prev_win_idx` continues tracking the un-bumped SNR-derived index
             // (the bump shouldn't compound across pixels).
-            if spec.mode == crate::modespec::SstvMode::ScottieDx && win_idx < 6 {
+            if spec.mode == crate::modespec::SstvMode::ScottieDx
+                && win_idx < crate::snr::HANN_LENS.len() - 1
+            {
                 win_idx += 1;
             }
             let center_in_scratch = s - sweep_start;

--- a/src/mode_pd.rs
+++ b/src/mode_pd.rs
@@ -498,8 +498,16 @@ pub(crate) fn decode_one_channel_into(
             // accepting a change. See
             // `crate::snr::window_idx_for_snr_with_hysteresis` and the
             // 0.3.2 entry in `docs/intentional-deviations.md`.
-            let win_idx = crate::snr::window_idx_for_snr_with_hysteresis(snr_db, prev_win_idx);
+            let mut win_idx = crate::snr::window_idx_for_snr_with_hysteresis(snr_db, prev_win_idx);
             prev_win_idx = win_idx;
+            // slowrx C video.c:367 — Scottie DX bumps WinIdx up by one when not
+            // already at saturation, giving SDX's 1.08 ms/pixel a longer
+            // integration window. Applied AFTER the hysteresis selector so
+            // `prev_win_idx` continues tracking the un-bumped SNR-derived index
+            // (the bump shouldn't compound across pixels).
+            if spec.mode == crate::modespec::SstvMode::ScottieDx && win_idx < 6 {
+                win_idx += 1;
+            }
             let center_in_scratch = s - sweep_start;
             current_freq =
                 demod.pixel_freq(&scratch_audio, center_in_scratch, hedr_shift_hz, win_idx);

--- a/src/mode_scottie.rs
+++ b/src/mode_scottie.rs
@@ -1,0 +1,70 @@
+//! Scottie-family mode decoder (Scottie 1, Scottie 2, Scottie DX).
+//!
+//! Three-channel sequential RGB layout per radio line, with sync sitting
+//! between the B and R channels (mid-line). This is the V2.3 mid-line-
+//! sync forcing-function — `decoder.rs`'s line-clock advance and
+//! `find_sync`'s detection both stay generic; the mid-line idiosyncrasy
+//! lives entirely inside `decode_line`.
+//!
+//! Translated from slowrx's `video.c:72-79` (Scottie `ChanStart` layout)
+//! and `video.c:367` (SDX Hann-bump). slowrx's GBR storage convention
+//! (`video.c:440-444`) is bypassed: we write RGB directly via
+//! [`crate::image::SstvImage::put_pixel`].
+//!
+//! ```text
+//! Scottie radio line layout:
+//!   [septr][ G pixels ][septr][ B pixels ][SYNC][porch][ R pixels ]
+//!     ^                                       ^
+//!     |                                       |
+//!     line start                              find_sync detects this
+//!                                             (mid-line)
+//! ```
+//!
+//! See `NOTICE.md` for full slowrx attribution.
+
+use crate::modespec::ModeSpec;
+
+/// Decode one Scottie radio line into `image`. Reads G, B from before
+/// the sync (negative offsets relative to `sync_time`) and R from after,
+/// composing RGB in place.
+///
+/// `line_index` is the 0-based image row this radio line emits;
+/// `line_seconds_offset` is `f64::from(line_index) * spec.line_seconds`
+/// (un-rounded — the per-pixel time computation does the single
+/// `round()` to match slowrx `video.c:140-142`).
+///
+/// **Phase 1 stub:** this function is a no-op until the Phase 3 commit
+/// lands the demodulation. Round-trip tests will fail with a non-zero
+/// per-pixel mean diff until then; that's the TDD red.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn decode_line(
+    spec: ModeSpec,
+    line_index: u32,
+    audio: &[f32],
+    skip_samples: i64,
+    line_seconds_offset: f64,
+    rate_hz: f64,
+    image: &mut crate::image::SstvImage,
+    demod: &mut crate::mode_pd::PdDemod,
+    snr_est: &mut crate::snr::SnrEstimator,
+    hedr_shift_hz: f64,
+) {
+    // Phase 1 stub — Phase 3 implements the real demodulation.
+    let _ = (
+        spec,
+        line_index,
+        audio,
+        skip_samples,
+        line_seconds_offset,
+        rate_hz,
+        image,
+        demod,
+        snr_est,
+        hedr_shift_hz,
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    // Tests land in Phase 3 alongside the implementation.
+}

--- a/src/mode_scottie.rs
+++ b/src/mode_scottie.rs
@@ -32,11 +32,7 @@ use crate::modespec::ModeSpec;
 /// `line_seconds_offset` is `f64::from(line_index) * spec.line_seconds`
 /// (un-rounded — the per-pixel time computation does the single
 /// `round()` to match slowrx `video.c:140-142`).
-///
-/// **Phase 1 stub:** this function is a no-op until the Phase 3 commit
-/// lands the demodulation. Round-trip tests will fail with a non-zero
-/// per-pixel mean diff until then; that's the TDD red.
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::cast_possible_truncation)]
 pub(crate) fn decode_line(
     spec: ModeSpec,
     line_index: u32,
@@ -49,19 +45,72 @@ pub(crate) fn decode_line(
     snr_est: &mut crate::snr::SnrEstimator,
     hedr_shift_hz: f64,
 ) {
-    // Phase 1 stub — Phase 3 implements the real demodulation.
-    let _ = (
-        spec,
-        line_index,
-        audio,
-        skip_samples,
-        line_seconds_offset,
-        rate_hz,
-        image,
-        demod,
-        snr_est,
-        hedr_shift_hz,
-    );
+    let pixel_secs = spec.pixel_seconds;
+    let sync_secs = spec.sync_seconds;
+    let porch_secs = spec.porch_seconds;
+    let septr_secs = spec.septr_seconds;
+    let width = spec.line_pixels;
+    let chan_len = f64::from(width) * pixel_secs;
+
+    // Scottie channel start times relative to *line start* (the start
+    // of the first septr at the beginning of line N). Translated from
+    // slowrx `video.c:72-79`:
+    //
+    //   [septr][G pixels][septr][B pixels][SYNC][porch][R pixels]
+    //   ^      ^                ^                       ^
+    //   0      septr            2·septr + chan_len      2·septr + 2·chan_len + sync + porch
+    //
+    // `find_sync` returns a `skip_samples` already corrected to point at
+    // line 0's start (its `SyncPosition::Scottie` branch applies
+    // `s = s - chan_len/2 + 2·porch` per slowrx `sync.c:123-125`), so
+    // these offsets are positive and identical to slowrx C's `ChanStart`
+    // values.
+    let chan_starts_sec: [f64; 3] = [
+        septr_secs,                                                 // G
+        2.0 * septr_secs + chan_len,                                // B
+        2.0 * septr_secs + 2.0 * chan_len + sync_secs + porch_secs, // R
+    ];
+
+    let width_us = width as usize;
+
+    // Channel sample-range bounds, computed once per channel with a
+    // single `round()` per bound (matches slowrx `video.c:140-142` to
+    // avoid per-pixel rounding drift).
+    let chan_bounds_abs: [(i64, i64); 3] = std::array::from_fn(|i| {
+        let start_sec = chan_starts_sec[i];
+        let end_sec = start_sec + chan_len;
+        let start_abs = skip_samples + ((line_seconds_offset + start_sec) * rate_hz).round() as i64;
+        let end_abs = skip_samples + ((line_seconds_offset + end_sec) * rate_hz).round() as i64;
+        (start_abs, end_abs)
+    });
+
+    // Decode each channel into its own buffer.
+    let mut g = vec![0_u8; width_us];
+    let mut b = vec![0_u8; width_us];
+    let mut r = vec![0_u8; width_us];
+
+    let buffers: [&mut [u8]; 3] = [&mut g, &mut b, &mut r];
+    for (chan_idx, buf) in buffers.into_iter().enumerate() {
+        crate::mode_pd::decode_one_channel_into(
+            buf,
+            chan_starts_sec[chan_idx],
+            chan_bounds_abs[chan_idx],
+            spec,
+            audio,
+            skip_samples,
+            line_seconds_offset,
+            rate_hz,
+            demod,
+            snr_est,
+            hedr_shift_hz,
+        );
+    }
+
+    // Compose RGB and write to the image. Scottie is already RGB; no
+    // chroma conversion needed (cf. Robot's YCrCb→RGB).
+    for x in 0..width_us {
+        image.put_pixel(x as u32, line_index, [r[x], g[x], b[x]]);
+    }
 }
 
 #[cfg(test)]

--- a/src/mode_scottie.rs
+++ b/src/mode_scottie.rs
@@ -112,8 +112,3 @@ pub(crate) fn decode_line(
         image.put_pixel(x as u32, line_index, [r[x], g[x], b[x]]);
     }
 }
-
-#[cfg(test)]
-mod tests {
-    // Tests land in Phase 3 alongside the implementation.
-}

--- a/src/modespec.rs
+++ b/src/modespec.rs
@@ -98,8 +98,8 @@ pub enum ChannelLayout {
 /// Where the sync pulse sits within a radio line.
 ///
 /// PD/Robot/Martin all place sync at line start (the standard SSTV
-/// convention). Scottie modes are the exception — sync sits between G
-/// and B channels, not at line start. Stored here so future mode
+/// convention). Scottie modes are the exception — sync sits between B
+/// and R channels, not at line start. Stored here so future mode
 /// decoders are forced to make their sync placement explicit at dispatch
 /// time, surfacing the V1 line-clock-advance assumption that sync ==
 /// line start.

--- a/src/modespec.rs
+++ b/src/modespec.rs
@@ -3,14 +3,17 @@
 //! Translated from slowrx's `modespec.c` (Oona Räisänen, ISC License).
 //! See `NOTICE.md` for full attribution.
 //!
-//! Implemented as of V2.2 (0.3.0): PD120, PD180, PD240, Robot 24, Robot 36,
-//! Robot 72. Remaining V2 modes (Scottie 1/2/DX, Martin 1/2) are not yet
-//! present in the [`SstvMode`] enum or the lookup tables; each will land
-//! with its own PR.
+//! Implemented as of V2.3 (0.4.0): PD120, PD180, PD240, Robot 24, Robot 36,
+//! Robot 72, Scottie 1, Scottie 2, Scottie DX. Scottie 1/2/DX are present
+//! in the [`SstvMode`] enum and the lookup tables as of 0.4.0 Phase 1
+//! scaffolding; the per-line demodulation lands in Phase 3 (see
+//! `mode_scottie::decode_line`). Remaining V2 modes (Martin 1/2) are
+//! not yet present and will land with their own PR.
 
 /// SSTV operating mode. Implemented: [`SstvMode::Pd120`], [`SstvMode::Pd180`],
 /// [`SstvMode::Pd240`], [`SstvMode::Robot24`], [`SstvMode::Robot36`],
-/// [`SstvMode::Robot72`]. Additional V2 modes (Scottie, Martin) planned.
+/// [`SstvMode::Robot72`], [`SstvMode::Scottie1`], [`SstvMode::Scottie2`],
+/// [`SstvMode::ScottieDx`]. Additional V2 modes (Martin) planned.
 #[non_exhaustive]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum SstvMode {
@@ -26,6 +29,14 @@ pub enum SstvMode {
     Robot36,
     /// Robot 72 (320×240, ~72s per image)
     Robot72,
+    /// Scottie 1 — VIS `0x3C`, 320×256 GBR, 0.4320 ms/pixel.
+    Scottie1,
+    /// Scottie 2 — VIS `0x38`, 320×256 GBR, 0.2752 ms/pixel.
+    Scottie2,
+    /// Scottie DX — VIS `0x4C`, 320×256 GBR, 1.08053 ms/pixel.
+    /// slowrx applies a +1 Hann-window-index bump in the per-pixel
+    /// demod when this mode is active (see `mode_scottie::decode_line`).
+    ScottieDx,
 }
 
 /// Mode timing + layout table entry.
@@ -78,6 +89,10 @@ pub enum ChannelLayout {
     /// per line. The shape difference is mode-internal — see
     /// `mode_robot::decode_line` for the per-mode dispatch.
     RobotYuv,
+    /// Sequential single-line RGB layout — three channels per radio
+    /// line. Used by Scottie (G→B→R, sync mid-line) and Martin (G→B→R,
+    /// sync at line start).
+    RgbSequential,
 }
 
 /// Where the sync pulse sits within a radio line.
@@ -88,15 +103,14 @@ pub enum ChannelLayout {
 /// decoders are forced to make their sync placement explicit at dispatch
 /// time, surfacing the V1 line-clock-advance assumption that sync ==
 /// line start.
-///
-/// All currently-shipped modes (PD, Robot) emit
-/// [`SyncPosition::LineStart`]. The `Scottie` variant lands with the
-/// V2.3 Scottie family epic.
 #[non_exhaustive]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum SyncPosition {
     /// Sync pulse at the start of each radio line. PD, Robot, Martin.
+    /// Scottie family uses [`SyncPosition::Scottie`] instead.
     LineStart,
+    /// Sync pulse between B and R within each radio line. Scottie family.
+    Scottie,
 }
 
 /// Look up the [`ModeSpec`] for a given 7-bit VIS code. Returns `None`
@@ -120,6 +134,9 @@ pub fn lookup(vis_code: u8) -> Option<ModeSpec> {
         0x04 => Some(ROBOT24),
         0x08 => Some(ROBOT36),
         0x0C => Some(ROBOT72),
+        0x38 => Some(SCOTTIE2),
+        0x3C => Some(SCOTTIE1),
+        0x4C => Some(SCOTTIE_DX),
         0x5F => Some(PD120),
         0x60 => Some(PD180),
         0x61 => Some(PD240),
@@ -141,6 +158,9 @@ pub fn for_mode(mode: SstvMode) -> ModeSpec {
         SstvMode::Robot24 => ROBOT24,
         SstvMode::Robot36 => ROBOT36,
         SstvMode::Robot72 => ROBOT72,
+        SstvMode::Scottie1 => SCOTTIE1,
+        SstvMode::Scottie2 => SCOTTIE2,
+        SstvMode::ScottieDx => SCOTTIE_DX,
     }
 }
 
@@ -241,6 +261,57 @@ const ROBOT72: ModeSpec = ModeSpec {
     septr_seconds: 0.0047,
     channel_layout: ChannelLayout::RobotYuv,
     sync_position: SyncPosition::LineStart,
+};
+
+const SCOTTIE1: ModeSpec = ModeSpec {
+    mode: SstvMode::Scottie1,
+    vis_code: 0x3C,
+    line_pixels: 320,
+    image_lines: 256,
+    // slowrx modespec.c:91-104 — S1 LineTime = 428.38e-3,
+    // PixelTime = 0.4320e-3, SyncTime = 9e-3, PorchTime = 1.5e-3,
+    // SeptrTime = 1.5e-3.
+    line_seconds: 0.428_38,
+    sync_seconds: 0.009,
+    porch_seconds: 0.001_5,
+    pixel_seconds: 0.000_432_0,
+    septr_seconds: 0.001_5,
+    channel_layout: ChannelLayout::RgbSequential,
+    sync_position: SyncPosition::Scottie,
+};
+
+const SCOTTIE2: ModeSpec = ModeSpec {
+    mode: SstvMode::Scottie2,
+    vis_code: 0x38,
+    line_pixels: 320,
+    image_lines: 256,
+    // slowrx modespec.c:105-117 — S2 LineTime = 277.692e-3,
+    // PixelTime = 0.2752e-3, SyncTime = 9e-3, PorchTime = 1.5e-3,
+    // SeptrTime = 1.5e-3.
+    line_seconds: 0.277_692,
+    sync_seconds: 0.009,
+    porch_seconds: 0.001_5,
+    pixel_seconds: 0.000_275_2,
+    septr_seconds: 0.001_5,
+    channel_layout: ChannelLayout::RgbSequential,
+    sync_position: SyncPosition::Scottie,
+};
+
+const SCOTTIE_DX: ModeSpec = ModeSpec {
+    mode: SstvMode::ScottieDx,
+    vis_code: 0x4C,
+    line_pixels: 320,
+    image_lines: 256,
+    // slowrx modespec.c:118-128 — SDX LineTime = 1050.3e-3,
+    // PixelTime = 1.08053e-3, SyncTime = 9e-3, PorchTime = 1.5e-3,
+    // SeptrTime = 1.5e-3.
+    line_seconds: 1.050_3,
+    sync_seconds: 0.009,
+    porch_seconds: 0.001_5,
+    pixel_seconds: 0.001_080_53,
+    septr_seconds: 0.001_5,
+    channel_layout: ChannelLayout::RgbSequential,
+    sync_position: SyncPosition::Scottie,
 };
 
 #[cfg(test)]
@@ -387,5 +458,59 @@ mod tests {
         assert_eq!(for_mode(SstvMode::Robot24).vis_code, 0x04);
         assert_eq!(for_mode(SstvMode::Robot36).vis_code, 0x08);
         assert_eq!(for_mode(SstvMode::Robot72).vis_code, 0x0C);
+    }
+
+    #[test]
+    fn scottie1_modespec() {
+        let spec = for_mode(SstvMode::Scottie1);
+        assert_eq!(spec.mode, SstvMode::Scottie1);
+        assert_eq!(spec.vis_code, 0x3C);
+        assert_eq!(spec.line_pixels, 320);
+        assert_eq!(spec.image_lines, 256);
+        assert_eq!(spec.channel_layout, ChannelLayout::RgbSequential);
+        assert_eq!(spec.sync_position, SyncPosition::Scottie);
+        assert!((spec.pixel_seconds - 0.4320e-3).abs() < 1e-9);
+        assert!((spec.line_seconds - 428.38e-3).abs() < 1e-9);
+    }
+
+    #[test]
+    fn scottie2_modespec() {
+        let spec = for_mode(SstvMode::Scottie2);
+        assert_eq!(spec.mode, SstvMode::Scottie2);
+        assert_eq!(spec.vis_code, 0x38);
+        assert!((spec.pixel_seconds - 0.2752e-3).abs() < 1e-9);
+        assert!((spec.line_seconds - 277.692e-3).abs() < 1e-9);
+        assert_eq!(spec.channel_layout, ChannelLayout::RgbSequential);
+        assert_eq!(spec.sync_position, SyncPosition::Scottie);
+    }
+
+    #[test]
+    fn scottie_dx_modespec() {
+        let spec = for_mode(SstvMode::ScottieDx);
+        assert_eq!(spec.mode, SstvMode::ScottieDx);
+        assert_eq!(spec.vis_code, 0x4C);
+        assert!((spec.pixel_seconds - 1.08053e-3).abs() < 1e-9);
+        assert!((spec.line_seconds - 1050.3e-3).abs() < 1e-9);
+        assert_eq!(spec.channel_layout, ChannelLayout::RgbSequential);
+        assert_eq!(spec.sync_position, SyncPosition::Scottie);
+    }
+
+    #[test]
+    fn scottie_vis_codes_resolve() {
+        // Codebase uses `lookup` (returning `Option<ModeSpec>`) rather
+        // than `for_vis_code`; mirrors the existing
+        // `pd120_vis_code_resolves` style.
+        assert_eq!(
+            lookup(0x3C).expect("S1 VIS resolves").mode,
+            SstvMode::Scottie1
+        );
+        assert_eq!(
+            lookup(0x38).expect("S2 VIS resolves").mode,
+            SstvMode::Scottie2
+        );
+        assert_eq!(
+            lookup(0x4C).expect("SDX VIS resolves").mode,
+            SstvMode::ScottieDx
+        );
     }
 }

--- a/src/scottie_test_encoder.rs
+++ b/src/scottie_test_encoder.rs
@@ -1,0 +1,195 @@
+//! Synthetic Scottie encoder for round-trip testing. Produces
+//! continuous-phase FM audio matching the encoder side of the SSTV
+//! protocol for Scottie 1, Scottie 2, and Scottie DX.
+//!
+//! Test-only — gated behind `cfg(any(test, feature = "test-support"))`.
+//! Lives in its own file so the production decoder stays under the
+//! 500-LOC ceiling.
+//!
+//! **Line layout per radio line:**
+//!
+//! ```text
+//! [septr 1500 Hz][G pixels 1500-2300 Hz][septr 1500 Hz]
+//! [B pixels 1500-2300 Hz][SYNC 1200 Hz][porch 1500 Hz]
+//! [R pixels 1500-2300 Hz]
+//! ```
+//!
+//! Total per line = 2·SeptrTime + 2·ImgWidth·PixelTime + SyncTime +
+//! PorchTime + ImgWidth·PixelTime = LineTime exactly (verified against
+//! the `ModeSpec` table for Scottie 1 / 2 / DX in `modespec.rs`).
+
+#![allow(
+    clippy::cast_precision_loss,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    clippy::cast_possible_wrap
+)]
+
+use crate::modespec::SstvMode;
+use crate::resample::WORKING_SAMPLE_RATE_HZ;
+use std::f64::consts::PI;
+
+const SYNC_HZ: f64 = 1200.0;
+const PORCH_HZ: f64 = 1500.0;
+const SEPTR_HZ: f64 = 1500.0;
+const BLACK_HZ: f64 = 1500.0;
+const WHITE_HZ: f64 = 2300.0;
+
+fn lum_to_freq(lum: u8) -> f64 {
+    BLACK_HZ + (WHITE_HZ - BLACK_HZ) * f64::from(lum) / 255.0
+}
+
+/// Emit samples up to absolute sample index `target_n`, advancing phase.
+/// Cumulative-target pattern (matches `robot_test_encoder::fill_to`) so
+/// per-tone rounding doesn't compound across the line.
+fn fill_to(out: &mut Vec<f32>, freq_hz: f64, target_n: usize, phase: &mut f64) {
+    let dphi = 2.0 * PI * freq_hz / f64::from(WORKING_SAMPLE_RATE_HZ);
+    while out.len() < target_n {
+        out.push(phase.sin() as f32);
+        *phase += dphi;
+        if *phase > 2.0 * PI {
+            *phase -= 2.0 * PI;
+        }
+    }
+}
+
+/// Encode an image as Scottie 1 / 2 / DX audio. `rgb` is row-major,
+/// `line_pixels × image_lines` `[R, G, B]` triples (320×256 for all
+/// three Scottie modes). Returns f32 PCM at [`WORKING_SAMPLE_RATE_HZ`]
+/// (11_025 Hz).
+///
+/// Per radio line, emits in this order:
+///   1. Septr 1 at `SEPTR_HZ`
+///   2. G channel at `pixel_seconds` per pixel
+///   3. Septr 2 at `SEPTR_HZ`
+///   4. B channel at `pixel_seconds` per pixel
+///   5. Sync at `SYNC_HZ` (mid-line, between B and R)
+///   6. Porch at `PORCH_HZ`
+///   7. R channel at `pixel_seconds` per pixel
+#[must_use]
+#[doc(hidden)]
+#[allow(dead_code)]
+pub fn encode_scottie(mode: SstvMode, rgb: &[[u8; 3]]) -> Vec<f32> {
+    assert!(matches!(
+        mode,
+        SstvMode::Scottie1 | SstvMode::Scottie2 | SstvMode::ScottieDx
+    ));
+    let spec = crate::modespec::for_mode(mode);
+    let w = spec.line_pixels;
+    let h = spec.image_lines;
+    assert_eq!(rgb.len() as u32, w * h);
+
+    let sr = f64::from(WORKING_SAMPLE_RATE_HZ);
+    let mut out: Vec<f32> = Vec::new();
+    let mut phase = 0.0_f64;
+
+    let mut t = 0.0_f64;
+    let advance = |t: &mut f64, secs: f64| -> usize {
+        *t += secs;
+        (*t * sr).round() as usize
+    };
+
+    for y in 0..h {
+        // Septr 1.
+        fill_to(
+            &mut out,
+            SEPTR_HZ,
+            advance(&mut t, spec.septr_seconds),
+            &mut phase,
+        );
+
+        // G channel.
+        for x in 0..w {
+            let g = rgb[(y * w + x) as usize][1];
+            fill_to(
+                &mut out,
+                lum_to_freq(g),
+                advance(&mut t, spec.pixel_seconds),
+                &mut phase,
+            );
+        }
+
+        // Septr 2.
+        fill_to(
+            &mut out,
+            SEPTR_HZ,
+            advance(&mut t, spec.septr_seconds),
+            &mut phase,
+        );
+
+        // B channel.
+        for x in 0..w {
+            let b = rgb[(y * w + x) as usize][2];
+            fill_to(
+                &mut out,
+                lum_to_freq(b),
+                advance(&mut t, spec.pixel_seconds),
+                &mut phase,
+            );
+        }
+
+        // Sync (mid-line, between B and R).
+        fill_to(
+            &mut out,
+            SYNC_HZ,
+            advance(&mut t, spec.sync_seconds),
+            &mut phase,
+        );
+
+        // Porch.
+        fill_to(
+            &mut out,
+            PORCH_HZ,
+            advance(&mut t, spec.porch_seconds),
+            &mut phase,
+        );
+
+        // R channel.
+        for x in 0..w {
+            let r = rgb[(y * w + x) as usize][0];
+            fill_to(
+                &mut out,
+                lum_to_freq(r),
+                advance(&mut t, spec.pixel_seconds),
+                &mut phase,
+            );
+        }
+
+        // Defensive pad to the line_seconds boundary. The Scottie line
+        // layout sums to exactly LineTime per the ModeSpec table, but
+        // float rounding could leave us a sample short — top up with
+        // PORCH_HZ (1500 Hz, the inter-line idle frequency) so the
+        // decoder's per-line timing model lines up with the audio.
+        let line_end_target = f64::from(y + 1) * spec.line_seconds;
+        let pad_secs = line_end_target - t;
+        if pad_secs > 0.0 {
+            fill_to(&mut out, PORCH_HZ, advance(&mut t, pad_secs), &mut phase);
+        }
+    }
+
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lum_to_freq_endpoints() {
+        assert!((lum_to_freq(0) - BLACK_HZ).abs() < 1e-9);
+        assert!((lum_to_freq(255) - WHITE_HZ).abs() < 1e-9);
+    }
+
+    #[test]
+    fn scottie1_encode_total_length() {
+        let rgb = vec![[128u8; 3]; 320 * 256];
+        let audio = encode_scottie(SstvMode::Scottie1, &rgb);
+        let spec = crate::modespec::for_mode(SstvMode::Scottie1);
+        let expected_len = (spec.line_seconds
+            * f64::from(spec.image_lines)
+            * f64::from(WORKING_SAMPLE_RATE_HZ)) as usize;
+        // Allow 1-sample rounding slack at end-of-image.
+        assert!(audio.len() >= expected_len);
+        assert!(audio.len() <= expected_len + 1);
+    }
+}

--- a/src/snr.rs
+++ b/src/snr.rs
@@ -109,9 +109,11 @@ impl Default for HannBank {
 /// ```
 ///
 /// slowrx also bumps the index up by one for Scottie DX (`Mode == SDX`)
-/// when `WinIdx < 6`. We don't yet support Scottie modes, so that branch
-/// is omitted; once the SDX decoder lands it will pass `is_sdx: bool`
-/// or call a separate selector.
+/// when `WinIdx < 6`. The Scottie family decoder applies that bump
+/// post-hoc inside [`crate::mode_pd::decode_one_channel_into`]
+/// (matching slowrx C `video.c:367` exactly), so this bare selector
+/// — and the [`window_idx_for_snr_with_hysteresis`] variant — stay
+/// mode-agnostic.
 #[must_use]
 pub(crate) fn window_idx_for_snr(snr_db: f64) -> usize {
     if snr_db >= 20.0 {

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -354,9 +354,27 @@ pub(crate) fn find_sync(has_sync: &[bool], initial_rate_hz: f64, spec: ModeSpec)
         xmax -= 350;
     }
 
-    // sync.c:120,127. V1 ports PD-family only; the Scottie branch
-    // (sync.c:123-125) is unreachable here.
-    let s_secs = (f64::from(xmax) / (X_ACC_BINS as f64)) * spec.line_seconds - spec.sync_seconds;
+    // sync.c:120 — base offset to start of line 0's content. The xmax
+    // detection lands at the falling edge of the sync pulse, so the
+    // raw `s_secs` is `(sync_pos_in_line + sync_secs) - sync_secs =
+    // sync_pos_in_line` for any mode. PD/Robot/Martin sync at line
+    // start: s_secs ≈ 0 (slightly negative → zero-pad). Scottie sync
+    // is mid-line, so `xmax` lands ~2/3 down the line. The
+    // `xmax > 350` slip check (sync.c:117) wraps it back to the left
+    // half of the line.
+    let s_secs_raw =
+        (f64::from(xmax) / (X_ACC_BINS as f64)) * spec.line_seconds - spec.sync_seconds;
+    // sync.c:123-125 — Scottie modes don't start lines with sync.
+    // The slip-wrapped xmax doesn't correspond to a line-start anchor,
+    // so apply slowrx C's mode-specific correction to bring `s_secs`
+    // back to ~0 (line 0's content start).
+    let s_secs = match spec.sync_position {
+        crate::modespec::SyncPosition::LineStart => s_secs_raw,
+        crate::modespec::SyncPosition::Scottie => {
+            let chan_len = f64::from(spec.line_pixels) * spec.pixel_seconds;
+            s_secs_raw - chan_len / 2.0 + 2.0 * spec.porch_seconds
+        }
+    };
     let skip_samples = (s_secs * rate).round() as i64;
 
     SyncResult {

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -220,3 +220,98 @@ fn robot36_roundtrip() {
 fn robot24_roundtrip() {
     run_robot_roundtrip(SstvMode::Robot24);
 }
+
+/// Build a synthetic RGB image for Scottie round-trip tests:
+/// horizontal red gradient + alternating green/blue stripes.
+#[allow(
+    clippy::cast_precision_loss,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    clippy::many_single_char_names
+)]
+fn test_scottie_image(mode: SstvMode) -> (u32, u32, Vec<[u8; 3]>) {
+    let spec = slowrx::for_mode(mode);
+    let w = spec.line_pixels;
+    let h = spec.image_lines;
+    let mut rgb = Vec::with_capacity((w * h) as usize);
+    for y in 0..h {
+        for x in 0..w {
+            let r = ((f64::from(x)) / (f64::from(w)) * 255.0) as u8;
+            let g = if y % 8 < 4 { 200 } else { 56 };
+            let b = if (y + 2) % 8 < 4 { 200 } else { 56 };
+            rgb.push([r, g, b]);
+        }
+    }
+    (w, h, rgb)
+}
+
+#[allow(
+    clippy::cast_precision_loss,
+    clippy::cast_possible_wrap,
+    clippy::cast_sign_loss
+)]
+fn run_scottie_roundtrip(mode: SstvMode) {
+    let (w, h, rgb) = test_scottie_image(mode);
+
+    let vis_code = match mode {
+        SstvMode::Scottie1 => 0x3C,
+        SstvMode::Scottie2 => 0x38,
+        SstvMode::ScottieDx => 0x4C,
+        _ => unreachable!(),
+    };
+    let mut audio = slowrx::__test_support::vis::synth_vis(vis_code, 0.0);
+    audio.extend(slowrx::__test_support::mode_scottie::encode_scottie(
+        mode, &rgb,
+    ));
+    audio.extend(std::iter::repeat_n(0.0_f32, 8192));
+
+    let mut d = SstvDecoder::new(WORKING_SAMPLE_RATE_HZ).expect("decoder");
+    let events = d.process(&audio);
+
+    let img = events
+        .iter()
+        .find_map(|e| match e {
+            SstvEvent::ImageComplete {
+                image,
+                partial: false,
+            } => Some(image.clone()),
+            _ => None,
+        })
+        .expect("ImageComplete event");
+
+    assert_eq!(img.mode, mode);
+    assert_eq!(img.width, w);
+    assert_eq!(img.height, h);
+
+    let mut max_diff = 0_u8;
+    let mut sum_diff: u64 = 0;
+    let mut n: u64 = 0;
+    for (i, src_rgb) in rgb.iter().enumerate() {
+        let dec = img.pixels[i];
+        for ch in 0..3 {
+            let d = (i32::from(src_rgb[ch]) - i32::from(dec[ch])).unsigned_abs() as u8;
+            if d > max_diff {
+                max_diff = d;
+            }
+            sum_diff += u64::from(d);
+            n += 1;
+        }
+    }
+    let mean = sum_diff as f64 / n as f64;
+    assert!(mean < 5.0, "{mode:?}: max_diff={max_diff} mean={mean:.2}");
+}
+
+#[test]
+fn scottie1_roundtrip() {
+    run_scottie_roundtrip(SstvMode::Scottie1);
+}
+
+#[test]
+fn scottie2_roundtrip() {
+    run_scottie_roundtrip(SstvMode::Scottie2);
+}
+
+#[test]
+fn scottie_dx_roundtrip() {
+    run_scottie_roundtrip(SstvMode::ScottieDx);
+}


### PR DESCRIPTION
## Summary

- Adds Scottie 1 (VIS \`0x3C\`), Scottie 2 (\`0x38\`), and Scottie DX (\`0x4C\`) decoders.
- Mid-line sync (sync between B and R within each radio line) is implemented across **two** call sites: \`mode_scottie::decode_line\` for the per-channel demodulation, and a new \`SyncPosition::Scottie\` branch in \`sync::find_sync\` that applies slowrx C's \`s = s − chan_len/2 + 2·porch\` correction (\`sync.c:123-125\`). Without the find_sync branch, the existing \`xmax > 350\` slip detection treats Scottie's mid-line sync as a wrapped PD/Robot sync and lands \`skip_samples\` ~64 ms past line 0 start. PD/Robot/Martin behavior is unchanged (\`SyncPosition::LineStart\` keeps the existing formula).
- Scottie-DX–specific Hann-window-index \`+1\` bump (slowrx C \`video.c:367\`) applied inside \`mode_pd::decode_one_channel_into\` based on \`spec.mode == ScottieDx && idx < 6\`. Bump happens after the hysteresis selector tracks the un-bumped index, so it doesn't compound across pixels.
- Three new synthetic round-trips (\`scottie1_roundtrip\`, \`scottie2_roundtrip\`, \`scottie_dx_roundtrip\`) pass at unchanged \`mean < 5.0\`. All 6 existing round-trips still pass — regression net intact.
- New \`ChannelLayout::RgbSequential\` and \`SyncPosition::Scottie\` enum variants. Three new \`ModeSpec\` consts. New \`crate::mode_scottie\` module. New \`crate::scottie_test_encoder\` (test-support gated).

## Test plan

- [x] \`cargo fmt --check\` clean
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\` clean
- [x] \`cargo test --all-features --locked\` — 110 lib tests + 9 round-trip tests + doc tests, all passing
- [x] \`RUSTDOCFLAGS=-D warnings cargo doc --no-deps --all-features\` clean
- [x] Coverage ≥ 92% per-file maintained

## Out of scope

- Real-radio Scottie validation — async, no fixtures available yet.
- V2.4 Martin family — separate epic ([#66]).
- Pixel-diff comparator ([#70]) and squiggle work ([#71]) — both still pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added native decoder support for Scottie 1, Scottie 2 and Scottie DX (mid-line sync) allowing direct playback of Scottie-format images.

* **Improvements**
  * Updated sync handling and per-channel timing for Scottie modes; adjusted Scottie DX demodulation window for more accurate pixel decoding.

* **Tests**
  * Added synthetic round‑trip tests for Scottie1/Scottie2/ScottieDx validating decode fidelity.

* **Documentation**
  * Added design, plan, and changelog entries for the 0.4.0 Scottie-family release.

* **Chores**
  * Project version bumped to 0.4.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->