### PR TITLE
feat(martin): V2.4 — Martin family (M1, M2) — 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,65 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-05-05
+
+Minor release adding Martin 1 (VIS `0x2C`) and Martin 2 (`0x28`) —
+both 320×256 GBR with sync at line start (standard SSTV convention).
+Reuses the `ChannelLayout::RgbSequential` infrastructure landed in
+V2.3 Scottie. Synthetic round-trip-validated; real-radio Martin
+capture validation is async ([#66]).
+
+[#66]: https://github.com/jasonherald/slowrx.rs/issues/66
+
+### Added
+
+- **`SstvMode::Martin1`** (VIS `0x2C`), **`Martin2`** (`0x28`).
+- Two new `ModeSpec` consts: `MARTIN1`, `MARTIN2`. Values
+  transcribed from slowrx C `modespec.c:39-63`.
+
+### Changed
+
+- **`mode_scottie::decode_line`** now branches on
+  `spec.sync_position` for `chan_starts_sec`. The `Scottie` branch
+  is unchanged from V2.3; the new `LineStart` branch handles Martin
+  via slowrx C `video.c` "default" case offsets (`sync + porch`,
+  then `+ chan_len + septr`, then `+ chan_len + septr`).
+- **`scottie_test_encoder::encode_scottie`** accepts Martin modes
+  and branches per-line tone emission on `spec.sync_position`.
+  Martin emission order: `[SYNC][porch][G][septr][B][septr][R]`.
+- **Module rustdocs** in `mode_scottie` and `scottie_test_encoder`
+  expanded to enumerate both Scottie and Martin families with
+  layout diagrams.
+- **`src/lib.rs` Status block** bumped from `0.4.x — V2.3 published`
+  to `0.5.x — V2.4 published`; Martin 1 / Martin 2 added to the
+  implemented-modes list.
+
+### Validation
+
+- Two new synthetic round-trips (`martin1_roundtrip`,
+  `martin2_roundtrip`) pass at unchanged `mean < 5.0` per-pixel-
+  RGB-diff threshold.
+- All 9 prior round-trips (PD120/180/240, R24/36/72, S1/S2/SDX)
+  continue to pass at the same threshold — regression net intact.
+- Coverage ≥ 92% per-file maintained.
+
+### Notes
+
+- Martin's `SyncPosition::LineStart` routes through the existing
+  PD/Robot path in `find_sync`; no `find_sync` changes were needed
+  (unlike V2.3 Scottie, which required a new branch).
+- Module / function names (`mode_scottie`, `encode_scottie`) stay
+  despite the family-scope expansion. Renaming was deferred per
+  the V2.4 epic's "Cross-mode shared-helper refactoring beyond
+  what naturally falls out of Scottie reuse" out-of-scope clause.
+- Real-radio Martin capture validation is async (no reference WAVs
+  available yet). [#70] (pixel-diff comparator), [#71] (squiggles),
+  and [#77] (SIMD multiversioning) remain pending.
+
+[#70]: https://github.com/jasonherald/slowrx.rs/issues/70
+[#71]: https://github.com/jasonherald/slowrx.rs/issues/71
+[#77]: https://github.com/jasonherald/slowrx.rs/issues/77
+
 ## [0.4.0] - 2026-05-04
 
 Minor release adding the Scottie family — Scottie 1, Scottie 2,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -707,7 +707,7 @@ checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "slowrx"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slowrx"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 rust-version = "1.85"
 description = "Pure-Rust SSTV (Slow-Scan TV) decoder library — a port of slowrx by Oona Räisänen"

--- a/docs/superpowers/plans/2026-05-05-v0.5.0-martin.md
+++ b/docs/superpowers/plans/2026-05-05-v0.5.0-martin.md
@@ -1,0 +1,892 @@
+# 0.5.0 V2.4 Martin Family Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add Martin 1 (VIS `0x2C`) and Martin 2 (`0x28`) decoders. Both 320×256 GBR, sync at line start (standard SSTV), reuses the V2.3-built `ChannelLayout::RgbSequential` infrastructure. Ship as `slowrx 0.5.0`.
+
+**Architecture:** Two new `SstvMode` variants + two `ModeSpec` consts in `src/modespec.rs`. `mode_scottie::decode_line` and `scottie_test_encoder::encode_scottie` gain a `match spec.sync_position` branch — Scottie-specific offsets stay; new `LineStart` arm handles Martin. `decoder.rs` and `find_sync` are unchanged (Martin's `LineStart` already routes through the existing PD/Robot path). Two new round-trip tests reuse the V2.3 Scottie helpers.
+
+**Tech Stack:** Rust 2021 (MSRV 1.85), `rustfft`, `thiserror`. CI runs `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --all-features --locked`, `RUSTDOCFLAGS=-D warnings cargo doc --no-deps --all-features`. Release: `cargo publish --features cli --allow-dirty`. GitHub via `gh` CLI.
+
+**Spec reference:** `docs/superpowers/specs/2026-05-05-v0.5.0-martin-design.md` (committed on this branch as `ce012f9`).
+**slowrx C reference (locally):** `original/slowrx/modespec.c:39-63` (M1/M2 ModeSpec consts), `original/slowrx/video.c` "default" case (PD/Robot/Martin ChanStart computation).
+
+**Working directory:** `/data/source/slowrx.rs-v0.5.0-martin` (worktree on `feat/v0.5.0-martin`, branched from `main` at v0.4.0 SHA `2a02369`).
+
+**Project conventions:**
+- **No GPG signing** of commits or tags. Use plain `git commit`.
+- **Full local CI gate** before each commit.
+- **No simplifications, no deferments.**
+
+**No-touch list:**
+- `src/sync.rs` — Martin's `SyncPosition::LineStart` uses the existing PD/Robot formula. No changes.
+- `src/decoder.rs` — `RgbSequential` dispatch arm landed in V2.3 and handles Martin transitively.
+- `src/snr.rs` — no FFT_LEN, HANN_LENS, or selector changes; SDX +1 bump in `mode_pd::decode_one_channel_into` is `ScottieDx`-gated and won't fire for Martin.
+- `src/vis.rs`, `src/mode_pd.rs`, `src/mode_robot.rs` — unchanged.
+- Existing 9 round-trips (PD120/180/240, R24/36/72, S1/S2/SDX) must continue to pass at unchanged `mean < 5.0`.
+
+---
+
+## Phase 1 — ModeSpec additions (single commit)
+
+### Task 1.1: Add `Martin1` / `Martin2` `SstvMode` variants + two `ModeSpec` consts + lookup arms + 3 unit tests
+
+**Files:** Modify `src/modespec.rs` only.
+
+**Step 1: Add new `SstvMode` variants**
+
+In `pub enum SstvMode`:
+
+```rust
+/// Martin 1 — VIS `0x2C`, 320×256 GBR, 0.4576 ms/pixel.
+Martin1,
+/// Martin 2 — VIS `0x28`, 320×256 GBR, 0.2288 ms/pixel.
+Martin2,
+```
+
+**Step 2: Add two `ModeSpec` consts**
+
+After the existing Scottie consts (`SCOTTIE_DX`), append:
+
+```rust
+/// Martin 1. slowrx `modespec.c:39-50`.
+const MARTIN1: ModeSpec = ModeSpec {
+    mode: SstvMode::Martin1,
+    vis_code: 0x2C,
+    line_pixels: 320,
+    image_lines: 256,
+    // slowrx modespec.c:39-50 — M1 LineTime = 446.446e-3,
+    // PixelTime = 0.4576e-3, SyncTime = 4.862e-3,
+    // PorchTime = 0.572e-3, SeptrTime = 0.572e-3.
+    line_seconds: 0.446_446,
+    sync_seconds: 0.004_862,
+    porch_seconds: 0.000_572,
+    pixel_seconds: 0.000_457_6,
+    septr_seconds: 0.000_572,
+    channel_layout: ChannelLayout::RgbSequential,
+    sync_position: SyncPosition::LineStart,
+};
+
+/// Martin 2. slowrx `modespec.c:52-63`.
+const MARTIN2: ModeSpec = ModeSpec {
+    mode: SstvMode::Martin2,
+    vis_code: 0x28,
+    line_pixels: 320,
+    image_lines: 256,
+    // slowrx modespec.c:52-63 — M2 LineTime = 226.7986e-3,
+    // PixelTime = 0.2288e-3, SyncTime = 4.862e-3,
+    // PorchTime = 0.572e-3, SeptrTime = 0.572e-3.
+    line_seconds: 0.226_798_6,
+    sync_seconds: 0.004_862,
+    porch_seconds: 0.000_572,
+    pixel_seconds: 0.000_228_8,
+    septr_seconds: 0.000_572,
+    channel_layout: ChannelLayout::RgbSequential,
+    sync_position: SyncPosition::LineStart,
+};
+```
+
+(Confirm field order matches the existing `SCOTTIE1` const before pasting. Match exactly.)
+
+**Step 3: Add `for_mode` lookup arms**
+
+Inside `pub fn for_mode(mode: SstvMode) -> ModeSpec`, add after the Scottie arms:
+
+```rust
+SstvMode::Martin1 => MARTIN1,
+SstvMode::Martin2 => MARTIN2,
+```
+
+**Step 4: Add `lookup` (VIS-code → `Option<ModeSpec>`) arms**
+
+Find the `lookup` function (the codebase's name for what slowrx C calls `for_vis_code`). Add:
+
+```rust
+0x2C => Some(MARTIN1),
+0x28 => Some(MARTIN2),
+```
+
+(Match the existing pattern shape; if `lookup` is a `match u8 { ... }` keep it consistent.)
+
+**Step 5: Add 3 unit tests in `mod tests`**
+
+Mirror the existing `scottie1_modespec` / `scottie2_modespec` style:
+
+```rust
+#[test]
+fn martin1_modespec() {
+    let spec = for_mode(SstvMode::Martin1);
+    assert_eq!(spec.mode, SstvMode::Martin1);
+    assert_eq!(spec.vis_code, 0x2C);
+    assert_eq!(spec.line_pixels, 320);
+    assert_eq!(spec.image_lines, 256);
+    assert_eq!(spec.channel_layout, ChannelLayout::RgbSequential);
+    assert_eq!(spec.sync_position, SyncPosition::LineStart);
+    assert!((spec.pixel_seconds - 0.000_457_6).abs() < 1e-9);
+    assert!((spec.line_seconds - 0.446_446).abs() < 1e-9);
+}
+
+#[test]
+fn martin2_modespec() {
+    let spec = for_mode(SstvMode::Martin2);
+    assert_eq!(spec.mode, SstvMode::Martin2);
+    assert_eq!(spec.vis_code, 0x28);
+    assert!((spec.pixel_seconds - 0.000_228_8).abs() < 1e-9);
+    assert!((spec.line_seconds - 0.226_798_6).abs() < 1e-9);
+    assert_eq!(spec.channel_layout, ChannelLayout::RgbSequential);
+    assert_eq!(spec.sync_position, SyncPosition::LineStart);
+}
+
+#[test]
+fn martin_vis_codes_resolve() {
+    assert_eq!(lookup(0x2C).expect("M1").mode, SstvMode::Martin1);
+    assert_eq!(lookup(0x28).expect("M2").mode, SstvMode::Martin2);
+}
+```
+
+(Adapt the helper-function name if the existing tests use `unwrap()` or other idioms — match `scottie_vis_codes_resolve` exactly.)
+
+**Step 6: Run modespec tests**
+
+```bash
+cargo test --features test-support --lib modespec 2>&1 | grep -E "^test result|FAIL"
+```
+
+Expected: every prior modespec test passes, plus the 3 new Martin tests. Lib build will not yet be fully wired since `decode_line` and `encode_scottie` haven't been updated — that's Phase 2.
+
+If lib build fails with `non-exhaustive patterns: SstvMode::Martin1 not covered`, the failing match is in `mode_scottie::decode_line` or `encode_scottie`'s mode assertion. That's expected; proceed to Phase 2.
+
+### Task 1.2: Run full local CI gate + commit Phase 1
+
+**Step 1: Full CI gate**
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --all-targets --all-features -- -D warnings 2>&1 | tail -3
+cargo test --all-features --locked 2>&1 | grep -E "^test result"
+RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features 2>&1 | tail -3
+```
+
+If clippy or test fails because Phase 2 hasn't landed yet (e.g., `encode_scottie`'s assertion rejects Martin), this Phase-1 split won't work — fold Phase 1 + Phase 2 into a single commit. Otherwise proceed.
+
+**Step 2: Commit**
+
+```bash
+git add -- src/modespec.rs
+git commit -m "$(cat <<'EOF'
+feat(martin): modespec — Martin1, Martin2, and VIS lookup arms
+
+Phase 1 of V2.4 Martin. Adds the two new SstvMode variants and
+ModeSpec consts (transcribed from slowrx C modespec.c:39-63), plus
+lookup arms in for_mode + lookup. Three new unit tests
+(martin1_modespec, martin2_modespec, martin_vis_codes_resolve).
+
+Decode + encode integration lands in Phase 2.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+**Step 3: Verify with `git log --oneline -3`** — expect 2 commits on the branch.
+
+---
+
+## Phase 2 — `decode_line` + `encode_scottie` sync_position branches (single commit)
+
+The substantive code change. Both `decode_line` and `encode_scottie` gain a `match spec.sync_position { Scottie => ..., LineStart => ... }` for the channel offset / per-line emission order. The Scottie branch is unchanged from V2.3.
+
+### Task 2.1: Update `mode_scottie::decode_line` to branch on `sync_position`
+
+**File:** `src/mode_scottie.rs`.
+
+**Step 1: Read the existing `chan_starts_sec` block**
+
+```bash
+sed -n '70,90p' src/mode_scottie.rs
+```
+
+You'll see the Scottie-only formula:
+
+```rust
+let chan_starts_sec: [f64; 3] = [
+    septr_secs,                                                  // G
+    2.0 * septr_secs + chan_len,                                // B
+    2.0 * septr_secs + 2.0 * chan_len + sync_secs + porch_secs, // R
+];
+```
+
+**Step 2: Replace with a `match spec.sync_position`**
+
+```rust
+// Channel start times relative to *line start*. Scottie's mid-line
+// sync sits at `2·septr + 2·chan_len`; the LineStart branch puts
+// sync at offset 0 (G follows after sync + porch). find_sync returns
+// `skip_samples` already corrected for both — Scottie applies
+// `s = s − chan_len/2 + 2·porch` (slowrx C `sync.c:123-125`),
+// LineStart uses the unmodified PD/Robot formula.
+let chan_starts_sec: [f64; 3] = match spec.sync_position {
+    crate::modespec::SyncPosition::Scottie => [
+        septr_secs,                                                 // G (post-septr1)
+        2.0 * septr_secs + chan_len,                               // B (post-septr2)
+        2.0 * septr_secs + 2.0 * chan_len + sync_secs + porch_secs, // R (post-sync+porch)
+    ],
+    crate::modespec::SyncPosition::LineStart => [
+        // Martin layout — slowrx C video.c default case:
+        //   ChanStart[0] = sync + porch
+        //   ChanStart[1] = ChanStart[0] + chan_len + septr
+        //   ChanStart[2] = ChanStart[1] + chan_len + septr
+        sync_secs + porch_secs,                                       // G
+        sync_secs + porch_secs + chan_len + septr_secs,               // B
+        sync_secs + porch_secs + 2.0 * chan_len + 2.0 * septr_secs,   // R
+    ],
+};
+```
+
+**Step 3: Update the module-level rustdoc**
+
+The existing rustdoc says "Scottie-family mode decoder (Scottie 1, Scottie 2, Scottie DX)." Expand to:
+
+```rust
+//! RGB-sequential mode decoder — Scottie 1/2/DX and Martin 1/2.
+//!
+//! Both families use [`crate::modespec::ChannelLayout::RgbSequential`]:
+//! three GBR channels per radio line, written to the image in-place
+//! via `image.put_pixel`. The two families differ in **where the sync
+//! pulse sits within a radio line**:
+//!
+//! - **Scottie** ([`crate::modespec::SyncPosition::Scottie`]): sync
+//!   sits between the B and R channels (mid-line). `find_sync`
+//!   applies a Scottie-specific correction so `skip_samples` lands
+//!   at line 0's start.
+//! - **Martin** ([`crate::modespec::SyncPosition::LineStart`]): sync
+//!   at line start (standard SSTV convention); same as PD and Robot.
+//!
+//! ```text
+//! Scottie line layout:
+//!   [septr][G pixels][septr][B pixels][SYNC][porch][R pixels]
+//!     ^                                  ^
+//!     |                                  |
+//!     line start                         find_sync detects this
+//!                                        (mid-line — Scottie branch
+//!                                        in find_sync corrects skip)
+//!
+//! Martin line layout:
+//!   [SYNC][porch][G pixels][septr][B pixels][septr][R pixels]
+//!   ^
+//!   |
+//!   line start (sync at line start; standard PD/Robot path)
+//! ```
+//!
+//! Translated from slowrx's `video.c:72-79` (Scottie ChanStart) and
+//! the `video.c` "default" case (Martin/PD/Robot ChanStart). slowrx's
+//! GBR storage convention (`video.c:440-444`) is bypassed — we write
+//! RGB directly via [`crate::image::SstvImage::put_pixel`].
+//!
+//! See `NOTICE.md` for full slowrx attribution.
+```
+
+The function-level rustdoc on `decode_line` itself stays — its signature semantics didn't change.
+
+### Task 2.2: Update `scottie_test_encoder::encode_scottie`
+
+**File:** `src/scottie_test_encoder.rs`.
+
+**Step 1: Relax the mode assertion**
+
+Find the existing assertion:
+
+```rust
+assert!(matches!(
+    mode,
+    SstvMode::Scottie1 | SstvMode::Scottie2 | SstvMode::ScottieDx
+));
+```
+
+Update to include Martin:
+
+```rust
+assert!(matches!(
+    mode,
+    SstvMode::Scottie1
+        | SstvMode::Scottie2
+        | SstvMode::ScottieDx
+        | SstvMode::Martin1
+        | SstvMode::Martin2
+));
+```
+
+**Step 2: Branch the per-line tone emission on `spec.sync_position`**
+
+The existing per-line loop emits Scottie's tone order:
+
+```text
+Septr 1 → G pixels → Septr 2 → B pixels → Sync → Porch → R pixels
+```
+
+Replace with:
+
+```rust
+for y in 0..h {
+    match spec.sync_position {
+        crate::modespec::SyncPosition::Scottie => {
+            // Septr 1.
+            fill_to(&mut out, SEPTR_HZ, advance(&mut t, spec.septr_seconds), &mut phase);
+
+            // G channel.
+            for x in 0..w {
+                let g = rgb[(y * w + x) as usize][1];
+                fill_to(&mut out, lum_to_freq(g), advance(&mut t, spec.pixel_seconds), &mut phase);
+            }
+
+            // Septr 2.
+            fill_to(&mut out, SEPTR_HZ, advance(&mut t, spec.septr_seconds), &mut phase);
+
+            // B channel.
+            for x in 0..w {
+                let b = rgb[(y * w + x) as usize][2];
+                fill_to(&mut out, lum_to_freq(b), advance(&mut t, spec.pixel_seconds), &mut phase);
+            }
+
+            // Sync (mid-line, between B and R).
+            fill_to(&mut out, SYNC_HZ, advance(&mut t, spec.sync_seconds), &mut phase);
+
+            // Porch.
+            fill_to(&mut out, PORCH_HZ, advance(&mut t, spec.porch_seconds), &mut phase);
+
+            // R channel.
+            for x in 0..w {
+                let r = rgb[(y * w + x) as usize][0];
+                fill_to(&mut out, lum_to_freq(r), advance(&mut t, spec.pixel_seconds), &mut phase);
+            }
+        }
+        crate::modespec::SyncPosition::LineStart => {
+            // Martin layout: sync at line start, then porch, then
+            // G/septr/B/septr/R.
+
+            // Sync.
+            fill_to(&mut out, SYNC_HZ, advance(&mut t, spec.sync_seconds), &mut phase);
+
+            // Porch.
+            fill_to(&mut out, PORCH_HZ, advance(&mut t, spec.porch_seconds), &mut phase);
+
+            // G channel.
+            for x in 0..w {
+                let g = rgb[(y * w + x) as usize][1];
+                fill_to(&mut out, lum_to_freq(g), advance(&mut t, spec.pixel_seconds), &mut phase);
+            }
+
+            // Septr 1.
+            fill_to(&mut out, SEPTR_HZ, advance(&mut t, spec.septr_seconds), &mut phase);
+
+            // B channel.
+            for x in 0..w {
+                let b = rgb[(y * w + x) as usize][2];
+                fill_to(&mut out, lum_to_freq(b), advance(&mut t, spec.pixel_seconds), &mut phase);
+            }
+
+            // Septr 2.
+            fill_to(&mut out, SEPTR_HZ, advance(&mut t, spec.septr_seconds), &mut phase);
+
+            // R channel.
+            for x in 0..w {
+                let r = rgb[(y * w + x) as usize][0];
+                fill_to(&mut out, lum_to_freq(r), advance(&mut t, spec.pixel_seconds), &mut phase);
+            }
+        }
+    }
+
+    // Defensive pad to the line_seconds boundary (existing logic —
+    // shape unchanged).
+    let line_end_target = f64::from(y + 1) * spec.line_seconds;
+    let pad_secs = line_end_target - t;
+    if pad_secs > 0.0 {
+        fill_to(&mut out, PORCH_HZ, advance(&mut t, pad_secs), &mut phase);
+    }
+}
+```
+
+(The exact form of the `advance` closure / target-position pattern stays whatever the existing code uses — match it. The CR feedback from PR #76 was that the per-line allocation pattern in `decode_line` is fine; same here. Do not refactor for allocation reasons.)
+
+**Step 3: Update the module-level rustdoc**
+
+The existing rustdoc says "Synthetic Scottie encoder for round-trip testing." Expand to:
+
+```rust
+//! Synthetic RGB-sequential encoder for round-trip testing —
+//! handles both Scottie (1/2/DX) and Martin (1/2) families.
+//!
+//! Test-only — gated behind `cfg(any(test, feature = "test-support"))`.
+//!
+//! **Per-line tone emission order branches on
+//! [`crate::modespec::SyncPosition`]:**
+//!
+//! ```text
+//! Scottie (sync_position::Scottie):
+//!   [septr 1500 Hz][G pixels 1500-2300 Hz][septr 1500 Hz]
+//!   [B pixels 1500-2300 Hz][SYNC 1200 Hz][porch 1500 Hz]
+//!   [R pixels 1500-2300 Hz]
+//!
+//! Martin (sync_position::LineStart):
+//!   [SYNC 1200 Hz][porch 1500 Hz][G pixels 1500-2300 Hz]
+//!   [septr 1500 Hz][B pixels 1500-2300 Hz][septr 1500 Hz]
+//!   [R pixels 1500-2300 Hz]
+//! ```
+//!
+//! Total per line = LineTime exactly (defensive pad fills the
+//! boundary if float arithmetic rounds short).
+```
+
+### Task 2.3: Run full lib + existing round-trips (regression)
+
+**Step 1: Lib tests**
+
+```bash
+cargo test --features test-support --lib 2>&1 | grep -E "^test result|FAIL"
+```
+
+Expected: every test passes.
+
+**Step 2: Existing round-trips**
+
+```bash
+cargo test --test roundtrip --features test-support --release 2>&1 | tail -15
+```
+
+Expected: 9 tests pass (3 PD + 3 Robot + 3 Scottie). Martin round-trips don't exist yet — they land in Phase 3.
+
+If any existing round-trip broke: the `match spec.sync_position` change in `decode_line` or `encode_scottie` regressed one of the existing modes. Diagnose carefully — most likely the Scottie branch was accidentally modified.
+
+### Task 2.4: Run full local CI gate + commit Phase 2
+
+**Step 1: CI gate** (four standard commands).
+
+**Step 2: Commit**
+
+```bash
+git add -- src/mode_scottie.rs src/scottie_test_encoder.rs
+git commit -m "$(cat <<'EOF'
+feat(martin): decode_line + encode_scottie sync_position branches
+
+Phase 2 of V2.4 Martin. mode_scottie::decode_line and
+scottie_test_encoder::encode_scottie gain a `match spec.sync_position`
+for channel offsets / per-line tone order. The Scottie branch
+(SyncPosition::Scottie) is unchanged from V2.3; the new LineStart
+branch handles Martin via slowrx C video.c "default" case offsets:
+  ChanStart[0] = sync + porch
+  ChanStart[1] = ChanStart[0] + chan_len + septr
+  ChanStart[2] = ChanStart[1] + chan_len + septr
+
+Encoder per-line emission for LineStart:
+  [SYNC][porch][G pixels][septr][B pixels][septr][R pixels]
+
+Module rustdocs updated to enumerate both families and their layouts.
+decoder.rs, find_sync, mode_pd, snr unchanged. SDX +1 Hann bump
+(spec.mode == ScottieDx) won't fire for Martin.
+
+Existing 9 round-trips (PD120/180/240, R24/36/72, S1/S2/SDX) all
+pass at unchanged mean < 5.0. Martin round-trips land in Phase 3.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Phase 3 — Two new round-trip tests + green (single commit)
+
+### Task 3.1: Add `martin1_roundtrip` and `martin2_roundtrip`
+
+**File:** `tests/roundtrip.rs`.
+
+**Step 1: Extend the Scottie helper to cover Martin**
+
+The existing `run_scottie_roundtrip` matches on `mode` to fetch the VIS code. Add Martin arms:
+
+```rust
+let vis_code = match mode {
+    SstvMode::Scottie1 => 0x3C,
+    SstvMode::Scottie2 => 0x38,
+    SstvMode::ScottieDx => 0x4C,
+    SstvMode::Martin1 => 0x2C,
+    SstvMode::Martin2 => 0x28,
+    _ => unreachable!(),
+};
+```
+
+The rest of the helper (`encode_scottie` call, padding, decoder driving, mean-diff assertion) is mode-agnostic and works for Martin without further changes.
+
+**Step 2: Append two test functions**
+
+After the existing `scottie_dx_roundtrip` test:
+
+```rust
+#[test]
+fn martin1_roundtrip() {
+    run_scottie_roundtrip(SstvMode::Martin1);
+}
+
+#[test]
+fn martin2_roundtrip() {
+    run_scottie_roundtrip(SstvMode::Martin2);
+}
+```
+
+(The function name `run_scottie_roundtrip` is a Phase-1-decided slight misnomer post-Martin. Acceptable per the spec's "no churn for renames" decision.)
+
+**Step 3: Run the new tests**
+
+```bash
+cargo test --test roundtrip --features test-support --release martin 2>&1 | tail -10
+```
+
+Expected: 2 tests pass at `mean < 5.0`. Iteration may be needed.
+
+**If a round-trip fails:**
+
+- **`martin1_roundtrip` fails with mean ≈ 30+:** structural bug. Most likely the Phase 2 LineStart `chan_starts_sec` formula is off (drop a `+ septr_secs`?), or the encoder's tone order is mismatched with the decoder.
+- **`martin2_roundtrip` fails but `martin1` passes:** less likely — same code path. Recheck the M2 ModeSpec values (PixelTime 0.000_228_8, LineTime 0.226_798_6).
+
+If after 2-3 iterations the round-trips don't pass, **STOP and report DONE_WITH_CONCERNS or BLOCKED**. Don't relax the threshold.
+
+**Step 4: Run all 11 round-trips for full regression**
+
+```bash
+cargo test --test roundtrip --features test-support --release 2>&1 | tail -15
+```
+
+Expected: 11 tests pass.
+
+### Task 3.2: Run full local CI gate + commit Phase 3
+
+**Step 1: CI gate**.
+
+**Step 2: Commit**
+
+```bash
+git add -- tests/roundtrip.rs
+git commit -m "$(cat <<'EOF'
+feat(martin): round-trip tests — Martin1, Martin2 green
+
+Phase 3 of V2.4 Martin. Two new round-trip tests
+(martin1_roundtrip, martin2_roundtrip) exercise the
+LineStart-variant of the RGB-sequential decode/encode pair
+landed in Phase 2. Both pass at unchanged mean < 5.0.
+
+run_scottie_roundtrip helper extended with Martin VIS-code arms
+(0x2C, 0x28) — function name kept (slight misnomer accepted per
+spec's no-rename-churn decision).
+
+All 11 round-trips green: 3 PD + 3 Robot + 3 Scottie + 2 Martin.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Phase 4 — Documentation cleanup (single commit)
+
+Loose-end docs that were forward-references in earlier phases.
+
+### Task 4.1: Update `src/lib.rs` Status block
+
+**File:** `src/lib.rs`.
+
+The existing block says (post-V2.3): "0.4.x — V2.3 published. PD120/PD180/PD240 + Robot 24/36/72 + Scottie 1 / Scottie 2 / Scottie DX decoding from raw audio. ... Martin family (M1, M2) is the next planned epic."
+
+Update to:
+
+```rust
+//! ## Status
+//!
+//! `0.5.x` — V2.4 published. PD120/PD180/PD240 + Robot 24/36/72 +
+//! Scottie 1 / Scottie 2 / Scottie DX + Martin 1 / Martin 2 decoding
+//! from raw audio. PD120/PD180 validated against ARISS Dec-2017;
+//! Robot 36 validated against the ARISS Fram2 corpus (see
+//! `tests/ariss_fram2_validation.md`). Scottie and Martin families
+//! are synthetic round-trip-validated only — no Scottie or Martin
+//! reference WAVs available. The public API is
+//! `#[non_exhaustive]`-protected for additive growth as future
+//! mode-family epics land. See
+//! <https://github.com/jasonherald/slowrx.rs/issues/9> for the V2 roadmap.
+```
+
+(Drop the "Martin family is the next planned epic" sentence — V2.4 ships in this PR.)
+
+### Task 4.2: Run full local CI gate + commit Phase 4
+
+**Step 1: CI gate**.
+
+**Step 2: Commit**
+
+```bash
+git add -- src/lib.rs
+git commit -m "$(cat <<'EOF'
+docs(martin): clean up forward-references after Martin ships
+
+Phase 4 of V2.4 Martin. src/lib.rs Status block:
+- Bumped from `0.4.x — V2.3 published` to
+  `0.5.x — V2.4 published`.
+- Added Martin 1 / Martin 2 to the implemented-modes list.
+- Dropped the "Martin family is the next planned epic" sentence —
+  Martin shipped in this PR.
+
+(mode_scottie and scottie_test_encoder module rustdocs were
+already updated in Phase 2 to enumerate both families.)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Phase 5 — Release prep (single commit)
+
+### Task 5.1: Insert CHANGELOG `[0.5.0] - 2026-05-05`
+
+**File:** `CHANGELOG.md`. Insert between `## [Unreleased]` and `## [0.4.0] - 2026-05-04`:
+
+```markdown
+## [Unreleased]
+
+## [0.5.0] - 2026-05-05
+
+Minor release adding Martin 1 (VIS `0x2C`) and Martin 2 (`0x28`) —
+both 320×256 GBR with sync at line start (standard SSTV convention).
+Reuses the `ChannelLayout::RgbSequential` infrastructure landed in
+V2.3 Scottie. Synthetic round-trip-validated; real-radio Martin
+capture validation is async ([#66]).
+
+[#66]: https://github.com/jasonherald/slowrx.rs/issues/66
+
+### Added
+
+- **`SstvMode::Martin1`** (VIS `0x2C`), **`Martin2`** (`0x28`).
+- Two new `ModeSpec` consts: `MARTIN1`, `MARTIN2`. Values transcribed
+  from slowrx C `modespec.c:39-63`.
+
+### Changed
+
+- **`mode_scottie::decode_line`** now branches on `spec.sync_position`
+  for `chan_starts_sec`. The `Scottie` branch is unchanged from V2.3;
+  the new `LineStart` branch handles Martin via slowrx C `video.c`
+  "default" case offsets (`sync + porch`, then `+ chan_len + septr`,
+  then `+ chan_len + septr`).
+- **`scottie_test_encoder::encode_scottie`** accepts Martin modes and
+  branches per-line tone emission on `spec.sync_position`. Martin
+  emission order: `[SYNC][porch][G][septr][B][septr][R]`.
+- **Module rustdocs** in `mode_scottie` and `scottie_test_encoder`
+  expanded to enumerate both Scottie and Martin families with layout
+  diagrams.
+
+### Validation
+
+- Two new synthetic round-trips (`martin1_roundtrip`,
+  `martin2_roundtrip`) pass at unchanged `mean < 5.0`.
+- All 9 prior round-trips (PD120/180/240, R24/36/72, S1/S2/SDX)
+  continue to pass at the same threshold — regression net intact.
+- Coverage ≥ 92% per-file maintained.
+
+### Notes
+
+- Martin's `SyncPosition::LineStart` routes through the existing
+  PD/Robot path in `find_sync`; no `find_sync` changes were needed
+  (unlike V2.3 Scottie, which required a new branch).
+- Module / function names (`mode_scottie`, `encode_scottie`) stay
+  despite the family-scope expansion. Renaming was deferred per the
+  V2.4 epic's "Cross-mode shared-helper refactoring beyond what
+  naturally falls out of Scottie reuse" out-of-scope clause.
+- Real-radio Martin capture validation is async (no reference WAVs
+  available yet). [#70] (pixel-diff comparator) and [#71] (squiggles)
+  remain pending.
+
+[#70]: https://github.com/jasonherald/slowrx.rs/issues/70
+[#71]: https://github.com/jasonherald/slowrx.rs/issues/71
+```
+
+### Task 5.2: Bump `Cargo.toml` to `0.5.0`
+
+**File:** `Cargo.toml`.
+
+Replace `version = "0.4.0"` with `version = "0.5.0"`.
+
+```bash
+cargo build --features cli 2>&1 | tail -3
+```
+
+Expected: `Finished dev profile`. `Cargo.lock` auto-updates.
+
+### Task 5.3: Run full CI gate + commit Phase 5
+
+**Step 1: CI gate**.
+
+**Step 2: Commit**
+
+```bash
+git add -- CHANGELOG.md Cargo.toml Cargo.lock
+git commit -m "$(cat <<'EOF'
+chore(release): 0.5.0 — V2.4 Martin family (M1, M2)
+
+Minor release adding Martin 1 (VIS 0x2C) and Martin 2 (0x28).
+Reuses the ChannelLayout::RgbSequential infrastructure from V2.3.
+All 11 round-trips green at unchanged mean < 5.0.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+**Step 3: Verify with `git log --oneline -7`** — expect 6 commits on the branch (spec, plan, modespec, decode/encode, round-trips, docs, release = 7).
+
+---
+
+## Phase 6 — Open PR + post-merge tag + publish
+
+### Task 6.1: Push + open PR
+
+**Step 1: Push**
+
+```bash
+git push -u origin feat/v0.5.0-martin
+```
+
+**Step 2: Open PR**
+
+```bash
+gh pr create --base main --head feat/v0.5.0-martin \
+  --title "feat(martin): V2.4 — Martin family (M1, M2) — 0.5.0" \
+  --body "$(cat <<'EOF'
+## Summary
+
+- Adds Martin 1 (VIS \`0x2C\`) and Martin 2 (\`0x28\`) decoders. Both 320×256 GBR with sync at line start.
+- Reuses V2.3's \`ChannelLayout::RgbSequential\` infrastructure. \`mode_scottie::decode_line\` and \`scottie_test_encoder::encode_scottie\` gain a \`match spec.sync_position\` for channel offsets and per-line tone emission. Scottie branch unchanged.
+- New \`LineStart\` branch uses slowrx C \`video.c\` "default" case offsets. Martin emission order: \`[SYNC][porch][G][septr][B][septr][R]\`.
+- \`find_sync\`, \`decoder.rs\`, \`mode_pd\`, \`snr\` are unchanged. Martin's \`LineStart\` routes through the existing PD/Robot path.
+- Two new round-trip tests (\`martin1_roundtrip\`, \`martin2_roundtrip\`) pass at unchanged \`mean < 5.0\`. All 9 existing round-trips still pass — regression net intact.
+- Module / function names (\`mode_scottie\`, \`encode_scottie\`) stay despite the family-scope expansion. Renaming was deferred per the V2.4 epic's no-refactor-churn out-of-scope clause.
+
+## Test plan
+
+- [x] \`cargo fmt --check\` clean
+- [x] \`cargo clippy --all-targets --all-features -- -D warnings\` clean
+- [x] \`cargo test --all-features --locked\` — 110+ lib tests + 11 round-trips, all pass
+- [x] \`RUSTDOCFLAGS=-D warnings cargo doc --no-deps --all-features\` clean
+- [x] Coverage ≥ 92% per-file maintained
+
+## Out of scope
+
+- Real-radio Martin validation — async, no fixtures available.
+- V2.5 Zarya — separate epic ([#67]).
+- Pixel-diff comparator ([#70]) and squiggle work ([#71]) — both still pending.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+### Task 6.2: Post-merge — tag + publish
+
+**Note:** Blocks until user merges.
+
+**Step 1: Sync main**
+
+```bash
+cd /data/source/slowrx.rs
+git fetch --all --prune
+git pull --ff-only
+```
+
+**Step 2: Re-run CI gate on main**
+
+(Same four commands.)
+
+**Step 3: Tag `v0.5.0`** (annotated, unsigned)
+
+```bash
+git tag -a v0.5.0 -m "$(cat <<'EOF'
+slowrx 0.5.0 — V2.4 Martin family (M1, M2)
+
+Minor release adding Martin 1 (VIS 0x2C) and Martin 2 (0x28).
+Both 320×256 GBR with sync at line start (standard SSTV
+convention). Reuses the ChannelLayout::RgbSequential
+infrastructure landed in V2.3 Scottie.
+
+mode_scottie::decode_line and scottie_test_encoder::encode_scottie
+gained a sync_position branch. Scottie path unchanged; new
+LineStart branch handles Martin via slowrx C video.c "default"
+case offsets (sync + porch, then + chan_len + septr, ×3 channels).
+
+Synthetic round-trip-validated; all 11 round-trips pass at
+mean < 5.0 (3 PD + 3 Robot + 3 Scottie + 2 Martin). Real-radio
+Martin validation is async (no reference WAVs available yet).
+
+PR: #<fill in>.
+EOF
+)"
+git push origin v0.5.0
+```
+
+**Step 4: Publish to crates.io** (after explicit user confirmation — irreversible)
+
+```bash
+cargo publish --features cli --allow-dirty 2>&1 | tail -10
+```
+
+### Task 6.3: Cleanup
+
+**Step 1: Comment status on epic #66**
+
+```bash
+gh issue comment 66 --repo jasonherald/slowrx.rs --body "$(cat <<'EOF'
+## V2.4 shipped — slowrx 0.5.0
+
+\`slowrx 0.5.0\` (PR #<fill in>, tag \`v0.5.0\`, published to crates.io)
+ships the Martin family — M1, M2. Both decoders pass synthetic
+round-trips at the unchanged \`mean < 5.0\` threshold; the existing
+9 PD + Robot + Scottie round-trips continue to pass.
+
+The implementation reused V2.3's \`ChannelLayout::RgbSequential\`
+infrastructure: \`mode_scottie::decode_line\` and
+\`scottie_test_encoder::encode_scottie\` gained a single
+\`match spec.sync_position\` for channel offsets / per-line tone
+emission. Scottie branch unchanged; new LineStart branch handles
+Martin via slowrx C \`video.c\` "default" case offsets.
+
+Real-radio Martin capture validation remains async — no reference
+WAVs available yet.
+
+Closing this issue.
+EOF
+)"
+gh issue close 66 --repo jasonherald/slowrx.rs
+```
+
+**Step 2: Remove the worktree**
+
+```bash
+cd /data/source/slowrx.rs
+git worktree remove /data/source/slowrx.rs-v0.5.0-martin
+git worktree list
+```
+
+**Step 3: Confirm crates.io has 0.5.0**
+
+```bash
+cargo search slowrx 2>&1 | head -3
+```
+
+Expected: `slowrx = "0.5.0"`.
+
+---
+
+## Done criteria
+
+- All 11 round-trips green at unchanged `mean < 5.0` thresholds.
+- `crates.io/crates/slowrx` shows `0.5.0` as latest.
+- `git tag -l v0.5.0` exists and is pushed.
+- Epic #66 closed with a status comment.
+- Worktree removed.

--- a/docs/superpowers/specs/2026-05-05-v0.5.0-martin-design.md
+++ b/docs/superpowers/specs/2026-05-05-v0.5.0-martin-design.md
@@ -1,0 +1,260 @@
+# slowrx.rs 0.5.0 — V2.4 Martin Family Design Specification
+
+**Status:** Approved 2026-05-05. Ready for implementation planning via the
+[superpowers:writing-plans](https://github.com/anthropic-ai/superpowers) skill.
+
+**Goal:** Add decoder support for Martin 1 (VIS `0x2C`) and Martin 2
+(`0x28`) — both 320×256, GBR color encoding, with sync at line start
+(standard SSTV convention, `SyncPosition::LineStart`). Reuses the
+`ChannelLayout::RgbSequential` infrastructure landed in V2.3 Scottie.
+Ship as `slowrx 0.5.0`.
+
+**Out of scope for this spec:**
+
+- Real-radio Martin capture validation. The epic ([#66]) explicitly
+  flags this as async — no Martin reference WAVs available.
+- V2.5 Zarya ([#67]) — separate epic, not version-gated.
+- Pixel-diff comparator ([#70]) and squiggle work ([#71]) — both
+  still pending.
+- Module/function renaming (`mode_scottie` → `mode_rgb_sequential`,
+  `encode_scottie` → `encode_rgb_sequential`). Per the epic's
+  "Cross-mode shared-helper refactoring beyond what naturally falls
+  out of Scottie reuse" out-of-scope clause, the names stay; we
+  update the rustdoc to reflect the expanded scope.
+
+[#66]: https://github.com/jasonherald/slowrx.rs/issues/66
+[#67]: https://github.com/jasonherald/slowrx.rs/issues/67
+[#70]: https://github.com/jasonherald/slowrx.rs/issues/70
+[#71]: https://github.com/jasonherald/slowrx.rs/issues/71
+
+## Context
+
+`slowrx 0.4.0` shipped V2.3 Scottie with the new
+`ChannelLayout::RgbSequential` and `SyncPosition::Scottie` variants
+plus the `mode_scottie::decode_line` entry point. V2.4 Martin
+exercises the *line-start* branch of the same RGB-sequential
+machinery — sync at line start, three GBR channels per radio line,
+no mid-line idiosyncrasy.
+
+### Per-line layout
+
+slowrx C `video.c` "default" case (PD/Robot/Martin):
+
+```text
+ChanLen[0..2]   = PixelTime · ImgWidth
+ChanStart[0]    = SyncTime + PorchTime                                    // G
+ChanStart[1]    = ChanStart[0] + ChanLen[0] + SeptrTime                   // B
+ChanStart[2]    = ChanStart[1] + ChanLen[1] + SeptrTime                   // R
+```
+
+Reading this as a line timeline:
+
+```text
+[SYNC][porch][G pixels][septr][B pixels][septr][R pixels]
+^
+line start (sync_position::LineStart)
+```
+
+This is structurally Robot 72 with RGB instead of YCrCb. find_sync
+is unchanged — the existing PD/Robot/Martin path through
+`SyncPosition::LineStart` already returns a correct
+`skip_samples ≈ 0` (line 0's sync at line start).
+
+## Design
+
+### Architectural change
+
+**A) Two new `SstvMode` variants and lookup arms in
+`src/modespec.rs`:**
+
+```rust
+pub enum SstvMode {
+    // ... existing ...
+    Martin1,
+    Martin2,
+}
+```
+
+Two new `ModeSpec` consts (values from slowrx C `modespec.c:39-63`):
+
+| Mode | VIS  | PixelTime  | LineTime     | Width | Height | SyncTime | PorchTime | SeptrTime |
+|------|------|------------|--------------|-------|--------|----------|-----------|-----------|
+| M1   | 0x2C | 0.4576 ms  | 446.446 ms   | 320   | 256    | 4.862 ms | 0.572 ms  | 0.572 ms  |
+| M2   | 0x28 | 0.2288 ms  | 226.7986 ms  | 320   | 256    | 4.862 ms | 0.572 ms  | 0.572 ms  |
+
+Both: `ChannelLayout::RgbSequential`, `SyncPosition::LineStart`.
+Existing `for_vis_code` (named `lookup` in this codebase) and
+`for_mode` lookups gain two arms each.
+
+**B) `mode_scottie::decode_line` gains a sync-position branch.**
+
+The function currently uses Scottie-only `chan_starts_sec`. V2.4
+introduces a match on `spec.sync_position`:
+
+```rust
+let chan_starts_sec: [f64; 3] = match spec.sync_position {
+    SyncPosition::Scottie => [
+        septr_secs,
+        2.0 * septr_secs + chan_len,
+        2.0 * septr_secs + 2.0 * chan_len + sync_secs + porch_secs,
+    ],
+    SyncPosition::LineStart => [
+        sync_secs + porch_secs,
+        sync_secs + porch_secs + chan_len + septr_secs,
+        sync_secs + porch_secs + 2.0 * chan_len + 2.0 * septr_secs,
+    ],
+};
+```
+
+The Scottie branch is unchanged from V2.3. The new `LineStart` branch
+mirrors slowrx C `video.c` default case (the same case that drives
+PD and Robot), but written for three full-pixel-time channels rather
+than PD's mixed Y/chroma layout.
+
+The rest of `decode_line` (chan_bounds_abs computation, three calls
+to `mode_pd::decode_one_channel_into`, RGB compose via `put_pixel`)
+stays identical to V2.3.
+
+**Why the function name stays `mode_scottie::decode_line`.** The
+epic explicitly scopes Martin reuse as "Re-uses `mode_scottie.rs` if
+duplication is small." The duplication IS small — one match arm and
+a rustdoc refresh — so renaming the module/function adds churn
+without addressing a real pain point. The expanded scope is
+documented inline.
+
+**C) `scottie_test_encoder::encode_scottie` gains the same branch.**
+
+The function currently asserts `mode in {Scottie1, Scottie2, ScottieDx}`
+and emits Scottie's per-line tone order. V2.4:
+
+- Relax the assertion to `mode in {Scottie1, Scottie2, ScottieDx, Martin1, Martin2}`.
+- Branch the per-line emission order on `spec.sync_position`:
+  - `Scottie`: `[septr][G][septr][B][SYNC][porch][R]` (existing).
+  - `LineStart`: `[SYNC][porch][G][septr][B][septr][R]` (new — Martin).
+
+Module rustdoc updates to enumerate both line layouts.
+
+**D) `decoder.rs` and `find_sync` are unchanged.** Martin uses
+`ChannelLayout::RgbSequential` (already dispatched in V2.3) and
+`SyncPosition::LineStart` (already handled by the existing find_sync
+formula). No new arms.
+
+### Test scaffolding
+
+Two new round-trips in `tests/roundtrip.rs`: `martin1_roundtrip`,
+`martin2_roundtrip`. Reuse the existing `test_scottie_image` /
+`run_scottie_roundtrip` helpers — the helpers are
+`SstvMode`-parameterized and just need the new VIS codes added to
+their match expressions. (Helpers stay named `*_scottie_*` per the
+same "no churn for renames" reasoning above.)
+
+Per-pixel-RGB-diff `mean < 5.0` threshold (same as PD/Robot/Scottie).
+Both must pass to merge.
+
+### Documentation
+
+**A) CHANGELOG `[0.5.0] - 2026-05-05`** before `[Unreleased]`. Sections:
+
+- **Added:** `SstvMode::Martin1`, `Martin2`. Two `ModeSpec` consts
+  (`MARTIN1`, `MARTIN2`).
+- **Changed:** `mode_scottie::decode_line` and
+  `scottie_test_encoder::encode_scottie` now also handle Martin via
+  a `sync_position` branch. Rustdocs updated to reflect Scottie +
+  Martin scope.
+- **Validation:** 2 new round-trips green at unchanged `mean < 5.0`.
+  All 9 prior round-trips continue to pass — regression net intact.
+
+**B) In-source rustdoc:**
+
+- `src/mode_scottie.rs` module-level doc — expand from "Scottie-
+  family mode decoder" to "RGB-sequential mode decoder (Scottie 1/2/DX
+  + Martin 1/2)." Add the Martin layout diagram alongside Scottie's.
+- `src/scottie_test_encoder.rs` module-level doc — same scope expansion.
+- `src/lib.rs` Status block — list Martin 1/2 alongside Scottie.
+  Note that V2.4 completes the RGB-sequential family.
+
+**C) No new `intentional-deviations.md` entry.** Martin tracks slowrx
+C exactly.
+
+### Versioning
+
+`0.4.0 → 0.5.0`. Minor bump per semver — two new public `SstvMode`
+enum variants.
+
+## Testing posture
+
+### Synthetic round-trip (per-PR gate)
+
+All 11 round-trips must pass at unchanged `mean < 5.0`:
+
+- 3 PD (PD120/180/240)
+- 3 Robot (R24/36/72)
+- 3 Scottie (S1/S2/DX)
+- 2 Martin (M1/M2) — **new**
+
+### Unit tests
+
+Two new modespec unit tests (`martin1_modespec`, `martin2_modespec`)
+plus extending `scottie_vis_codes_resolve` (or adding
+`martin_vis_codes_resolve`) to cover M1/M2 codes. The existing
+encoder unit tests are mode-agnostic and cover Martin transitively
+once the assertion is relaxed.
+
+### Coverage gate
+
+`cargo llvm-cov` ≥ 92 % per-file maintained.
+
+### Real-audio validation
+
+**Out of scope.** No Martin reference WAVs available.
+
+## Risks
+
+1. **`encode_scottie` assertion regression for non-Scottie callers.**
+   Currently asserts `mode in {Scottie1, Scottie2, ScottieDx}`. V2.4
+   relaxes to include Martin. If any external test or example pinned
+   on the old assertion failing for Martin, that's a finding —
+   unlikely since `encode_scottie` is `#[doc(hidden)] pub` behind
+   `cfg(any(test, feature = "test-support"))`. Mitigation: search
+   the codebase for `encode_scottie(SstvMode::Martin` patterns
+   before relaxing.
+
+2. **`mode_scottie::decode_line` LineStart branch is wrong on first
+   try.** The branch is line-by-line transcribed from slowrx C
+   `video.c` default case, but the offsets calculation is small
+   enough that a typo could produce a working-but-wrong result
+   (e.g., dropping a `+ septr_secs` term yields a Robot-72-style
+   layout that round-trips as Robot). Mitigation: round-trip
+   coverage at `mean < 5.0` catches any structural error; the
+   threshold is tight enough to surface mid-line offsets being off
+   by a `septr_secs` or two.
+
+3. **Hidden assumption surfaces.** V2.3 caught one hidden assumption
+   (find_sync's `xmax > 350` slip-detection mishandling Scottie's
+   mid-line sync). Martin's `SyncPosition::LineStart` puts it on the
+   well-trodden PD/Robot path, so no new surprises expected. Round-
+   trip coverage is the safety net.
+
+## Acceptance criteria
+
+`slowrx 0.5.0` ships when:
+
+1. Two new `SstvMode` variants + two `ModeSpec` consts in
+   `src/modespec.rs`. VIS lookup arms green.
+2. `mode_scottie::decode_line` `chan_starts_sec` branches on
+   `spec.sync_position`.
+3. `scottie_test_encoder::encode_scottie` accepts Martin modes and
+   branches per-line emission on `spec.sync_position`.
+4. Two new round-trip tests (`martin1_roundtrip`, `martin2_roundtrip`)
+   pass at `mean < 5.0`.
+5. All 9 existing round-trips continue to pass at unchanged
+   thresholds (regression net).
+6. CI gate clean: `cargo fmt --check`, `cargo clippy -- -D warnings`,
+   `cargo test --all-features --locked`,
+   `RUSTDOCFLAGS=-D warnings cargo doc --no-deps --all-features`.
+7. Coverage ≥ 92% per-file.
+8. CHANGELOG `[0.5.0]` section committed; `Cargo.toml` bumped to
+   `0.5.0`.
+9. PR opened, CR review addressed, merged to main.
+10. `v0.5.0` annotated tag pushed (unsigned per project convention);
+    `cargo publish --features cli --allow-dirty` succeeds.

--- a/docs/superpowers/specs/2026-05-05-v0.5.0-martin-design.md
+++ b/docs/superpowers/specs/2026-05-05-v0.5.0-martin-design.md
@@ -153,7 +153,9 @@ Both must pass to merge.
 
 ### Documentation
 
-**A) CHANGELOG `[0.5.0] - 2026-05-05`** before `[Unreleased]`. Sections:
+**A) CHANGELOG `[0.5.0] - 2026-05-05`** inserted **after** `[Unreleased]`
+(between the `[Unreleased]` placeholder and the prior `[0.4.0]`
+section). Matches Keep-a-Changelog convention. Sections:
 
 - **Added:** `SstvMode::Martin1`, `Martin2`. Two `ModeSpec` consts
   (`MARTIN1`, `MARTIN2`).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,14 +7,14 @@
 //!
 //! ## Status
 //!
-//! `0.4.x` — V2.3 published. PD120/PD180/PD240 + Robot 24/36/72 +
-//! Scottie 1 / Scottie 2 / Scottie DX decoding from raw audio.
-//! PD120/PD180 validated against ARISS Dec-2017; Robot 36 validated
-//! against the ARISS Fram2 corpus (see
-//! `tests/ariss_fram2_validation.md`). Scottie family is synthetic
-//! round-trip-validated only — no Scottie reference WAVs available.
-//! Martin family (M1, M2) is the next planned epic. The public API
-//! is `#[non_exhaustive]`-protected for additive growth as V2.x
+//! `0.5.x` — V2.4 published. PD120/PD180/PD240 + Robot 24/36/72 +
+//! Scottie 1 / Scottie 2 / Scottie DX + Martin 1 / Martin 2 decoding
+//! from raw audio. PD120/PD180 validated against ARISS Dec-2017;
+//! Robot 36 validated against the ARISS Fram2 corpus (see
+//! `tests/ariss_fram2_validation.md`). Scottie and Martin families
+//! are synthetic round-trip-validated only — no Scottie or Martin
+//! reference WAVs available. The public API is
+//! `#[non_exhaustive]`-protected for additive growth as future
 //! mode-family epics land. See
 //! <https://github.com/jasonherald/slowrx.rs/issues/9> for the V2 roadmap.
 //!

--- a/src/mode_scottie.rs
+++ b/src/mode_scottie.rs
@@ -37,9 +37,22 @@
 
 use crate::modespec::ModeSpec;
 
-/// Decode one Scottie radio line into `image`. Reads G, B from before
-/// the sync (negative offsets relative to `sync_time`) and R from after,
-/// composing RGB in place.
+/// Decode one RGB-sequential radio line (Scottie or Martin) into
+/// `image`. Per-channel start times are line-start-relative and
+/// branch on `spec.sync_position`:
+///
+/// - [`crate::modespec::SyncPosition::Scottie`] — channels are
+///   `[septr, 2·septr+chan_len, 2·septr+2·chan_len+sync+porch]` from
+///   line start. The mid-line sync sits at `2·septr + 2·chan_len`;
+///   `find_sync` corrects `skip_samples` to land at line 0's start
+///   (slowrx C `sync.c:123-125`), so all three offsets stay positive.
+/// - [`crate::modespec::SyncPosition::LineStart`] — channels are
+///   `[sync+porch, sync+porch+chan_len+septr, sync+porch+2·chan_len+2·septr]`
+///   from line start, all post-sync. `find_sync` uses the unmodified
+///   PD/Robot formula. Same shape as Robot 72 with RGB instead of `YCrCb`.
+///
+/// In both cases RGB is composed in place via `image.put_pixel`; no
+/// chroma side-buffer is needed (cf. R36/R24's `chroma_planes`).
 ///
 /// `line_index` is the 0-based image row this radio line emits;
 /// `line_seconds_offset` is `f64::from(line_index) * spec.line_seconds`

--- a/src/mode_scottie.rs
+++ b/src/mode_scottie.rs
@@ -1,24 +1,37 @@
-//! Scottie-family mode decoder (Scottie 1, Scottie 2, Scottie DX).
+//! RGB-sequential mode decoder — Scottie 1/2/DX and Martin 1/2.
 //!
-//! Three-channel sequential RGB layout per radio line, with sync sitting
-//! between the B and R channels (mid-line). This is the V2.3 mid-line-
-//! sync forcing-function — `decoder.rs`'s line-clock advance and
-//! `find_sync`'s detection both stay generic; the mid-line idiosyncrasy
-//! lives entirely inside `decode_line`.
+//! Both families use [`crate::modespec::ChannelLayout::RgbSequential`]:
+//! three GBR channels per radio line, written to the image in-place
+//! via `image.put_pixel`. The two families differ in **where the sync
+//! pulse sits within a radio line**:
 //!
-//! Translated from slowrx's `video.c:72-79` (Scottie `ChanStart` layout)
-//! and `video.c:367` (SDX Hann-bump). slowrx's GBR storage convention
-//! (`video.c:440-444`) is bypassed: we write RGB directly via
-//! [`crate::image::SstvImage::put_pixel`].
+//! - **Scottie** ([`crate::modespec::SyncPosition::Scottie`]): sync
+//!   sits between the B and R channels (mid-line). `find_sync`
+//!   applies a Scottie-specific correction so `skip_samples` lands
+//!   at line 0's start.
+//! - **Martin** ([`crate::modespec::SyncPosition::LineStart`]): sync
+//!   at line start (standard SSTV convention); same as PD and Robot.
 //!
 //! ```text
-//! Scottie radio line layout:
-//!   [septr][ G pixels ][septr][ B pixels ][SYNC][porch][ R pixels ]
-//!     ^                                       ^
-//!     |                                       |
-//!     line start                              find_sync detects this
-//!                                             (mid-line)
+//! Scottie line layout:
+//!   [septr][G pixels][septr][B pixels][SYNC][porch][R pixels]
+//!     ^                                  ^
+//!     |                                  |
+//!     line start                         find_sync detects this
+//!                                        (mid-line — Scottie branch
+//!                                        in find_sync corrects skip)
+//!
+//! Martin line layout:
+//!   [SYNC][porch][G pixels][septr][B pixels][septr][R pixels]
+//!   ^
+//!   |
+//!   line start (sync at line start; standard PD/Robot path)
 //! ```
+//!
+//! Translated from slowrx's `video.c:72-79` (Scottie `ChanStart`) and
+//! the `video.c` "default" case (Martin/PD/Robot `ChanStart`). slowrx's
+//! GBR storage convention (`video.c:440-444`) is bypassed — we write
+//! RGB directly via [`crate::image::SstvImage::put_pixel`].
 //!
 //! See `NOTICE.md` for full slowrx attribution.
 
@@ -52,24 +65,29 @@ pub(crate) fn decode_line(
     let width = spec.line_pixels;
     let chan_len = f64::from(width) * pixel_secs;
 
-    // Scottie channel start times relative to *line start* (the start
-    // of the first septr at the beginning of line N). Translated from
-    // slowrx `video.c:72-79`:
-    //
-    //   [septr][G pixels][septr][B pixels][SYNC][porch][R pixels]
-    //   ^      ^                ^                       ^
-    //   0      septr            2·septr + chan_len      2·septr + 2·chan_len + sync + porch
-    //
-    // `find_sync` returns a `skip_samples` already corrected to point at
-    // line 0's start (its `SyncPosition::Scottie` branch applies
-    // `s = s - chan_len/2 + 2·porch` per slowrx `sync.c:123-125`), so
-    // these offsets are positive and identical to slowrx C's `ChanStart`
-    // values.
-    let chan_starts_sec: [f64; 3] = [
-        septr_secs,                                                 // G
-        2.0 * septr_secs + chan_len,                                // B
-        2.0 * septr_secs + 2.0 * chan_len + sync_secs + porch_secs, // R
-    ];
+    // Channel start times relative to *line start*. Scottie's mid-line
+    // sync sits at `2·septr + 2·chan_len`; the LineStart branch puts
+    // sync at offset 0 (G follows after sync + porch). find_sync
+    // returns `skip_samples` already corrected for both — Scottie
+    // applies `s = s − chan_len/2 + 2·porch` (slowrx C
+    // `sync.c:123-125`), LineStart uses the unmodified PD/Robot
+    // formula.
+    let chan_starts_sec: [f64; 3] = match spec.sync_position {
+        crate::modespec::SyncPosition::Scottie => [
+            septr_secs,                                                 // G (post-septr1)
+            2.0 * septr_secs + chan_len,                                // B (post-septr2)
+            2.0 * septr_secs + 2.0 * chan_len + sync_secs + porch_secs, // R (post-sync+porch)
+        ],
+        crate::modespec::SyncPosition::LineStart => [
+            // Martin layout — slowrx C video.c default case:
+            //   ChanStart[0] = sync + porch
+            //   ChanStart[1] = ChanStart[0] + chan_len + septr
+            //   ChanStart[2] = ChanStart[1] + chan_len + septr
+            sync_secs + porch_secs,                                     // G
+            sync_secs + porch_secs + chan_len + septr_secs,             // B
+            sync_secs + porch_secs + 2.0 * chan_len + 2.0 * septr_secs, // R
+        ],
+    };
 
     let width_us = width as usize;
 

--- a/src/modespec.rs
+++ b/src/modespec.rs
@@ -3,17 +3,16 @@
 //! Translated from slowrx's `modespec.c` (Oona Räisänen, ISC License).
 //! See `NOTICE.md` for full attribution.
 //!
-//! Implemented as of V2.3 (0.4.0): PD120, PD180, PD240, Robot 24, Robot 36,
-//! Robot 72, Scottie 1, Scottie 2, Scottie DX. Scottie 1/2/DX are present
-//! in the [`SstvMode`] enum and the lookup tables as of 0.4.0 Phase 1
-//! scaffolding; the per-line demodulation lands in Phase 3 (see
-//! `mode_scottie::decode_line`). Remaining V2 modes (Martin 1/2) are
-//! not yet present and will land with their own PR.
+//! Implemented as of V2.4 (0.5.0): PD120, PD180, PD240, Robot 24,
+//! Robot 36, Robot 72, Scottie 1, Scottie 2, Scottie DX, Martin 1,
+//! Martin 2. All RGB-sequential modes (Scottie + Martin) share a
+//! single decode path; the per-line offsets branch on
+//! [`SyncPosition`].
 
 /// SSTV operating mode. Implemented: [`SstvMode::Pd120`], [`SstvMode::Pd180`],
 /// [`SstvMode::Pd240`], [`SstvMode::Robot24`], [`SstvMode::Robot36`],
 /// [`SstvMode::Robot72`], [`SstvMode::Scottie1`], [`SstvMode::Scottie2`],
-/// [`SstvMode::ScottieDx`]. Additional V2 modes (Martin) planned.
+/// [`SstvMode::ScottieDx`], [`SstvMode::Martin1`], [`SstvMode::Martin2`].
 #[non_exhaustive]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum SstvMode {

--- a/src/modespec.rs
+++ b/src/modespec.rs
@@ -37,6 +37,10 @@ pub enum SstvMode {
     /// slowrx applies a +1 Hann-window-index bump in the per-pixel
     /// demod when this mode is active (see `mode_scottie::decode_line`).
     ScottieDx,
+    /// Martin 1 — VIS `0x2C`, 320×256 GBR, 0.4576 ms/pixel.
+    Martin1,
+    /// Martin 2 — VIS `0x28`, 320×256 GBR, 0.2288 ms/pixel.
+    Martin2,
 }
 
 /// Mode timing + layout table entry.
@@ -134,6 +138,8 @@ pub fn lookup(vis_code: u8) -> Option<ModeSpec> {
         0x04 => Some(ROBOT24),
         0x08 => Some(ROBOT36),
         0x0C => Some(ROBOT72),
+        0x28 => Some(MARTIN2),
+        0x2C => Some(MARTIN1),
         0x38 => Some(SCOTTIE2),
         0x3C => Some(SCOTTIE1),
         0x4C => Some(SCOTTIE_DX),
@@ -161,6 +167,8 @@ pub fn for_mode(mode: SstvMode) -> ModeSpec {
         SstvMode::Scottie1 => SCOTTIE1,
         SstvMode::Scottie2 => SCOTTIE2,
         SstvMode::ScottieDx => SCOTTIE_DX,
+        SstvMode::Martin1 => MARTIN1,
+        SstvMode::Martin2 => MARTIN2,
     }
 }
 
@@ -312,6 +320,42 @@ const SCOTTIE_DX: ModeSpec = ModeSpec {
     septr_seconds: 0.001_5,
     channel_layout: ChannelLayout::RgbSequential,
     sync_position: SyncPosition::Scottie,
+};
+
+/// Martin 1. slowrx `modespec.c:39-50`.
+const MARTIN1: ModeSpec = ModeSpec {
+    mode: SstvMode::Martin1,
+    vis_code: 0x2C,
+    line_pixels: 320,
+    image_lines: 256,
+    // slowrx modespec.c:39-50 — M1 LineTime = 446.446e-3,
+    // PixelTime = 0.4576e-3, SyncTime = 4.862e-3,
+    // PorchTime = 0.572e-3, SeptrTime = 0.572e-3.
+    line_seconds: 0.446_446,
+    sync_seconds: 0.004_862,
+    porch_seconds: 0.000_572,
+    pixel_seconds: 0.000_457_6,
+    septr_seconds: 0.000_572,
+    channel_layout: ChannelLayout::RgbSequential,
+    sync_position: SyncPosition::LineStart,
+};
+
+/// Martin 2. slowrx `modespec.c:52-63`.
+const MARTIN2: ModeSpec = ModeSpec {
+    mode: SstvMode::Martin2,
+    vis_code: 0x28,
+    line_pixels: 320,
+    image_lines: 256,
+    // slowrx modespec.c:52-63 — M2 LineTime = 226.7986e-3,
+    // PixelTime = 0.2288e-3, SyncTime = 4.862e-3,
+    // PorchTime = 0.572e-3, SeptrTime = 0.572e-3.
+    line_seconds: 0.226_798_6,
+    sync_seconds: 0.004_862,
+    porch_seconds: 0.000_572,
+    pixel_seconds: 0.000_228_8,
+    septr_seconds: 0.000_572,
+    channel_layout: ChannelLayout::RgbSequential,
+    sync_position: SyncPosition::LineStart,
 };
 
 #[cfg(test)]
@@ -512,5 +556,35 @@ mod tests {
             lookup(0x4C).expect("SDX VIS resolves").mode,
             SstvMode::ScottieDx
         );
+    }
+
+    #[test]
+    fn martin1_modespec() {
+        let spec = for_mode(SstvMode::Martin1);
+        assert_eq!(spec.mode, SstvMode::Martin1);
+        assert_eq!(spec.vis_code, 0x2C);
+        assert_eq!(spec.line_pixels, 320);
+        assert_eq!(spec.image_lines, 256);
+        assert_eq!(spec.channel_layout, ChannelLayout::RgbSequential);
+        assert_eq!(spec.sync_position, SyncPosition::LineStart);
+        assert!((spec.pixel_seconds - 0.000_457_6).abs() < 1e-9);
+        assert!((spec.line_seconds - 0.446_446).abs() < 1e-9);
+    }
+
+    #[test]
+    fn martin2_modespec() {
+        let spec = for_mode(SstvMode::Martin2);
+        assert_eq!(spec.mode, SstvMode::Martin2);
+        assert_eq!(spec.vis_code, 0x28);
+        assert!((spec.pixel_seconds - 0.000_228_8).abs() < 1e-9);
+        assert!((spec.line_seconds - 0.226_798_6).abs() < 1e-9);
+        assert_eq!(spec.channel_layout, ChannelLayout::RgbSequential);
+        assert_eq!(spec.sync_position, SyncPosition::LineStart);
+    }
+
+    #[test]
+    fn martin_vis_codes_resolve() {
+        assert_eq!(lookup(0x2C).expect("M1").mode, SstvMode::Martin1);
+        assert_eq!(lookup(0x28).expect("M2").mode, SstvMode::Martin2);
     }
 }

--- a/src/scottie_test_encoder.rs
+++ b/src/scottie_test_encoder.rs
@@ -1,22 +1,25 @@
-//! Synthetic Scottie encoder for round-trip testing. Produces
-//! continuous-phase FM audio matching the encoder side of the SSTV
-//! protocol for Scottie 1, Scottie 2, and Scottie DX.
+//! Synthetic RGB-sequential encoder for round-trip testing —
+//! handles both Scottie (1/2/DX) and Martin (1/2) families.
 //!
 //! Test-only — gated behind `cfg(any(test, feature = "test-support"))`.
-//! Lives in its own file so the production decoder stays under the
-//! 500-LOC ceiling.
 //!
-//! **Line layout per radio line:**
+//! **Per-line tone emission order branches on
+//! [`crate::modespec::SyncPosition`]:**
 //!
 //! ```text
-//! [septr 1500 Hz][G pixels 1500-2300 Hz][septr 1500 Hz]
-//! [B pixels 1500-2300 Hz][SYNC 1200 Hz][porch 1500 Hz]
-//! [R pixels 1500-2300 Hz]
+//! Scottie (sync_position::Scottie):
+//!   [septr 1500 Hz][G pixels 1500-2300 Hz][septr 1500 Hz]
+//!   [B pixels 1500-2300 Hz][SYNC 1200 Hz][porch 1500 Hz]
+//!   [R pixels 1500-2300 Hz]
+//!
+//! Martin (sync_position::LineStart):
+//!   [SYNC 1200 Hz][porch 1500 Hz][G pixels 1500-2300 Hz]
+//!   [septr 1500 Hz][B pixels 1500-2300 Hz][septr 1500 Hz]
+//!   [R pixels 1500-2300 Hz]
 //! ```
 //!
-//! Total per line = 2·SeptrTime + 2·ImgWidth·PixelTime + SyncTime +
-//! PorchTime + ImgWidth·PixelTime = LineTime exactly (verified against
-//! the `ModeSpec` table for Scottie 1 / 2 / DX in `modespec.rs`).
+//! Total per line = LineTime exactly (defensive pad fills the
+//! boundary if float arithmetic rounds short).
 
 #![allow(
     clippy::cast_precision_loss,
@@ -68,11 +71,15 @@ fn fill_to(out: &mut Vec<f32>, freq_hz: f64, target_n: usize, phase: &mut f64) {
 ///   7. R channel at `pixel_seconds` per pixel
 #[must_use]
 #[doc(hidden)]
-#[allow(dead_code)]
+#[allow(dead_code, clippy::too_many_lines)]
 pub fn encode_scottie(mode: SstvMode, rgb: &[[u8; 3]]) -> Vec<f32> {
     assert!(matches!(
         mode,
-        SstvMode::Scottie1 | SstvMode::Scottie2 | SstvMode::ScottieDx
+        SstvMode::Scottie1
+            | SstvMode::Scottie2
+            | SstvMode::ScottieDx
+            | SstvMode::Martin1
+            | SstvMode::Martin2
     ));
     let spec = crate::modespec::for_mode(mode);
     let w = spec.line_pixels;
@@ -90,76 +97,146 @@ pub fn encode_scottie(mode: SstvMode, rgb: &[[u8; 3]]) -> Vec<f32> {
     };
 
     for y in 0..h {
-        // Septr 1.
-        fill_to(
-            &mut out,
-            SEPTR_HZ,
-            advance(&mut t, spec.septr_seconds),
-            &mut phase,
-        );
+        match spec.sync_position {
+            crate::modespec::SyncPosition::Scottie => {
+                // Septr 1.
+                fill_to(
+                    &mut out,
+                    SEPTR_HZ,
+                    advance(&mut t, spec.septr_seconds),
+                    &mut phase,
+                );
 
-        // G channel.
-        for x in 0..w {
-            let g = rgb[(y * w + x) as usize][1];
-            fill_to(
-                &mut out,
-                lum_to_freq(g),
-                advance(&mut t, spec.pixel_seconds),
-                &mut phase,
-            );
+                // G channel.
+                for x in 0..w {
+                    let g = rgb[(y * w + x) as usize][1];
+                    fill_to(
+                        &mut out,
+                        lum_to_freq(g),
+                        advance(&mut t, spec.pixel_seconds),
+                        &mut phase,
+                    );
+                }
+
+                // Septr 2.
+                fill_to(
+                    &mut out,
+                    SEPTR_HZ,
+                    advance(&mut t, spec.septr_seconds),
+                    &mut phase,
+                );
+
+                // B channel.
+                for x in 0..w {
+                    let b = rgb[(y * w + x) as usize][2];
+                    fill_to(
+                        &mut out,
+                        lum_to_freq(b),
+                        advance(&mut t, spec.pixel_seconds),
+                        &mut phase,
+                    );
+                }
+
+                // Sync (mid-line, between B and R).
+                fill_to(
+                    &mut out,
+                    SYNC_HZ,
+                    advance(&mut t, spec.sync_seconds),
+                    &mut phase,
+                );
+
+                // Porch.
+                fill_to(
+                    &mut out,
+                    PORCH_HZ,
+                    advance(&mut t, spec.porch_seconds),
+                    &mut phase,
+                );
+
+                // R channel.
+                for x in 0..w {
+                    let r = rgb[(y * w + x) as usize][0];
+                    fill_to(
+                        &mut out,
+                        lum_to_freq(r),
+                        advance(&mut t, spec.pixel_seconds),
+                        &mut phase,
+                    );
+                }
+            }
+            crate::modespec::SyncPosition::LineStart => {
+                // Martin layout: sync at line start, then porch, then
+                // G/septr/B/septr/R.
+
+                // Sync.
+                fill_to(
+                    &mut out,
+                    SYNC_HZ,
+                    advance(&mut t, spec.sync_seconds),
+                    &mut phase,
+                );
+
+                // Porch.
+                fill_to(
+                    &mut out,
+                    PORCH_HZ,
+                    advance(&mut t, spec.porch_seconds),
+                    &mut phase,
+                );
+
+                // G channel.
+                for x in 0..w {
+                    let g = rgb[(y * w + x) as usize][1];
+                    fill_to(
+                        &mut out,
+                        lum_to_freq(g),
+                        advance(&mut t, spec.pixel_seconds),
+                        &mut phase,
+                    );
+                }
+
+                // Septr 1.
+                fill_to(
+                    &mut out,
+                    SEPTR_HZ,
+                    advance(&mut t, spec.septr_seconds),
+                    &mut phase,
+                );
+
+                // B channel.
+                for x in 0..w {
+                    let b = rgb[(y * w + x) as usize][2];
+                    fill_to(
+                        &mut out,
+                        lum_to_freq(b),
+                        advance(&mut t, spec.pixel_seconds),
+                        &mut phase,
+                    );
+                }
+
+                // Septr 2.
+                fill_to(
+                    &mut out,
+                    SEPTR_HZ,
+                    advance(&mut t, spec.septr_seconds),
+                    &mut phase,
+                );
+
+                // R channel.
+                for x in 0..w {
+                    let r = rgb[(y * w + x) as usize][0];
+                    fill_to(
+                        &mut out,
+                        lum_to_freq(r),
+                        advance(&mut t, spec.pixel_seconds),
+                        &mut phase,
+                    );
+                }
+            }
         }
 
-        // Septr 2.
-        fill_to(
-            &mut out,
-            SEPTR_HZ,
-            advance(&mut t, spec.septr_seconds),
-            &mut phase,
-        );
-
-        // B channel.
-        for x in 0..w {
-            let b = rgb[(y * w + x) as usize][2];
-            fill_to(
-                &mut out,
-                lum_to_freq(b),
-                advance(&mut t, spec.pixel_seconds),
-                &mut phase,
-            );
-        }
-
-        // Sync (mid-line, between B and R).
-        fill_to(
-            &mut out,
-            SYNC_HZ,
-            advance(&mut t, spec.sync_seconds),
-            &mut phase,
-        );
-
-        // Porch.
-        fill_to(
-            &mut out,
-            PORCH_HZ,
-            advance(&mut t, spec.porch_seconds),
-            &mut phase,
-        );
-
-        // R channel.
-        for x in 0..w {
-            let r = rgb[(y * w + x) as usize][0];
-            fill_to(
-                &mut out,
-                lum_to_freq(r),
-                advance(&mut t, spec.pixel_seconds),
-                &mut phase,
-            );
-        }
-
-        // Defensive pad to the line_seconds boundary. The Scottie line
-        // layout sums to exactly LineTime per the ModeSpec table, but
-        // float rounding could leave us a sample short — top up with
-        // PORCH_HZ (1500 Hz, the inter-line idle frequency) so the
-        // decoder's per-line timing model lines up with the audio.
+        // Defensive pad to the line_seconds boundary (existing logic
+        // — shape unchanged).
         let line_end_target = f64::from(y + 1) * spec.line_seconds;
         let pad_secs = line_end_target - t;
         if pad_secs > 0.0 {

--- a/src/scottie_test_encoder.rs
+++ b/src/scottie_test_encoder.rs
@@ -70,6 +70,18 @@ fn fill_to(out: &mut Vec<f32>, freq_hz: f64, target_n: usize, phase: &mut f64) {
 ///   6. Porch at `PORCH_HZ`
 ///   7. R channel at `pixel_seconds` per pixel
 #[must_use]
+/// Encode an RGB image as continuous-phase FM audio for either
+/// Scottie (S1/S2/DX) or Martin (M1/M2). The per-line tone emission
+/// order branches on `spec.sync_position`:
+///
+/// - [`crate::modespec::SyncPosition::Scottie`] —
+///   `[septr][G][septr][B][SYNC][porch][R]` (sync mid-line).
+/// - [`crate::modespec::SyncPosition::LineStart`] —
+///   `[SYNC][porch][G][septr][B][septr][R]` (Martin / standard
+///   PD-Robot order).
+///
+/// Panics if `mode` is not one of the five supported variants or if
+/// `rgb.len() != line_pixels * image_lines`.
 #[doc(hidden)]
 #[allow(dead_code, clippy::too_many_lines)]
 pub fn encode_scottie(mode: SstvMode, rgb: &[[u8; 3]]) -> Vec<f32> {

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -257,6 +257,8 @@ fn run_scottie_roundtrip(mode: SstvMode) {
         SstvMode::Scottie1 => 0x3C,
         SstvMode::Scottie2 => 0x38,
         SstvMode::ScottieDx => 0x4C,
+        SstvMode::Martin1 => 0x2C,
+        SstvMode::Martin2 => 0x28,
         _ => unreachable!(),
     };
     let mut audio = slowrx::__test_support::vis::synth_vis(vis_code, 0.0);
@@ -314,4 +316,14 @@ fn scottie2_roundtrip() {
 #[test]
 fn scottie_dx_roundtrip() {
     run_scottie_roundtrip(SstvMode::ScottieDx);
+}
+
+#[test]
+fn martin1_roundtrip() {
+    run_scottie_roundtrip(SstvMode::Martin1);
+}
+
+#[test]
+fn martin2_roundtrip() {
+    run_scottie_roundtrip(SstvMode::Martin2);
 }


### PR DESCRIPTION
## Summary

- Adds Martin 1 (VIS \`0x2C\`) and Martin 2 (\`0x28\`) decoders. Both 320×256 GBR with sync at line start (standard SSTV convention).
- **Reuses V2.3's \`ChannelLayout::RgbSequential\` infrastructure.** \`mode_scottie::decode_line\` and \`scottie_test_encoder::encode_scottie\` gain a \`match spec.sync_position\` for channel offsets and per-line tone emission. Scottie branch unchanged from V2.3.
- New \`LineStart\` branch uses slowrx C \`video.c\` "default" case offsets. Martin emission order: \`[SYNC][porch][G][septr][B][septr][R]\`.
- \`find_sync\`, \`decoder.rs\`, \`mode_pd\`, \`snr\` are unchanged. Martin's \`LineStart\` routes through the existing PD/Robot path.
- Two new round-trip tests (\`martin1_roundtrip\`, \`martin2_roundtrip\`) pass at unchanged \`mean < 5.0\`. All 9 existing round-trips still pass — regression net intact.
- Module / function names (\`mode_scottie\`, \`encode_scottie\`) stay despite the family-scope expansion. Renaming was deferred per the V2.4 epic's no-refactor-churn out-of-scope clause.

## Test plan

- [x] \`cargo fmt --check\` clean
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\` clean
- [x] \`cargo test --all-features --locked\` — 113+ lib tests + 11 round-trips, all pass
- [x] \`RUSTDOCFLAGS=-D warnings cargo doc --no-deps --all-features\` clean
- [x] Coverage ≥ 92% per-file maintained

## Out of scope

- Real-radio Martin validation — async, no fixtures available.
- V2.5 Zarya — separate epic ([#67]).
- Pixel-diff comparator ([#70]), squiggle work ([#71]), and SIMD multiversioning ([#77]) — all still pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Version 0.5.0: Added Martin 1 (VIS 0x2C) and Martin 2 (VIS 0x28) SSTV support for encode/decode with 320×256 GBR, including correct line-start sync behavior and per-line tone ordering.

* **Documentation**
  * Updated changelog, release plan, design spec, and crate status to document Martin support and 0.5.0 release; bumped package version.

* **Tests**
  * Added synthetic round-trip tests for Martin1 and Martin2 modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->