### PR TITLE
test(decoder): negative-regression tests for non-SSTV input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Negative-regression integration tests** in `tests/no_vis.rs`:
+  - `decoder_no_vis_on_white_noise` — 10 s of deterministic LCG white
+    noise at 48 kHz (≈ 0.3 RMS, matching the measured level of an
+    ISS Zarya non-SSTV pass).
+  - `decoder_no_vis_on_silence` — 10 s of pure silence.
+
+  Both assert `SstvDecoder::process` produces zero
+  `SstvEvent::ImageComplete { partial: false }` events without panicking.
+  This is the no-signal counterpart to the synthetic round-trip suite —
+  both must hold for any release. Inspired by an ISS Zarya capture on
+  2026-05-04 that turned out to carry no SSTV (Zarya transmits SSTV
+  only during ARISS-scheduled events); see [#67] for the capture
+  story.
+
+[#67]: https://github.com/jasonherald/slowrx.rs/issues/67
+
 ## [0.5.0] - 2026-05-05
 
 Minor release adding Martin 1 (VIS `0x2C`) and Martin 2 (`0x28`) —

--- a/tests/no_vis.rs
+++ b/tests/no_vis.rs
@@ -60,7 +60,13 @@ fn decoder_no_vis_on_white_noise() {
     // ~0.3 RMS — matches the measured level of the Zarya 2026-05-04
     // recording, so the decoder operates on realistic signal-strength
     // input rather than near-zero amplitudes.
-    let audio: Vec<f32> = (0..n).map(|_| rng.next_unit() * 0.6).collect();
+    //
+    // `next_unit()` is uniform on `[-0.5, 0.5]`, whose RMS is
+    // `1/sqrt(12) ≈ 0.2887`. Scaling by `target_rms * sqrt(12)` makes
+    // the resulting noise hit the target RMS exactly (modulo
+    // sample-count statistical jitter).
+    let noise_scale = 0.3_f32 * 12.0_f32.sqrt();
+    let audio: Vec<f32> = (0..n).map(|_| rng.next_unit() * noise_scale).collect();
 
     let mut decoder = SstvDecoder::new(SAMPLE_RATE_HZ).expect("decoder construct");
     let events = decoder.process(&audio);

--- a/tests/no_vis.rs
+++ b/tests/no_vis.rs
@@ -1,0 +1,90 @@
+//! Negative real-radio regression — [`slowrx::SstvDecoder`] must not
+//! false-positive on non-SSTV audio.
+//!
+//! **Origin.** An ISS Zarya capture on 2026-05-04 22:38:27 UTC turned
+//! out to carry no SSTV (Zarya transmits SSTV only during ARISS-
+//! scheduled events). 0 VIS codes detected on the 25-minute recording;
+//! a separate spectrum check confirmed the audio sat in the 247–563 Hz
+//! band with no energy in SSTV's 1500–2300 Hz pixel band. We could not
+//! commit the recording itself (`/tests/fixtures` is gitignored per the
+//! project's "no third-party-licensed fixtures in the repo" convention,
+//! and the redistribution-license story for community-shared captures
+//! is unclear), so the regression coverage is reproduced with two
+//! synthetic non-SSTV audio buffers: white noise at the Zarya
+//! recording's measured RMS level (~0.3), and pure silence.
+//!
+//! Both must produce zero `SstvEvent::ImageComplete { partial: false }`
+//! events without panicking. This is the no-signal counterpart to the
+//! synthetic round-trip suite in `tests/roundtrip.rs` — both must hold
+//! for any release.
+
+#![allow(clippy::expect_used, clippy::cast_precision_loss)]
+
+use slowrx::{SstvDecoder, SstvEvent};
+
+/// Sample rate matching what a typical SDR / file capture produces;
+/// also exercises the resampler since `WORKING_SAMPLE_RATE_HZ` = `11_025`.
+const SAMPLE_RATE_HZ: u32 = 48_000;
+const DURATION_SEC: u32 = 10;
+
+/// Deterministic linear-congruential generator. Numerical Recipes'
+/// "Quick and Dirty" constants — sufficient for white-noise regression
+/// purposes (no cryptographic strength needed). A fixed seed makes the
+/// test reproducible across runs / hosts.
+struct Lcg(u32);
+
+impl Lcg {
+    fn new(seed: u32) -> Self {
+        Self(seed)
+    }
+
+    fn next_unit(&mut self) -> f32 {
+        // state ← state · 1664525 + 1013904223 (mod 2³²)
+        self.0 = self.0.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
+        // Map u32 → [-0.5, 0.5).
+        (self.0 as f32 / u32::MAX as f32) - 0.5
+    }
+}
+
+fn count_complete_images(events: &[SstvEvent]) -> usize {
+    events
+        .iter()
+        .filter(|e| matches!(e, SstvEvent::ImageComplete { partial: false, .. }))
+        .count()
+}
+
+#[test]
+fn decoder_no_vis_on_white_noise() {
+    let n = (SAMPLE_RATE_HZ * DURATION_SEC) as usize;
+    let mut rng = Lcg::new(0x5EED_5EED);
+    // ~0.3 RMS — matches the measured level of the Zarya 2026-05-04
+    // recording, so the decoder operates on realistic signal-strength
+    // input rather than near-zero amplitudes.
+    let audio: Vec<f32> = (0..n).map(|_| rng.next_unit() * 0.6).collect();
+
+    let mut decoder = SstvDecoder::new(SAMPLE_RATE_HZ).expect("decoder construct");
+    let events = decoder.process(&audio);
+
+    let n_complete = count_complete_images(&events);
+    assert_eq!(
+        n_complete, 0,
+        "decoder false-positive: emitted {n_complete} non-partial \
+         ImageComplete event(s) on 10 s of white noise",
+    );
+}
+
+#[test]
+fn decoder_no_vis_on_silence() {
+    let n = (SAMPLE_RATE_HZ * DURATION_SEC) as usize;
+    let audio = vec![0.0_f32; n];
+
+    let mut decoder = SstvDecoder::new(SAMPLE_RATE_HZ).expect("decoder construct");
+    let events = decoder.process(&audio);
+
+    let n_complete = count_complete_images(&events);
+    assert_eq!(
+        n_complete, 0,
+        "decoder false-positive: emitted {n_complete} non-partial \
+         ImageComplete event(s) on 10 s of pure silence",
+    );
+}


### PR DESCRIPTION
## Summary

Two new integration tests in \`tests/no_vis.rs\` that assert \`SstvDecoder::process\` produces zero \`SstvEvent::ImageComplete { partial: false }\` events on non-SSTV audio:

- \`decoder_no_vis_on_white_noise\` — 10 s of deterministic LCG white noise at 48 kHz, ≈ 0.3 RMS (matching the measured level of an ISS Zarya 2026-05-04 capture that turned out to carry no SSTV).
- \`decoder_no_vis_on_silence\` — 10 s of pure silence at 48 kHz.

This is the no-signal counterpart to the synthetic round-trip suite — both must hold for any release. Cheap regression net (both tests run in < 0.5 s) for the \"decoder doesn't false-positive on noisy non-SSTV audio\" property.

## Why synthetic, not the actual Zarya recording

The 144 MB stereo-float recording isn't committable: \`/tests/fixtures\` is gitignored per the project's \"no third-party-licensed fixtures in the repo\" convention, and the redistribution-license story for community-shared captures is unclear. Synthetic noise reproduces the regression property without policy friction and is reproducible across hosts.

## Test plan

- [x] \`cargo fmt --check\` clean
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\` clean
- [x] \`cargo test --all-features --locked\` — 113 lib + 2 cli + 11 round-trips + 2 no_vis + 1 doctest, all pass
- [x] \`RUSTDOCFLAGS=-D warnings cargo doc --no-deps --all-features\` clean

## Related

- Captures the V2.5 Zarya validation work for now (#67). Real-Zarya-with-SSTV validation will land when a successful SSTV-bearing capture surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added regression tests using deterministic synthetic inputs (white noise and silence) to ensure the SSTV decoder emits no false-positive image-complete events and operates without crashes or panics.
  * Tests are reproducible and strengthen robustness against non-SSTV audio; changelog now references issue 67.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->