### PR TITLE
fix(cli): emit Scottie / Martin filenames instead of "unknown" + 0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1] - 2026-05-05
+
+Patch release bundling the `slowrx-cli` mode-tag fix discovered during
+V2.5 Zarya real-radio validation work, plus the negative-regression
+integration tests added under #79. Both ride the `[Unreleased]` queue;
+no new crate-public API surface.
+
+### Fixed
+
+- **`slowrx-cli` saved Scottie and Martin images as `img-NNN-unknown.png`** —
+  the `mode_tag` match in `src/bin/slowrx_cli.rs` was missing arms for the V2.3
+  Scottie 1/2/DX and V2.4 Martin 1/2 variants. Same trap V2.1 fixed for PD240
+  and V2.2 caught for Robot 24/36/72; the wildcard arm absorbed the new
+  variants silently because `SstvMode` is `#[non_exhaustive]`. Surfaced
+  during V2.5 Zarya real-radio capture work when 3 Scottie 1 images decoded
+  from a 2013 Wolverine Radio shortwave broadcast all came out tagged
+  "unknown". Added the 5 missing arms (`scottie1`, `scottie2`, `scottiedx`,
+  `martin1`, `martin2`) plus a unit test
+  (`mode_tag_covers_all_known_variants`) that iterates every known
+  `SstvMode` variant and asserts each maps to a non-"unknown" tag — the
+  next mode-family addition can no longer slip through silently.
+
 ### Added
 
 - **Negative-regression integration tests** in `tests/no_vis.rs`:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -707,7 +707,7 @@ checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "slowrx"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slowrx"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 rust-version = "1.85"
 description = "Pure-Rust SSTV (Slow-Scan TV) decoder library — a port of slowrx by Oona Räisänen"

--- a/src/bin/slowrx_cli.rs
+++ b/src/bin/slowrx_cli.rs
@@ -287,12 +287,26 @@ fn mode_tag(mode: SstvMode) -> &'static str {
         SstvMode::Robot24 => "robot24",
         SstvMode::Robot36 => "robot36",
         SstvMode::Robot72 => "robot72",
-        // SstvMode is #[non_exhaustive] which forces a wildcard arm in
-        // matches even within the same crate. New variants will use
-        // this fallback — when adding one, also add an explicit arm
-        // above. (V2.1 PD240 trap: missed this match and shipped images
-        // as `img-NNN-unknown.png` until 0.2.1. Same trap caught for
-        // V2.2 Robot24/36/72 during code review of the dispatch refactor.)
+        SstvMode::Scottie1 => "scottie1",
+        SstvMode::Scottie2 => "scottie2",
+        SstvMode::ScottieDx => "scottiedx",
+        SstvMode::Martin1 => "martin1",
+        SstvMode::Martin2 => "martin2",
+        // SstvMode is #[non_exhaustive] which forces a wildcard arm
+        // here even within the same crate. New variants fall through
+        // to this fallback unless an explicit arm is added — and
+        // that's bitten us multiple times:
+        //
+        //   V2.1 PD240    — shipped as `img-NNN-unknown.png` until 0.2.1.
+        //   V2.2 Robot24/36/72 — caught during code review.
+        //   V2.3 Scottie 1/2/DX — slipped through; surfaced when a real
+        //                  Wolverine Radio shortwave broadcast decoded
+        //                  3 Scottie 1 images all tagged "unknown".
+        //   V2.4 Martin 1/2 — same root cause; same fix.
+        //
+        // When adding the next mode variant: add an explicit arm above
+        // AND an entry to `mode_tag_covers_all_known_variants` below
+        // so the test catches the omission automatically.
         _ => "unknown",
     }
 }
@@ -309,4 +323,38 @@ fn save_image(image: &SstvImage, path: &std::path::Path) -> Result<()> {
     img.save(path)
         .with_context(|| format!("write {}", path.display()))?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every currently-known [`SstvMode`] variant must have an explicit
+    /// `mode_tag` arm — no falling through to "unknown". Keep this list
+    /// in lockstep with `SstvMode` (the enum is `#[non_exhaustive]`, so
+    /// the compiler can't enforce coverage; this test does).
+    #[test]
+    fn mode_tag_covers_all_known_variants() {
+        let known = [
+            SstvMode::Pd120,
+            SstvMode::Pd180,
+            SstvMode::Pd240,
+            SstvMode::Robot24,
+            SstvMode::Robot36,
+            SstvMode::Robot72,
+            SstvMode::Scottie1,
+            SstvMode::Scottie2,
+            SstvMode::ScottieDx,
+            SstvMode::Martin1,
+            SstvMode::Martin2,
+        ];
+        for mode in known {
+            let tag = mode_tag(mode);
+            assert_ne!(
+                tag, "unknown",
+                "mode_tag({mode:?}) returned 'unknown' — missing explicit match arm in src/bin/slowrx_cli.rs",
+            );
+            assert!(!tag.is_empty(), "mode_tag({mode:?}) returned empty string");
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Patch fix + 0.5.1 release bundling.

\`slowrx-cli\`'s \`mode_tag()\` match was missing arms for V2.3 Scottie (1/2/DX) and V2.4 Martin (M1/M2) variants. The wildcard arm absorbed them silently because \`SstvMode\` is \`#[non_exhaustive]\`, so any real-world Scottie/Martin decode emitted \`img-NNN-unknown.png\`.

This is the **same trap V2.1 fixed for PD240** (shipped as "unknown" until 0.2.1) and V2.2 caught for Robot 24/36/72 during code review. The wildcard's own comment warned about it — yet V2.3 + V2.4 slipped through anyway. It surfaced when a 2013 Wolverine Radio shortwave recording (slowrx.rs's first real-radio Scottie test, ever) decoded 3 Scottie 1 images all tagged "unknown".

## Changes

- \`src/bin/slowrx_cli.rs\`: 5 missing arms added (\`scottie1\`, \`scottie2\`, \`scottiedx\`, \`martin1\`, \`martin2\`). Wildcard's comment expanded to enumerate every trap occurrence (PD240, Robot, Scottie, Martin) so future readers see this isn't theoretical.
- \`src/bin/slowrx_cli.rs\`: new unit test \`mode_tag_covers_all_known_variants\` iterates every known \`SstvMode\` variant and asserts each maps to a non-"unknown" tag. The next mode-family addition that forgets the \`mode_tag\` arm will fail this test instead of slipping through to a release.
- \`CHANGELOG.md\`: cut \`[Unreleased]\` → \`[0.5.1] - 2026-05-05\`. Bundles this fix with the \`tests/no_vis.rs\` negative-regression tests already queued from #79. No new public API surface; patch bump per semver.
- \`Cargo.toml\`: \`0.5.0\` → \`0.5.1\`.

## End-to-end verification

Re-decoded the Wolverine Radio WAV that originally surfaced this bug:

\`\`\`
img-001-scottie1.png
img-002-scottie1.png
img-003-scottie1.png
\`\`\`

(Was previously \`img-001-unknown.png\` etc.)

## Test plan

- [x] \`cargo fmt --check\` clean
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\` clean
- [x] \`cargo test --all-features --locked --release\` — 113 lib + 11 round-trips + 2 cli (1 new) + 2 no_vis + 1 doctest, all pass
- [x] \`RUSTDOCFLAGS=-D warnings cargo doc --no-deps --all-features\` clean
- [x] End-to-end: real Scottie 1 audio decodes to correctly-named PNGs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved support for SSTV mode variants (Scottie1, Scottie2, ScottieDx, Martin1, Martin2).
  * Added regression tests to verify decoder behavior under no-signal conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->