### PR TITLE
fix(vis): VIS detector fidelity — reseed on unknown code, keep-search, SstvEvent::UnknownVis (#89)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`SstvEvent::UnknownVis { code, hedr_shift_hz, sample_offset }`** — a VIS
+  burst that parses and passes parity but maps to no decodable SSTV mode is now
+  surfaced to callers (previously dropped silently). `match_vis_pattern` also
+  keeps searching its 9 alignments for a *known* code before falling back to an
+  unknown one, matching slowrx (#89 A3/C1).
+
+### Fixed
+
+- **Stale VIS detector after an unknown VIS code** — `SstvDecoder::process`
+  drained the detector's residual buffer but did not reconstruct it, violating
+  the `#40` re-anchor contract (`hops_completed` / `history` were carried over
+  into the next detection). It is now reseeded via the same `restart_vis_detection`
+  helper the post-image path uses (#89 A1).
+
+### Removed
+
+- **`Error::UnknownVisCode`** — never constructed (`SstvDecoder::process` does
+  not return `Result`; unknown codes are now reported via `SstvEvent::UnknownVis`).
+
+### Internal
+
+- `R12BW_VIS_CODE` named constant replacing bare `0x06` literals; faithful
+  parity-check shape in `match_vis_pattern` (flip the accumulated parity for
+  R12BW, matching slowrx `vis.c:116`) (#89 C5/C15).
+
 ## [0.5.1] - 2026-05-05
 
 Patch release bundling the `slowrx-cli` mode-tag fix discovered during

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,3 +68,7 @@ required-features = ["test-support"]
 [[test]]
 name = "cli"
 required-features = ["cli"]
+
+[[test]]
+name = "unknown_vis"
+required-features = ["test-support"]

--- a/docs/intentional-deviations.md
+++ b/docs/intentional-deviations.md
@@ -116,6 +116,46 @@ If a real burst gives Rust a *different* valid VIS code than slowrx
 
 ---
 
+## VIS: keep-searching for a known code; surface clean unknown bursts
+
+### What slowrx does
+
+`vis.c`'s pattern matcher tries all 9 `(i, j)` alignments. For each alignment
+that passes parity it does `VISmap[VIS]` — and if the code is unknown it
+`printf`s `"Unknown VIS %d"`, leaves `gotvis = false`, and keeps trying the
+remaining alignments. Only a *known* code stops the search (`gotvis = true`).
+If no alignment yields a known code, `GetVIS()` returns `0` and `Listen()`'s
+`do { ... } while (Mode == 0)` loop re-detects from the audio stream.
+
+### What we do
+
+`match_vis_pattern` takes an `is_known` predicate (`|c| modespec::lookup(c).is_some()`)
+and mirrors slowrx: it tries all 9 alignments and returns the **first known**
+code. If no alignment is known but at least one parity-passing alignment maps
+to an **unknown** code, it returns the first such code as a fallback. The
+decoder then emits `SstvEvent::UnknownVis { code, hedr_shift_hz, sample_offset }`
+(our equivalent of slowrx's `printf`), reseeds the VIS detector on the
+post-stop-bit residue (the `#40` re-anchor contract), and stays in
+`AwaitingVis` — the same "try again" loop as slowrx.
+
+### Why we deviated
+
+slowrx's `printf` is a console side effect with no programmatic surface; a
+library decoder should let callers observe "a burst arrived but I can't decode
+it" (stream monitors, diagnostics). Returning the unknown code as a fallback
+from `match_vis_pattern` (rather than `None`, which slowrx effectively does) is
+what makes that event possible. The keep-searching-for-a-known-code behavior is
+otherwise byte-for-byte slowrx's.
+
+### When to revisit
+
+If R12BW (or any other currently-unimplemented mode) gains a `ModeSpec`, it
+becomes "known" automatically (the predicate is `lookup(...).is_some()`), and
+bursts for it stop surfacing as `UnknownVis` and start decoding. Nothing else
+to change.
+
+---
+
 ## Synthetic round-trip max_diff tolerance
 
 **Files:** `tests/roundtrip.rs`.

--- a/docs/intentional-deviations.md
+++ b/docs/intentional-deviations.md
@@ -144,8 +144,9 @@ slowrx's `printf` is a console side effect with no programmatic surface; a
 library decoder should let callers observe "a burst arrived but I can't decode
 it" (stream monitors, diagnostics). Returning the unknown code as a fallback
 from `match_vis_pattern` (rather than `None`, which slowrx effectively does) is
-what makes that event possible. The keep-searching-for-a-known-code behavior is
-otherwise byte-for-byte slowrx's.
+what makes that event possible. The keep-searching-for-a-known-code behavior
+otherwise matches slowrx's (modulo the separate `HedrShift != 0` early-exit
+quirk documented above, which we also deliberately diverge from).
 
 ### When to revisit
 

--- a/docs/superpowers/plans/2026-05-11-issue-89-vis-detector-fidelity.md
+++ b/docs/superpowers/plans/2026-05-11-issue-89-vis-detector-fidelity.md
@@ -1,0 +1,808 @@
+# Issue #89 — VIS detector fidelity — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land the five VIS-detection fixes from audit bundle #89 — A1 (reseed the VIS detector after an unknown code), A3 (keep searching alignments for a *known* code, slowrx-style), C1 (surface unknown VIS bursts via a new `SstvEvent::UnknownVis`, drop the dead `Error::UnknownVisCode`), C5 (`R12BW_VIS_CODE` named constant), C15 (faithful parity-check shape in `match_vis_pattern`).
+
+**Architecture:** `match_vis_pattern` (in `src/vis.rs`) gains an `is_known: impl Fn(u8) -> bool` predicate and, instead of returning the first parity-passing alignment, returns the first *known* code (falling back to the first parity-passing *unknown* code so the caller can still report it). `VisDetector` stores that predicate as a `fn(u8) -> bool` field set at construction. `SstvDecoder` holds the one predicate value in a `const IS_KNOWN_VIS`, gains a `restart_vis_detection` helper that reseeds `self.vis` per the documented `#40` re-anchor contract, and emits `SstvEvent::UnknownVis { code, hedr_shift_hz, sample_offset }` for unrecognized bursts. `Error::UnknownVisCode` (never constructed) is removed.
+
+**Tech Stack:** Rust 2021, MSRV 1.85. `rustfft`. Crate clippy config: `clippy::all`/`pedantic` = warn, `unwrap_used`/`panic`/`expect_used` = warn (no panics in lib code). CI gate: `cargo test --all-features --locked --release`, `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `RUSTDOCFLAGS=-D warnings cargo doc --no-deps --all-features`. No GPG signing (`git commit` / `git tag -a` plain).
+
+**Reference docs:**
+- Spec: `docs/superpowers/specs/2026-05-11-issue-89-vis-detector-fidelity-design.md`
+- Audit: `docs/audits/2026-05-11-deep-code-review-audit.md` (IDs A1, A3, C1, C5, C15)
+- `docs/intentional-deviations.md` (existing VIS entries the new one slots near)
+
+---
+
+## File Structure
+
+| File | Change |
+|------|--------|
+| `src/vis.rs` | Add `pub(crate) const R12BW_VIS_CODE`. `match_vis_pattern`: faithful parity-check shape (C15) + `is_known` predicate + keep-searching/`first_unknown` (A3) + doc update. `VisDetector`: `is_known_vis: fn(u8) -> bool` field + `new` signature; `process` reads `self.is_known_vis`. Replace `0x06` literals in the test encoder + test comments. New `match_vis_pattern` unit tests + a test-local tone-history builder. Update `VisDetector::new()` call site in the `run` test helper. |
+| `src/decoder.rs` | `const IS_KNOWN_VIS: fn(u8) -> bool`. `VisDetector::new(IS_KNOWN_VIS)` at the two construction sites. New `SstvEvent::UnknownVis` variant. `restart_vis_detection` helper. Rewrite the unknown-VIS branch (emit event → `restart_vis_detection` → `continue`). Refactor the post-image reseed to call `restart_vis_detection`. |
+| `src/error.rs` | Delete `Error::UnknownVisCode` variant + its test `unknown_vis_code_renders_in_hex`. |
+| `src/modespec.rs` | Tweak the `lookup` `#27` doc note to mention `SstvEvent::UnknownVis`. |
+| `tests/unknown_vis.rs` | **New.** Integration test: `SstvDecoder::process` emits `UnknownVis` then recovers a following valid VIS. Gated `#![cfg(feature = "test-support")]` (uses `synth_vis`). |
+| `docs/intentional-deviations.md` | New section: *"VIS: keep-searching for a known code; surface clean unknown bursts."* |
+| `CHANGELOG.md` | `[Unreleased]` entries (Fixed / Added / Removed / internal). |
+
+Task order: **T1** (C5 + C15, `vis.rs` cleanups, no behavior change) → **T2** (A3 predicate + `VisDetector` field + `IS_KNOWN_VIS` + unit tests) → **T3** (`SstvEvent::UnknownVis` + `restart_vis_detection` + A1 fix + post-image refactor + integration test) → **T4** (delete `Error::UnknownVisCode`) → **T5** (docs) → **T6** (full CI gate).
+
+---
+
+## Task 1: `vis.rs` cleanups — `R12BW_VIS_CODE` constant + faithful parity-check shape (C5, C15)
+
+Pure refactor — functionally identical. No new test (existing `vis.rs::tests` cover it: `r12bw_uses_inverted_parity`, `r12bw_rejects_standard_parity`, `parity_failure_is_rejected`, the proptests).
+
+**Files:**
+- Modify: `src/vis.rs` (constants block ~lines 22-34; `match_vis_pattern` k==7 branch ~lines 377-388; test encoder `synth_vis_with_offset` ~lines 493-497; test comments ~lines 609-676)
+
+- [ ] **Step 1: Add the `R12BW_VIS_CODE` constant**
+
+In `src/vis.rs`, in the constants block just after `pub(crate) const HISTORY_LEN: usize = 45; // slowrx HedrBuf size` (currently line 34), add:
+
+```rust
+/// VIS code for the (unimplemented) Robot 12 B/W mode. R12BW inverts the
+/// parity bit (slowrx `vis.c:116`). No `ModeSpec` exists for it yet, so
+/// `crate::modespec::lookup` returns `None` for it; `match_vis_pattern`
+/// still classifies it so a future R12BW implementation that adds it to
+/// `lookup` works without re-touching the parity logic.
+//
+// TODO: when R12BW gains a `ModeSpec`, derive this from `modespec`.
+pub(crate) const R12BW_VIS_CODE: u8 = 0x06;
+```
+
+- [ ] **Step 2: Rewrite the `k == 7` parity-check branch in `match_vis_pattern` (C15)**
+
+Replace the `else` arm of the `if k < 7 { ... } else { ... }` inside the `for k in 0..8` loop. Currently:
+
+```rust
+                } else {
+                    // R12BW (`0x06`) inverts parity per slowrx `vis.c:116`:
+                    // `if (VISmap[VIS] == R12BW) Parity = !Parity;`. V1
+                    // doesn't decode R12BW (lookup returns None for 0x06),
+                    // but the parity check must still pass so a future V2
+                    // implementation that adds R12BW to the lookup table
+                    // doesn't silently reject every R12BW burst.
+                    let expected = if code == 0x06 { bit ^ 1 } else { bit };
+                    if parity != expected {
+                        bit_ok = false;
+                    }
+                }
+```
+
+becomes:
+
+```rust
+                } else {
+                    // `bit` is the received parity bit. R12BW flips the
+                    // *accumulated* parity per slowrx `vis.c:116`:
+                    // `if (VISmap[VIS] == R12BW) Parity = !Parity;`. No
+                    // `ModeSpec` exists for R12BW yet (`lookup` returns
+                    // `None` for `R12BW_VIS_CODE`), but the parity check
+                    // must still pass so a future R12BW implementation that
+                    // adds it to `lookup` is not silently broken.
+                    if code == R12BW_VIS_CODE {
+                        parity ^= 1;
+                    }
+                    if parity != bit {
+                        bit_ok = false;
+                    }
+                    break; // k == 7 is the last iteration; explicit break mirrors the classify-fail arm
+                }
+```
+
+- [ ] **Step 3: Replace `0x06` literals in the test encoder**
+
+In `synth_vis_with_offset` (`#[cfg(any(test, feature = "test-support"))] pub mod tests`), the lines currently:
+
+```rust
+        // R12BW (code 0x06) inverts the parity bit per slowrx `vis.c:116`.
+        // The detector's `match_vis_pattern` does the same inversion when
+        // checking, so synthetic bursts must follow the same convention or
+        // they'd fail parity at the receiver.
+        let parity_bit = if code == 0x06 { parity ^ 1 } else { parity };
+```
+
+become:
+
+```rust
+        // R12BW (`R12BW_VIS_CODE`) inverts the parity bit per slowrx `vis.c:116`.
+        // The detector's `match_vis_pattern` does the same inversion when
+        // checking, so synthetic bursts must follow the same convention or
+        // they'd fail parity at the receiver.
+        let parity_bit = if code == R12BW_VIS_CODE { parity ^ 1 } else { parity };
+```
+
+(`R12BW_VIS_CODE` is `pub(crate)` and the test module does `use super::*`, so it is in scope.)
+
+In `r12bw_rejects_standard_parity`, replace `let bit = (0x06_u8 >> b) & 1;` with `let bit = (R12BW_VIS_CODE >> b) & 1;`.
+
+Other `0x06` occurrences in that module are inside doc comments / string literals / `vis_padded(0x06, ...)` / `assert_eq!(detected.code, 0x06)` — leave the *argument* and *assertion* literals (`vis_padded(0x06, ..)`, `assert_eq!(.., 0x06)`) as-is (they read fine as a concrete code), but in the prose comments above those tests change "code 0x06" → "code `R12BW_VIS_CODE` (`0x06`)" where it improves clarity. Minimal touch — do not churn comments unnecessarily.
+
+- [ ] **Step 4: Run the existing tests**
+
+Run: `cargo test --lib vis -- --nocapture`
+Expected: PASS — all of `vis::tests` still green (`r12bw_uses_inverted_parity`, `r12bw_rejects_standard_parity`, `parity_failure_is_rejected`, `detects_clean_pd120_and_pd180`, the proptests, etc.).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/vis.rs
+git commit -m "refactor(vis): R12BW_VIS_CODE const + faithful parity-check shape (#89 C5/C15)"
+```
+
+---
+
+## Task 2: A3 — keep-searching `match_vis_pattern`, `is_known_vis` field, `IS_KNOWN_VIS` const
+
+`match_vis_pattern` tries all 9 `(i, j)` alignments and returns the first *known* code (like slowrx, which breaks on the first known code); if none is known but ≥1 parity-passing *unknown* code exists, it returns the first such (the caller surfaces it via `SstvEvent::UnknownVis` in T3). `VisDetector` carries the predicate as a `fn(u8) -> bool` field.
+
+**Files:**
+- Modify: `src/vis.rs` (`match_vis_pattern` signature + body + doc; `VisDetector` field + `new` + `process`; `run` test helper; new tests)
+- Modify: `src/decoder.rs` (add `const IS_KNOWN_VIS`; update the two `VisDetector::new()` call sites)
+- Test: `src/vis.rs` `pub mod tests` — three new `match_vis_pattern` unit tests + a test-local `synth_tone_history` builder
+
+- [ ] **Step 1: Write the failing unit tests + the tone-history builder**
+
+In `src/vis.rs`, inside `pub mod tests { ... }`, add (placed after the existing `synth_tone_n` helper, before the `#[test]` functions — or anywhere in the module):
+
+```rust
+    /// Build a 45-entry tone history (`HedrBuf` order: `[0]` oldest) that the
+    /// matcher reads as `phase0_code` at phase `i = 0` and, if `phase1_code`
+    /// is `Some(c)`, as `c` at phase `i = 1`. Phase `i = 2`'s bit slots are
+    /// left as leader tones, so it fails bit classification (never matches).
+    /// All leader / break slots are positioned so phases 0 and 1 pass those
+    /// checks. Tones are at the un-shifted (`hedr_shift = 0`) frequencies.
+    fn synth_tone_history(phase0_code: u8, phase1_code: Option<u8>) -> [f64; HISTORY_LEN] {
+        let leader = LEADER_HZ;
+        let break_f = leader + BREAK_HZ_OFFSET;
+        let zero_f = leader + BIT_ZERO_OFFSET;
+        let one_f = leader + BIT_ONE_OFFSET;
+        let bit_freq = |b: u8| if b == 1 { one_f } else { zero_f };
+        let mut t = [leader; HISTORY_LEN];
+        // Break tones — checked at indices 15+i and 42+i for i in 0..3.
+        t[15] = break_f;
+        t[16] = break_f;
+        t[42] = break_f;
+        t[43] = break_f;
+        // Phase i=0: data bits at tones[18 + 3k] (k=0..6), parity at tones[39].
+        let mut p0 = 0u8;
+        for k in 0..7 {
+            let b = (phase0_code >> k) & 1;
+            p0 ^= b;
+            t[18 + 3 * k] = bit_freq(b);
+        }
+        let p0 = if phase0_code == R12BW_VIS_CODE { p0 ^ 1 } else { p0 };
+        t[39] = bit_freq(p0);
+        // Phase i=1: data bits at tones[19 + 3k], parity at tones[40].
+        if let Some(c) = phase1_code {
+            let mut p1 = 0u8;
+            for k in 0..7 {
+                let b = (c >> k) & 1;
+                p1 ^= b;
+                t[19 + 3 * k] = bit_freq(b);
+            }
+            let p1 = if c == R12BW_VIS_CODE { p1 ^ 1 } else { p1 };
+            t[40] = bit_freq(p1);
+        }
+        t
+    }
+
+    /// `is_known` predicate as used in production: a 7-bit VIS code is "known"
+    /// iff it maps to a `ModeSpec`.
+    fn vis_known(code: u8) -> bool {
+        crate::modespec::lookup(code).is_some()
+    }
+
+    #[test]
+    fn match_vis_pattern_clean_known_code() {
+        // 0x5F == PD120 is in the lookup table.
+        let tones = synth_tone_history(0x5F, None);
+        let m = match_vis_pattern(&tones, vis_known).expect("known code matches");
+        assert_eq!(m.0, 0x5F);
+        assert!(m.1.abs() < 1e-9, "hedr_shift should be 0, got {}", m.1);
+        assert_eq!(m.2, 0, "matched at phase i = 0");
+    }
+
+    #[test]
+    fn match_vis_pattern_clean_unknown_code_falls_back() {
+        // 0x01 is a valid 7-bit code with parity 1, but maps to no mode.
+        assert!(crate::modespec::lookup(0x01).is_none());
+        let tones = synth_tone_history(0x01, None);
+        let m = match_vis_pattern(&tones, vis_known)
+            .expect("an unknown-but-parity-passing code is still returned (fallback)");
+        assert_eq!(m.0, 0x01);
+        assert_eq!(m.2, 0);
+    }
+
+    #[test]
+    fn match_vis_pattern_prefers_known_over_earlier_unknown() {
+        // Phase i=0 spells unknown 0x01; phase i=1 spells known 0x5F.
+        // The (i,j) loop hits i=0 first — the old code returned 0x01 there;
+        // the fix must skip it and return 0x5F at i=1.
+        let tones = synth_tone_history(0x01, Some(0x5F));
+        let m = match_vis_pattern(&tones, vis_known).expect("known code at a later alignment");
+        assert_eq!(m.0, 0x5F, "should skip the earlier unknown 0x01 alignment");
+        assert_eq!(m.2, 1, "matched at phase i = 1");
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cargo test --lib vis::tests::match_vis_pattern`
+Expected: FAIL to compile — `match_vis_pattern` takes one argument, not two (`is_known` not yet added). (Once you add the parameter in Step 3 the `prefers_known_over_earlier_unknown` test would still fail against the *old* body because it returns the first parity-passing alignment.)
+
+- [ ] **Step 3: Change `match_vis_pattern` — add `is_known`, keep-search, `first_unknown` fallback**
+
+Signature (`src/vis.rs`): change
+
+```rust
+fn match_vis_pattern(tones: &[f64; HISTORY_LEN]) -> Option<(u8, f64, usize)> {
+```
+
+to
+
+```rust
+fn match_vis_pattern(
+    tones: &[f64; HISTORY_LEN],
+    is_known: impl Fn(u8) -> bool,
+) -> Option<(u8, f64, usize)> {
+```
+
+Body: add `let mut first_unknown: Option<(u8, f64, usize)> = None;` immediately before `for i in 0..3 {`. Replace the trailing `if bit_ok { return Some((code, leader - LEADER_HZ, i)); }` with:
+
+```rust
+            if bit_ok {
+                let m = (code, leader - LEADER_HZ, i);
+                if is_known(code) {
+                    return Some(m); // slowrx breaks on the first known code
+                }
+                first_unknown.get_or_insert(m);
+            }
+```
+
+Replace the function's final `None` with `first_unknown`.
+
+Update the doc comment on `match_vis_pattern`. The intro currently says
+*"Returns `(vis_code, hedr_shift_hz, i)` on detection ..."* — change that to
+*"Returns the first **known** parity-passing alignment as `(vis_code, hedr_shift_hz, i)` (or the first parity-passing **unknown** code as a fallback) ..."*. Keep the existing `## Deliberate divergence ... Finding 5` paragraph. Append a new paragraph:
+
+```rust
+/// **Keep-searching for a known code (issue #89, A3):** like slowrx (`vis.c`),
+/// this tries all 9 alignments and returns the *first known* code (`is_known`).
+/// A clean burst whose only parity-passing alignment maps to an *unknown* code
+/// (a real R12BW transmission, or an unimplemented mode) is still returned — as
+/// the `first_unknown` fallback — so the caller can surface it via
+/// `SstvEvent::UnknownVis` (added in #89 — note: a plain code span, not an
+/// intra-doc link, since `vis` is below `decoder` in the module graph). See
+/// `docs/intentional-deviations.md`
+/// ("VIS: keep-searching for a known code; surface clean unknown bursts").
+```
+
+- [ ] **Step 4: Add the `is_known_vis` field to `VisDetector`**
+
+In the `VisDetector` struct (`src/vis.rs`), add a field (place it last, after `detected: Option<DetectedVis>,`):
+
+```rust
+    /// `|c| crate::modespec::lookup(c).is_some()` — passed to
+    /// [`match_vis_pattern`] so the matcher keeps searching alignments for a
+    /// *known* VIS code (issue #89 A3). An `fn` pointer: the closure captures
+    /// nothing, so it coerces.
+    is_known_vis: fn(u8) -> bool,
+```
+
+Change `VisDetector::new`:
+
+```rust
+    pub fn new() -> Self {
+```
+
+to
+
+```rust
+    pub fn new(is_known_vis: fn(u8) -> bool) -> Self {
+```
+
+and add `is_known_vis,` to the returned struct literal (alongside the other fields).
+
+In `VisDetector::process`, change the `match_vis_pattern` call from
+
+```rust
+                if let Some((code, hedr_shift_hz, i_match)) =
+                    match_vis_pattern(&self.rotated_history())
+                {
+```
+
+to
+
+```rust
+                if let Some((code, hedr_shift_hz, i_match)) =
+                    match_vis_pattern(&self.rotated_history(), self.is_known_vis)
+                {
+```
+
+(`self.is_known_vis` is `Copy` — copying out the `fn` pointer does not conflict with `&mut self`.)
+
+- [ ] **Step 5: Update the `run` test helper in `vis.rs`**
+
+In `pub mod tests`, the `run` helper currently:
+
+```rust
+    fn run(audio: &[f32]) -> Option<DetectedVis> {
+        let mut det = VisDetector::new();
+        det.process(audio, audio.len() as u64);
+        det.take_detected()
+    }
+```
+
+becomes:
+
+```rust
+    fn run(audio: &[f32]) -> Option<DetectedVis> {
+        let mut det = VisDetector::new(vis_known);
+        det.process(audio, audio.len() as u64);
+        det.take_detected()
+    }
+```
+
+(`vis_known` is the helper added in Step 1.)
+
+- [ ] **Step 6: Add the `IS_KNOWN_VIS` const + update `decoder.rs` call sites**
+
+In `src/decoder.rs`, near the other crate-private items (immediately after `const FINDSYNC_AUDIO_HEADROOM: f64 = 1.00;`, currently line 139), add:
+
+```rust
+/// `|c| crate::modespec::lookup(c).is_some()` as an `fn` pointer — the
+/// "is this VIS code one we can decode?" predicate handed to every
+/// [`crate::vis::VisDetector`] (issue #89 A3). The closure captures nothing,
+/// so it coerces to `fn(u8) -> bool` in const context.
+const IS_KNOWN_VIS: fn(u8) -> bool = |c| crate::modespec::lookup(c).is_some();
+```
+
+Update the two construction sites:
+- `SstvDecoder::new` (currently `vis: crate::vis::VisDetector::new(),` ~line 193) → `vis: crate::vis::VisDetector::new(IS_KNOWN_VIS),`
+- The post-image reseed in `process` (currently `self.vis = crate::vis::VisDetector::new();` ~line 345) → `self.vis = crate::vis::VisDetector::new(IS_KNOWN_VIS);` (T3 refactors this whole block; this keeps it compiling in the meantime).
+
+- [ ] **Step 7: Run the tests**
+
+Run: `cargo test --lib`
+Expected: PASS — the three new `match_vis_pattern` tests green, all existing `vis::tests` + `decoder::tests` still green.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/vis.rs src/decoder.rs
+git commit -m "feat(vis): keep-searching VIS alignments for a known code (#89 A3)"
+```
+
+---
+
+## Task 3: `SstvEvent::UnknownVis` + `restart_vis_detection` + A1 fix + post-image refactor
+
+The unknown-VIS branch in `SstvDecoder::process` currently drops the residual buffer and `break`s without reseeding `self.vis` — violating the `#40` re-anchor contract documented on `VisDetector::take_residual_buffer` (the successful-decode path and the post-image path both reseed). Fix it via a `restart_vis_detection` helper, emit a `SstvEvent::UnknownVis` for the dropped burst, and `continue` so a follow-up VIS already in the residual surfaces in the same `process()` call.
+
+**Files:**
+- Modify: `src/decoder.rs` (`SstvEvent` enum; `restart_vis_detection` helper; unknown-VIS branch; post-image reseed)
+- Create: `tests/unknown_vis.rs`
+
+- [ ] **Step 1: Write the failing integration test**
+
+Create `tests/unknown_vis.rs`:
+
+```rust
+//! `SstvDecoder` must surface an unrecognized-but-well-formed VIS burst as
+//! `SstvEvent::UnknownVis` (rather than dropping it silently) and then keep
+//! detecting subsequent valid VIS bursts — i.e. the unknown-code path reseeds
+//! the VIS detector per the `#40` re-anchor contract (audit #89: A1 + C1).
+
+#![cfg(feature = "test-support")]
+#![allow(clippy::expect_used, clippy::cast_possible_truncation)]
+
+use slowrx::{SstvDecoder, SstvEvent, SstvMode, WORKING_SAMPLE_RATE_HZ};
+
+/// 0x01 is a valid 7-bit VIS code (parity 1) that maps to no SSTV mode.
+const UNKNOWN_CODE: u8 = 0x01;
+/// 0x5F == PD120.
+const PD120_CODE: u8 = 0x5F;
+
+#[test]
+fn decoder_emits_unknown_vis_then_recovers() {
+    // burst 1: a well-formed VIS for an unknown code.
+    // burst 2: a well-formed VIS for PD120, immediately following.
+    // trailing zeros so the resampler's FIR group delay still yields a full
+    // set of stop-bit windows for burst 2.
+    let mut audio = slowrx::__test_support::vis::synth_vis(UNKNOWN_CODE, 0.0);
+    audio.extend(slowrx::__test_support::vis::synth_vis(PD120_CODE, 0.0));
+    audio.extend(std::iter::repeat_n(0.0_f32, 512));
+
+    let mut decoder = SstvDecoder::new(WORKING_SAMPLE_RATE_HZ).expect("decoder construct");
+    let events = decoder.process(&audio);
+
+    // Expect: UnknownVis { code: 0x01, .. } then VisDetected { mode: Pd120, .. }.
+    let unknown_at = events
+        .iter()
+        .position(|e| matches!(e, SstvEvent::UnknownVis { code, .. } if *code == UNKNOWN_CODE))
+        .unwrap_or_else(|| panic!("no UnknownVis event for 0x{UNKNOWN_CODE:02x}; got {events:?}"));
+    let detected_at = events
+        .iter()
+        .position(|e| matches!(e, SstvEvent::VisDetected { mode: SstvMode::Pd120, .. }))
+        .unwrap_or_else(|| panic!("no VisDetected for PD120 after the unknown burst; got {events:?}"));
+    assert!(
+        unknown_at < detected_at,
+        "UnknownVis should precede the recovered VisDetected; got {events:?}"
+    );
+
+    // The recovered detection's sample_offset should be a sane working-rate
+    // index (non-zero, and not wildly past the end of the fed audio). Exact
+    // semantics post-restart (relative-to-restart vs absolute) are tracked
+    // separately; this is only a gross-corruption guard.
+    if let SstvEvent::VisDetected { sample_offset, .. } = &events[detected_at] {
+        assert!(
+            *sample_offset > 0 && (*sample_offset as usize) <= audio.len(),
+            "VisDetected.sample_offset = {sample_offset} out of [1, {}]",
+            audio.len()
+        );
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cargo test --features test-support --test unknown_vis`
+Expected: FAIL to compile — `SstvEvent::UnknownVis` does not exist yet. (After Step 3 adds the variant but before the branch is rewritten, it would fail at runtime: the old code drops burst 2 via the early `break`, so no `VisDetected` is emitted.)
+
+- [ ] **Step 3: Add the `SstvEvent::UnknownVis` variant**
+
+In `src/decoder.rs`, in the `SstvEvent` enum, add a variant after `VisDetected { ... },` (and before `LineDecoded`):
+
+```rust
+    /// A VIS header parsed and passed parity, but its 7-bit code maps to no
+    /// SSTV mode this build can decode (reserved / undefined, or a mode not
+    /// yet implemented). The decoder discards the burst and resumes scanning
+    /// for the next VIS — equivalent to slowrx's `printf("Unknown VIS %d")`
+    /// plus its retry-`GetVIS()` loop.
+    UnknownVis {
+        /// The 7-bit VIS code that did not resolve.
+        code: u8,
+        /// Radio mistuning offset in Hz: `observed_leader_hz - 1900` (the
+        /// same quantity as [`SstvEvent::VisDetected`]'s `hedr_shift_hz`).
+        /// Surfaced for diagnostics; the burst is dropped, so it does not
+        /// feed any decode.
+        hedr_shift_hz: f64,
+        /// Working-rate (11025 Hz) sample offset where the VIS stop bit ended.
+        sample_offset: u64,
+    },
+```
+
+- [ ] **Step 4: Add the `restart_vis_detection` helper**
+
+In `src/decoder.rs`, inside `impl SstvDecoder`, add (place it next to `process` — e.g. immediately after `process`). It is an **associated** function taking `&mut self.vis` (not `&mut self`), mirroring the existing `Self::run_findsync_and_decode(...)` pattern — so it can be called from inside a `match &mut self.state` arm without a whole-`self` borrow conflict:
+
+```rust
+    /// Discard `vis` and start a fresh detector on `leftover_audio`
+    /// (post-stop-bit residue, or trailing image audio). Honors the `#40`
+    /// re-anchor contract documented on
+    /// [`crate::vis::VisDetector::take_residual_buffer`] — a spent detector's
+    /// `hops_completed` / `history` state is never reset, so it must be
+    /// replaced rather than re-used. `working_samples_emitted` is the
+    /// decoder's running working-rate output count (used to anchor the fresh
+    /// detector).
+    fn restart_vis_detection(
+        vis: &mut crate::vis::VisDetector,
+        working_samples_emitted: u64,
+        leftover_audio: Vec<f32>,
+    ) {
+        *vis = crate::vis::VisDetector::new(IS_KNOWN_VIS);
+        vis.process(&leftover_audio, working_samples_emitted);
+    }
+```
+
+- [ ] **Step 5: Rewrite the unknown-VIS branch in `process`**
+
+In `SstvDecoder::process`, the `State::AwaitingVis` arm currently ends (after the `if let Some(spec) = ... { ... continue; }` block) with:
+
+```rust
+                        // Unknown VIS codes silently drop. Reset the
+                        // detector's buffer so it does not accumulate
+                        // forever on uninterpretable bursts.
+                        let _ = self.vis.take_residual_buffer();
+                    }
+                    break;
+```
+
+Replace the `let _ = self.vis.take_residual_buffer();` line with:
+
+```rust
+                        // Unknown VIS code: surface it so stream-monitoring
+                        // callers know a burst arrived, then reseed the
+                        // detector (the `#40` re-anchor contract) on the
+                        // post-stop-bit residue and re-enter the loop — a
+                        // back-to-back VIS in the residue then surfaces in
+                        // this same `process` call. Mirrors the known-code
+                        // branch's `continue`.
+                        out.push(SstvEvent::UnknownVis {
+                            code: detected.code,
+                            hedr_shift_hz: detected.hedr_shift_hz,
+                            sample_offset: detected.end_sample,
+                        });
+                        let residual = self.vis.take_residual_buffer();
+                        Self::restart_vis_detection(
+                            &mut self.vis,
+                            self.working_samples_emitted,
+                            residual,
+                        );
+                        continue;
+```
+
+The `}` closing the `if let Some(detected) = self.vis.take_detected()` block and the trailing `break;` stay.
+
+- [ ] **Step 6: Refactor the post-image reseed to use the helper**
+
+In the `State::Decoding(d)` arm of `process`, the block currently (the comment block plus):
+
+```rust
+                    let trailing = std::mem::take(&mut d.audio);
+                    self.state = State::AwaitingVis;
+                    self.vis = crate::vis::VisDetector::new(IS_KNOWN_VIS);
+                    self.vis.process(&trailing, self.working_samples_emitted);
+                    break;
+```
+
+becomes:
+
+```rust
+                    let trailing = std::mem::take(&mut d.audio);
+                    self.state = State::AwaitingVis;
+                    Self::restart_vis_detection(
+                        &mut self.vis,
+                        self.working_samples_emitted,
+                        trailing,
+                    );
+                    break;
+```
+
+(Keep the surrounding `// Image complete. Preserve trailing audio ... Closes #31.` comment block. This is a pure DRY change — no behavior difference. The `mem::take`-vs-`split_off` question on that line is issue #90's, untouched here.)
+
+- [ ] **Step 7: Run the tests**
+
+Run: `cargo test --features test-support`
+Expected: PASS — `tests/unknown_vis.rs::decoder_emits_unknown_vis_then_recovers` green; all existing tests still green.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/decoder.rs tests/unknown_vis.rs
+git commit -m "feat(decoder): SstvEvent::UnknownVis + reseed VIS detector after unknown code (#89 A1/C1)"
+```
+
+---
+
+## Task 4: Delete the dead `Error::UnknownVisCode`
+
+`Error::UnknownVisCode(u8)` is never constructed — `SstvDecoder::process` returns `Vec<SstvEvent>`, never `Result`, and `SstvDecoder::new` only fails on a bad sample rate. The unknown-code path now emits `SstvEvent::UnknownVis` instead. Remove the variant and its test.
+
+**Files:**
+- Modify: `src/error.rs`
+
+- [ ] **Step 1: Delete the variant**
+
+In `src/error.rs`, remove the `UnknownVisCode` variant from `pub enum Error` (the doc comment, the `#[error(...)]` attribute, and `UnknownVisCode(u8),` — currently lines 17-21):
+
+```rust
+    /// VIS code does not map to a known SSTV mode.
+    ///
+    /// The `u8` value is the raw 7-bit VIS byte read from the audio stream.
+    #[error("VIS code {0:#04x} does not map to a known SSTV mode")]
+    UnknownVisCode(u8),
+```
+
+Leave `InvalidSampleRate { got: u32 }`. The enum stays `#[non_exhaustive]`.
+
+- [ ] **Step 2: Delete the variant's test**
+
+In `src/error.rs`'s `#[cfg(test)] mod tests`, remove the whole `unknown_vis_code_renders_in_hex` test:
+
+```rust
+    #[test]
+    fn unknown_vis_code_renders_in_hex() {
+        let e = Error::UnknownVisCode(0x42);
+        assert_eq!(
+            e.to_string(),
+            "VIS code 0x42 does not map to a known SSTV mode"
+        );
+    }
+```
+
+Leave `invalid_sample_rate_renders_with_value`.
+
+- [ ] **Step 3: Confirm nothing else references it**
+
+Run: `grep -rn "UnknownVisCode" src/ tests/ examples/`
+Expected: no output.
+
+- [ ] **Step 4: Run the tests**
+
+Run: `cargo test --lib error`
+Expected: PASS — `invalid_sample_rate_renders_with_value` green; nothing references the deleted variant.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/error.rs
+git commit -m "refactor(error): remove never-constructed Error::UnknownVisCode (#89 C1)"
+```
+
+---
+
+## Task 5: Docs — `modespec::lookup` note, `intentional-deviations.md`, `CHANGELOG.md`
+
+**Files:**
+- Modify: `src/modespec.rs` (the `lookup` `#27` doc note)
+- Modify: `docs/intentional-deviations.md` (new section)
+- Modify: `CHANGELOG.md` (`[Unreleased]`)
+
+- [ ] **Step 1: Tweak the `lookup` doc note**
+
+In `src/modespec.rs`, the `lookup` doc comment's `#27` paragraph currently reads (the relevant sentences):
+
+```rust
+/// **Parity-audit note (#27):** `0x00` is intentionally unmapped and
+/// returns `None`. In slowrx (`vis.c:172-174`), an unknown VIS code causes
+/// `GetVIS()` to return 0 and `Listen()` loops back to re-detect
+/// (`do { ... } while (Mode == 0)`). Rust's equivalent is `None` from
+/// this function: the caller in `SstvDecoder::process` drains the VIS
+/// detector's buffer and stays in `AwaitingVis`, which has the same
+/// effect as slowrx's re-detect loop. Both treat an unknown code as a
+/// silent "try again" rather than an error.
+```
+
+Replace the last two sentences with:
+
+```rust
+/// this function: the caller in `SstvDecoder::process` emits
+/// `SstvEvent::UnknownVis`, reseeds the VIS detector on the post-stop-bit
+/// residue, and stays in `AwaitingVis` — the same "try again" effect as
+/// slowrx's re-detect loop (slowrx's `printf("Unknown VIS")` becomes the
+/// `UnknownVis` event). An unknown code is never an `Error`.
+```
+
+- [ ] **Step 2: Add the `intentional-deviations.md` section**
+
+In `docs/intentional-deviations.md`, add a new top-level section. Place it right after the existing `## VIS retry behavior on parity failure` section (i.e. before `## Synthetic round-trip max_diff tolerance`) so the VIS entries are grouped:
+
+```markdown
+## VIS: keep-searching for a known code; surface clean unknown bursts
+
+### What slowrx does
+
+`vis.c`'s pattern matcher tries all 9 `(i, j)` alignments. For each alignment
+that passes parity it does `VISmap[VIS]` — and if the code is unknown it
+`printf`s `"Unknown VIS %d"`, leaves `gotvis = false`, and keeps trying the
+remaining alignments. Only a *known* code stops the search (`gotvis = true`).
+If no alignment yields a known code, `GetVIS()` returns `0` and `Listen()`'s
+`do { ... } while (Mode == 0)` loop re-detects from the audio stream.
+
+### What we do
+
+`match_vis_pattern` takes an `is_known` predicate (`|c| modespec::lookup(c).is_some()`)
+and mirrors slowrx: it tries all 9 alignments and returns the **first known**
+code. If no alignment is known but at least one parity-passing alignment maps
+to an **unknown** code, it returns the first such code as a fallback. The
+decoder then emits `SstvEvent::UnknownVis { code, hedr_shift_hz, sample_offset }`
+(our equivalent of slowrx's `printf`), reseeds the VIS detector on the
+post-stop-bit residue (the `#40` re-anchor contract), and stays in
+`AwaitingVis` — the same "try again" loop as slowrx.
+
+### Why we deviated
+
+slowrx's `printf` is a console side effect with no programmatic surface; a
+library decoder should let callers observe "a burst arrived but I can't decode
+it" (stream monitors, diagnostics). Returning the unknown code as a fallback
+from `match_vis_pattern` (rather than `None`, which slowrx effectively does) is
+what makes that event possible. The keep-searching-for-a-known-code behavior is
+otherwise byte-for-byte slowrx's.
+
+### When to revisit
+
+If R12BW (or any other currently-unimplemented mode) gains a `ModeSpec`, it
+becomes "known" automatically (the predicate is `lookup(...).is_some()`), and
+bursts for it stop surfacing as `UnknownVis` and start decoding. Nothing else
+to change.
+```
+
+- [ ] **Step 3: Add the `CHANGELOG.md` `[Unreleased]` entries**
+
+In `CHANGELOG.md`, under the `## [Unreleased]` header, add:
+
+```markdown
+### Added
+
+- **`SstvEvent::UnknownVis { code, hedr_shift_hz, sample_offset }`** — a VIS
+  burst that parses and passes parity but maps to no decodable SSTV mode is now
+  surfaced to callers (previously dropped silently). `match_vis_pattern` also
+  keeps searching its 9 alignments for a *known* code before falling back to an
+  unknown one, matching slowrx (#89 A3/C1).
+
+### Fixed
+
+- **Stale VIS detector after an unknown VIS code** — `SstvDecoder::process`
+  drained the detector's residual buffer but did not reconstruct it, violating
+  the `#40` re-anchor contract (`hops_completed` / `history` were carried over
+  into the next detection). It is now reseeded via the same `restart_vis_detection`
+  helper the post-image path uses (#89 A1).
+
+### Removed
+
+- **`Error::UnknownVisCode`** — never constructed (`SstvDecoder::process` does
+  not return `Result`; unknown codes are now reported via `SstvEvent::UnknownVis`).
+
+### Internal
+
+- `R12BW_VIS_CODE` named constant replacing bare `0x06` literals; faithful
+  parity-check shape in `match_vis_pattern` (flip the accumulated parity for
+  R12BW, matching slowrx `vis.c:116`) (#89 C5/C15).
+```
+
+(If `[Unreleased]` already has `### Added` / `### Fixed` / etc. subsections, merge into them in Keep-a-Changelog order rather than duplicating headers.)
+
+- [ ] **Step 4: Verify the docs build**
+
+Run: `RUSTDOCFLAGS=-D warnings cargo doc --no-deps --all-features` and `cargo test --doc --all-features`
+Expected: PASS — no broken intra-doc links (the new doc comments reference `SstvEvent::UnknownVis`, `crate::vis::VisDetector::take_residual_buffer`, `match_vis_pattern` — all resolvable).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/modespec.rs docs/intentional-deviations.md CHANGELOG.md
+git commit -m "docs: VIS keep-searching deviation + SstvEvent::UnknownVis changelog (#89)"
+```
+
+---
+
+## Task 6: Full CI gate
+
+**Files:** none (verification + any lint fixes)
+
+- [ ] **Step 1: `cargo fmt`**
+
+Run: `cargo fmt --all`
+Then: `cargo fmt --all -- --check`
+Expected: PASS (no diff).
+
+- [ ] **Step 2: `cargo clippy`**
+
+Run: `cargo clippy --all-targets --all-features -- -D warnings`
+Expected: PASS. If a warning fires (e.g. `clippy::doc_markdown` on `SstvEvent` in a doc comment, or `clippy::missing_panics_doc`), fix it minimally — backtick-wrap identifiers in docs, etc. Do **not** add blanket `#[allow]`s.
+
+- [ ] **Step 3: `cargo test` (release, all features, locked)**
+
+Run: `cargo test --all-features --locked --release`
+Expected: PASS — full suite green, including `tests/unknown_vis.rs`, `tests/roundtrip.rs`, `tests/no_vis.rs`.
+
+- [ ] **Step 4: `cargo doc` (deny warnings)**
+
+Run: `RUSTDOCFLAGS=-D warnings cargo doc --no-deps --all-features`
+Expected: PASS.
+
+- [ ] **Step 5: Commit any fixes**
+
+If Steps 1-4 produced changes:
+
+```bash
+git add -A
+git commit -m "chore: satisfy fmt/clippy/doc gate (#89)"
+```
+
+If nothing changed, skip the commit. The branch is now ready for the final review and a PR against `main`.
+
+---
+
+## Self-review notes (for the implementer / reviewers)
+
+- **Spec coverage:** A1 → T3 Steps 4-6; A3 → T2 Steps 3-4 (+ unit tests T2 Step 1); C1 → T3 Step 3 (`UnknownVis`) + T4 (delete `Error::UnknownVisCode`); C5 → T1 Step 1, 3; C15 → T1 Step 2. `intentional-deviations.md` entry → T5 Step 2. `CHANGELOG` → T5 Step 3. `modespec::lookup` doc → T5 Step 1.
+- **`fn(u8) -> bool` in `const`:** `const IS_KNOWN_VIS: fn(u8) -> bool = |c| crate::modespec::lookup(c).is_some();` is valid — the closure captures nothing, so it coerces to a function pointer; only the pointer (a link-time constant) is stored, the body is not const-evaluated.
+- **`SstvEvent` is `#[non_exhaustive]`** — adding `UnknownVis` is a non-breaking addition; all existing internal matches are `matches!`/`if let`, never exhaustive, so nothing else needs touching.
+- **`process` signature is unchanged** — only `VisDetector::new` gains a parameter; the two `new` call sites are in `decoder.rs` (covered) and the `run` test helper in `vis.rs` (covered T2 Step 5). `decoder.rs::tests` does not construct a `VisDetector` directly.
+- **Out of scope (do not touch):** the post-image `break`-vs-`continue` and `mem::take`-vs-`split_off` of `d.audio` (issue #90); `sample_offset`-absolute-vs-relative-after-restart semantics (tracked with #90 / the `working_samples_emitted` note); any wider `vis.rs` decomposition (#88).

--- a/docs/superpowers/specs/2026-05-11-issue-89-vis-detector-fidelity-design.md
+++ b/docs/superpowers/specs/2026-05-11-issue-89-vis-detector-fidelity-design.md
@@ -1,0 +1,278 @@
+# Issue #89 — VIS detector fidelity — design
+
+**Issue:** [#89](https://github.com/jasonherald/slowrx.rs/issues/89) (audit bundle 5 of 12)
+**Source of record:** `docs/audits/2026-05-11-deep-code-review-audit.md` (IDs A1, A3, C1, C5, C15)
+**Scope:** five cohesive fixes in the VIS-detection path. No behavior change for the 99.9% case (clean, known VIS burst); the changes harden the unknown-code path and bring `match_vis_pattern` closer to slowrx's structure.
+
+## Background
+
+`SstvDecoder` runs a VIS detector (`src/vis.rs::VisDetector`) until a 14-window VIS
+pattern matches; the resulting 7-bit code is looked up in `src/modespec.rs::lookup`
+to dispatch a mode. The deep code-review audit found five issues clustered here:
+
+- **A1 (High)** — on an *unknown* VIS code, `SstvDecoder::process` drains the detector's
+  residual buffer but never reconstructs `self.vis`. `VisDetector::take_residual_buffer`'s
+  documented "#40 re-anchor contract" requires a fresh `VisDetector::new()` afterward
+  (`hops_completed` / `history` / `history_ptr` / `history_filled` are not reset), or the
+  next detection's `end_sample` and pattern window are corrupted. The successful-decode
+  path and the post-image path both already reseed; the unknown path was the outlier.
+- **A3** — `match_vis_pattern` returns the *first* parity-passing `(i, j)` alignment, known
+  or not. slowrx (`vis.c`) tries all 9 alignments, only stopping on a *known* code (and
+  `printf`s unknown-but-parity-passing ones as it goes). On a marginal burst that classifies
+  to garbage-but-parity-OK at one alignment and the real code at another, slowrx recovers
+  and we don't.
+- **C1** — `Error::UnknownVisCode(u8)` is never constructed. `process()` returns
+  `Vec<SstvEvent>`, never `Result`, and `SstvDecoder::new` only fails on a bad sample rate,
+  so the variant is unreachable. Unknown codes are dropped silently.
+- **C5** — the R12BW VIS code `0x06` appears as a bare literal in `vis.rs`
+  (`match_vis_pattern`, the test encoder, test comments). slowrx writes `VISmap[VIS] == R12BW`
+  symbolically.
+- **C15** — the parity-bit branch of `match_vis_pattern`'s bit loop flips the *expected bit*
+  (`bit ^ 1`) for R12BW rather than the *accumulator* (`Parity = !Parity` in slowrx), and
+  has no `break` after a parity failure (harmless — `k == 7` is the last iteration — but
+  asymmetric with the classify-fail arm).
+
+## Design
+
+### Part 1 — Decoder side (`src/decoder.rs`, `src/error.rs`, `src/modespec.rs`)
+
+**A1 fix + DRY helper.** Add to `SstvDecoder`:
+
+```rust
+/// `|c| crate::modespec::lookup(c).is_some()` as an `fn` pointer (the closure
+/// captures nothing, so it coerces). Threaded into every `VisDetector` so it
+/// can keep-search past unknown codes (issue #89 A3).
+const IS_KNOWN_VIS: fn(u8) -> bool = |c| crate::modespec::lookup(c).is_some();
+
+/// Discard the current VIS detector and start fresh on `leftover_audio`
+/// (post-stop-bit residue, or trailing image audio). Honors the #40
+/// re-anchor contract documented on `vis::VisDetector::take_residual_buffer`.
+fn restart_vis_detection(&mut self, leftover_audio: Vec<f32>) {
+    self.vis = crate::vis::VisDetector::new(IS_KNOWN_VIS);
+    self.vis.process(&leftover_audio, self.working_samples_emitted);
+}
+```
+
+(`VisDetector::new` takes `IS_KNOWN_VIS` and stores it; `process`'s signature is unchanged
+— see Part 2.)
+
+The unknown-VIS branch (currently `decoder.rs:284-289`) becomes, on `lookup(detected.code)` → `None`:
+
+```rust
+out.push(SstvEvent::UnknownVis {
+    code: detected.code,
+    hedr_shift_hz: detected.hedr_shift_hz,
+    sample_offset: detected.end_sample,
+});
+let residual = self.vis.take_residual_buffer();
+self.restart_vis_detection(residual);
+continue; // surface a follow-up VIS already in the residual within this call
+```
+
+`continue` (not the current `break`) matches the known-VIS branch — a back-to-back VIS
+in the residual is detected without waiting for another `process()` call.
+
+The post-image reseed (`decoder.rs:343-346`) is refactored to use the helper — a pure
+DRY change, no behavior difference:
+
+```rust
+let trailing = std::mem::take(&mut d.audio);
+self.state = State::AwaitingVis;
+self.restart_vis_detection(trailing);
+break;
+```
+
+(The `mem::take`-vs-`split_off` question on that line is issue #90's; this PR does not
+touch it. `SstvDecoder::new`'s initial `VisDetector::new(IS_KNOWN_VIS)` stays inline —
+it isn't a "restart".)
+
+**`SstvEvent::UnknownVis`** — new variant on the `#[non_exhaustive]` `SstvEvent` enum
+(additive):
+
+```rust
+/// A VIS header parsed and passed parity, but its 7-bit code maps to no
+/// SSTV mode this build can decode (reserved / undefined, or a mode not yet
+/// implemented). The decoder discards the burst and resumes scanning for the
+/// next VIS — equivalent to slowrx's `printf("Unknown VIS %d")` plus its
+/// retry-`GetVIS()` loop.
+UnknownVis {
+    /// The 7-bit VIS code that did not resolve.
+    code: u8,
+    /// Radio mistuning offset in Hz: `observed_leader_hz - 1900` (same
+    /// quantity as [`SstvEvent::VisDetected::hedr_shift_hz`]). Surfaced for
+    /// diagnostics only; the burst is dropped, so it does not feed decode.
+    hedr_shift_hz: f64,
+    /// Working-rate (11025 Hz) sample offset where the VIS stop bit ended.
+    sample_offset: u64,
+},
+```
+
+**`Error::UnknownVisCode`** — deleted, along with its test `unknown_vis_code_renders_in_hex`.
+`Error::InvalidSampleRate` stays. (Removing a variant from a `#[non_exhaustive]` enum is
+technically breaking, but the variant has never been constructed — noted in the CHANGELOG.)
+
+**`modespec::lookup`** — the `#27` doc note is tweaked to mention `SstvEvent::UnknownVis` is
+now emitted (the "silent try again" wording becomes "emits `SstvEvent::UnknownVis` and tries
+again").
+
+### Part 2 — `src/vis.rs`: faithful keep-searching, `R12BW_VIS_CODE`, parity-check shape
+
+**`R12BW_VIS_CODE` (C5).** Add near the other VIS constants:
+
+```rust
+/// VIS code for the (unimplemented) Robot 12 B/W mode. R12BW inverts the
+/// parity bit (slowrx `vis.c:116`). No `ModeSpec` exists for it yet;
+/// `match_vis_pattern` still classifies it so a future R12BW implementation
+/// that adds it to `modespec::lookup` works without re-touching the parity
+/// logic. TODO: when R12BW gains a `ModeSpec`, derive this from it.
+pub(crate) const R12BW_VIS_CODE: u8 = 0x06;
+```
+
+Use it in `match_vis_pattern`, in the test encoder `synth_vis_with_offset`, and in the
+R12BW test comments — replacing the bare `0x06` literals.
+
+**A3 — keep-searching for a known code.** `match_vis_pattern` gains an `is_known` predicate:
+
+```rust
+fn match_vis_pattern(
+    tones: &[f64; HISTORY_LEN],
+    is_known: impl Fn(u8) -> bool,
+) -> Option<(u8, f64, usize)> {
+    let tol = TONE_TOLERANCE_HZ;
+    let mut first_unknown: Option<(u8, f64, usize)> = None;
+    for i in 0..3 {
+        for j in 0..3 {
+            // ... leader / break / 8-bit classification + parity (unchanged) ...
+            if bit_ok {
+                let m = (code, leader - LEADER_HZ, i);
+                if is_known(code) {
+                    return Some(m); // slowrx breaks on the first known code
+                }
+                first_unknown.get_or_insert(m);
+            }
+        }
+    }
+    first_unknown
+}
+```
+
+- A marginal burst that hits an unknown-but-parity-OK alignment first and the real code at a
+  later alignment now returns the real code (the A3 motivating case).
+- A clean *unknown-but-well-formed* burst (a real R12BW transmission, or an unimplemented
+  mode) still surfaces — as the `first_unknown` fallback, with `code` intact — so the decoder
+  can emit `SstvEvent::UnknownVis`. The caller already re-runs `crate::modespec::lookup(code)`
+  to split known→`VisDetected` / unknown→`UnknownVis`, so `DetectedVis` needs no new field.
+
+**Threading the predicate.** `VisDetector` gains an `is_known_vis: fn(u8) -> bool` field, set
+by `VisDetector::new(is_known_vis: fn(u8) -> bool)` and stored on the struct; `process` reads
+`self.is_known_vis` when calling `match_vis_pattern` — `process`'s signature is unchanged.
+(`fn` pointer, not `Box<dyn Fn>` — `|c| crate::modespec::lookup(c).is_some()` captures
+nothing, so it coerces; `decoder.rs` holds the one value in `IS_KNOWN_VIS`. `vis.rs::tests`
+pass `|c| crate::modespec::lookup(c).is_some()` to `VisDetector::new` — `modespec` is a
+sibling leaf module, no cycle.)
+
+**C15 — parity-check shape.** The `k == 7` branch of the bit loop becomes:
+
+```rust
+} else {
+    // `bit` is the received parity bit. R12BW flips the *accumulated* parity
+    // per slowrx `vis.c:116`: `if (VISmap[VIS] == R12BW) Parity = !Parity;`.
+    if code == R12BW_VIS_CODE {
+        parity ^= 1;
+    }
+    if parity != bit {
+        bit_ok = false;
+    }
+    break; // k == 7 is the last iteration; explicit break mirrors the classify-fail arm
+}
+```
+
+Functionally identical to today, but faithful in structure and the `break` makes the loop's
+two exits symmetric. The surrounding comment block (currently `vis.rs:378-384`) is updated to
+match.
+
+**`match_vis_pattern` doc comment.** The existing `#5` / round-2 deviation note stays; a new
+sentence points at the new `intentional-deviations.md` entry for the keep-searching /
+`UnknownVis` behavior.
+
+### Part 3 — Tests, docs, changelog
+
+**`src/vis.rs::tests` — `match_vis_pattern` unit tests** (it's private; the test module can
+call it directly). A small test-local helper builds a `[f64; HISTORY_LEN]` array from a
+`(phase0_code, phase1_code)` pair (leader / break tones positioned so phases `i = 0` and
+`i = 1` both pass the leader/break checks):
+
+- `match_vis_pattern_clean_known_code` — array for known code `0x5F` at `i = 0`; assert
+  `Some((0x5F, ~0.0, 0))`.
+- `match_vis_pattern_clean_unknown_code_falls_back` — array for code `0x01` (well-formed,
+  `lookup` → `None`); assert `Some((0x01, _, 0))` (the `first_unknown` fallback).
+- `match_vis_pattern_prefers_known_over_earlier_unknown` — `phase0 = 0x01` (unknown),
+  `phase1 = 0x5F` (known); assert it returns `(0x5F, _, 1)` — i.e. it skipped the earlier
+  unknown alignment. **This is the A3 regression test.**
+
+Existing `vis.rs::tests` keep passing: the `VisDetector::new(...)` and `process(...)` call
+sites in the test module gain the predicate arg; `every_valid_vis_code_decodes_correctly`
+still holds because an unknown code surfaces via `first_unknown` with `code` intact.
+
+**`tests/unknown_vis.rs` — new integration test** (uses the `test-support` feature, like
+`tests/no_vis.rs`):
+
+- `decoder_emits_unknown_vis_then_recovers` —
+  `SstvDecoder::process(synth_vis(0x01, 0.0) ++ synth_vis(0x5F, 0.0) ++ short zero pad)`,
+  collect events, assert the sequence contains `SstvEvent::UnknownVis { code: 0x01, .. }`
+  followed by `SstvEvent::VisDetected { mode: SstvMode::Pd120, .. }`, **and** the
+  `VisDetected.sample_offset` is within one VIS-window of the true end of the second burst's
+  stop bit (≈ both bursts' combined working-rate length). The `sample_offset` check is the
+  A1 regression — with the stale detector, `sample_offset` came out as
+  `(cumulative_hops + i) * HOP_SAMPLES`, wildly inflated. No full-image decode is needed —
+  `VisDetected` fires the moment the second stop bit is recognized.
+
+**`src/error.rs`** — drop `unknown_vis_code_renders_in_hex`; `invalid_sample_rate_renders_with_value`
+stays.
+
+**`docs/intentional-deviations.md`** — one new entry near the existing VIS entries:
+*"VIS: keep-searching for a known code; surface clean unknown bursts."* Covers the A3
+mechanics (all 9 alignments tried, first known wins), the `SstvEvent::UnknownVis`-vs-slowrx-
+`printf` choice (we surface the code as an event; slowrx prints it and returns 0), and the
+residual edge case (the only scenario slowrx still beats us is now also handled).
+
+**`CHANGELOG.md`** under `[Unreleased]`:
+
+- *Fixed* — stale `VisDetector` after an unknown VIS code (A1): could mis-anchor the next
+  detection's `sample_offset` and pollute its pattern window.
+- *Added* — `SstvEvent::UnknownVis { code, hedr_shift_hz, sample_offset }`: unrecognized-but-
+  well-formed VIS bursts are surfaced instead of dropped silently; `match_vis_pattern` keeps
+  searching past unknown alignments for a known one (A3).
+- *Removed* — `Error::UnknownVisCode` (never constructed; `process()` does not return `Result`).
+- *(internal)* — `R12BW_VIS_CODE` named constant; faithful parity-check shape in
+  `match_vis_pattern` (C5, C15).
+
+## Out of scope
+
+- The post-image `break`-vs-`continue` and the `mem::take`-vs-`split_off` of the decoded
+  audio buffer — issue #90 (A2 / D4).
+- Any wider `vis.rs` decomposition or the shared-DSP `dsp`/`demod` modules — issues #88, #85.
+- `SstvImage` / `Error` further changes beyond deleting the dead variant.
+
+## Files touched
+
+- `src/decoder.rs` — `IS_KNOWN_VIS` const, `restart_vis_detection` helper, `SstvEvent::UnknownVis`
+  variant + handling, refactor the post-image reseed to use the helper, `VisDetector::new(IS_KNOWN_VIS)`
+  at every construction site (`SstvDecoder::new`, the helper).
+- `src/vis.rs` — `R12BW_VIS_CODE` const; `match_vis_pattern` `is_known` parameter + keep-searching
+  + parity shape; `VisDetector::is_known_vis` field + `new` signature (`process` unchanged); doc
+  updates; new `match_vis_pattern` unit tests; test-encoder/test-comment literal cleanup.
+- `src/error.rs` — delete `UnknownVisCode` variant + its test.
+- `src/modespec.rs` — tweak the `lookup` `#27` doc note.
+- `tests/unknown_vis.rs` — new integration test (`test-support` feature).
+- `docs/intentional-deviations.md` — new VIS deviation entry.
+- `CHANGELOG.md` — `[Unreleased]` entries.
+
+## Verification
+
+Full local CI gate after the work, per repo convention:
+
+- `cargo test --all-features --locked --release`
+- `cargo fmt --all -- --check`
+- `cargo clippy --all-targets --all-features -- -D warnings`
+- `RUSTDOCFLAGS=-D warnings cargo doc --no-deps --all-features`

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -319,7 +319,7 @@ impl SstvDecoder {
                         Self::restart_vis_detection(
                             &mut self.vis,
                             self.working_samples_emitted,
-                            residual,
+                            &residual,
                         );
                         continue;
                     }
@@ -382,7 +382,7 @@ impl SstvDecoder {
                     Self::restart_vis_detection(
                         &mut self.vis,
                         self.working_samples_emitted,
-                        trailing,
+                        &trailing,
                     );
                     break;
                 }
@@ -399,16 +399,13 @@ impl SstvDecoder {
     /// replaced rather than re-used. `working_samples_emitted` is the
     /// decoder's running working-rate output count (used to anchor the fresh
     /// detector).
-    // `leftover_audio` is taken by value because both call sites hand over an
-    // owned `Vec` they no longer need (`take_residual_buffer()` / `mem::take`).
-    #[allow(clippy::needless_pass_by_value)]
     fn restart_vis_detection(
         vis: &mut crate::vis::VisDetector,
         working_samples_emitted: u64,
-        leftover_audio: Vec<f32>,
+        leftover_audio: &[f32],
     ) {
         *vis = crate::vis::VisDetector::new(IS_KNOWN_VIS);
-        vis.process(&leftover_audio, working_samples_emitted);
+        vis.process(leftover_audio, working_samples_emitted);
     }
 
     /// Run [`find_sync`] over the buffered sync track, then decode every

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -32,6 +32,22 @@ pub enum SstvEvent {
         /// (`vis.c` line 106 → `video.c` line 406).
         hedr_shift_hz: f64,
     },
+    /// A VIS header parsed and passed parity, but its 7-bit code maps to no
+    /// SSTV mode this build can decode (reserved / undefined, or a mode not
+    /// yet implemented). The decoder discards the burst and resumes scanning
+    /// for the next VIS — equivalent to slowrx's `printf("Unknown VIS %d")`
+    /// plus its retry-`GetVIS()` loop.
+    UnknownVis {
+        /// The 7-bit VIS code that did not resolve.
+        code: u8,
+        /// Radio mistuning offset in Hz: `observed_leader_hz - 1900` (the
+        /// same quantity as [`SstvEvent::VisDetected`]'s `hedr_shift_hz`).
+        /// Surfaced for diagnostics; the burst is dropped, so it does not
+        /// feed any decode.
+        hedr_shift_hz: f64,
+        /// Working-rate (11025 Hz) sample offset where the VIS stop bit ended.
+        sample_offset: u64,
+    },
     /// One scan line completed (callers may render incrementally).
     ///
     /// For PD and Robot 72: `pixels` is fully composed at emission time
@@ -287,10 +303,25 @@ impl SstvDecoder {
                             }));
                             continue; // re-enter loop to process leftover audio
                         }
-                        // Unknown VIS codes silently drop. Reset the
-                        // detector's buffer so it does not accumulate
-                        // forever on uninterpretable bursts.
-                        let _ = self.vis.take_residual_buffer();
+                        // Unknown VIS code: surface it so stream-monitoring
+                        // callers know a burst arrived, then reseed the
+                        // detector (the `#40` re-anchor contract) on the
+                        // post-stop-bit residue and re-enter the loop — a
+                        // back-to-back VIS in the residue then surfaces in
+                        // this same `process` call. Mirrors the known-code
+                        // branch's `continue`.
+                        out.push(SstvEvent::UnknownVis {
+                            code: detected.code,
+                            hedr_shift_hz: detected.hedr_shift_hz,
+                            sample_offset: detected.end_sample,
+                        });
+                        let residual = self.vis.take_residual_buffer();
+                        Self::restart_vis_detection(
+                            &mut self.vis,
+                            self.working_samples_emitted,
+                            residual,
+                        );
+                        continue;
                     }
                     break;
                 }
@@ -348,13 +379,36 @@ impl SstvDecoder {
                     // detected without any caller intervention. Closes #31.
                     let trailing = std::mem::take(&mut d.audio);
                     self.state = State::AwaitingVis;
-                    self.vis = crate::vis::VisDetector::new(IS_KNOWN_VIS);
-                    self.vis.process(&trailing, self.working_samples_emitted);
+                    Self::restart_vis_detection(
+                        &mut self.vis,
+                        self.working_samples_emitted,
+                        trailing,
+                    );
                     break;
                 }
             }
         }
         out
+    }
+
+    /// Discard `vis` and start a fresh detector on `leftover_audio`
+    /// (post-stop-bit residue, or trailing image audio). Honors the `#40`
+    /// re-anchor contract documented on
+    /// [`crate::vis::VisDetector::take_residual_buffer`] — a spent detector's
+    /// `hops_completed` / `history` state is never reset, so it must be
+    /// replaced rather than re-used. `working_samples_emitted` is the
+    /// decoder's running working-rate output count (used to anchor the fresh
+    /// detector).
+    // `leftover_audio` is taken by value because both call sites hand over an
+    // owned `Vec` they no longer need (`take_residual_buffer()` / `mem::take`).
+    #[allow(clippy::needless_pass_by_value)]
+    fn restart_vis_detection(
+        vis: &mut crate::vis::VisDetector,
+        working_samples_emitted: u64,
+        leftover_audio: Vec<f32>,
+    ) {
+        *vis = crate::vis::VisDetector::new(IS_KNOWN_VIS);
+        vis.process(&leftover_audio, working_samples_emitted);
     }
 
     /// Run [`find_sync`] over the buffered sync track, then decode every

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -138,6 +138,12 @@ struct DecodingState {
 /// pad the buffer to absorb additional offset.
 const FINDSYNC_AUDIO_HEADROOM: f64 = 1.00;
 
+/// `|c| crate::modespec::lookup(c).is_some()` as an `fn` pointer — the
+/// "is this VIS code one we can decode?" predicate handed to every
+/// [`crate::vis::VisDetector`] (issue #89 A3). The closure captures nothing,
+/// so it coerces to `fn(u8) -> bool` in const context.
+const IS_KNOWN_VIS: fn(u8) -> bool = |c| crate::modespec::lookup(c).is_some();
+
 /// Streaming SSTV decoder. Push audio buffers in via
 /// [`Self::process`]; consume the returned events.
 pub struct SstvDecoder {
@@ -190,7 +196,7 @@ impl SstvDecoder {
     pub fn new(input_sample_rate_hz: u32) -> Result<Self> {
         Ok(Self {
             resampler: Resampler::new(input_sample_rate_hz)?,
-            vis: crate::vis::VisDetector::new(),
+            vis: crate::vis::VisDetector::new(IS_KNOWN_VIS),
             pd_demod: crate::mode_pd::PdDemod::new(),
             snr_est: crate::snr::SnrEstimator::new(),
             state: State::AwaitingVis,
@@ -342,7 +348,7 @@ impl SstvDecoder {
                     // detected without any caller intervention. Closes #31.
                     let trailing = std::mem::take(&mut d.audio);
                     self.state = State::AwaitingVis;
-                    self.vis = crate::vis::VisDetector::new();
+                    self.vis = crate::vis::VisDetector::new(IS_KNOWN_VIS);
                     self.vis.process(&trailing, self.working_samples_emitted);
                     break;
                 }
@@ -499,7 +505,7 @@ impl SstvDecoder {
         self.state = State::AwaitingVis;
         self.samples_processed = 0;
         self.working_samples_emitted = 0;
-        self.vis = crate::vis::VisDetector::new();
+        self.vis = crate::vis::VisDetector::new(IS_KNOWN_VIS);
         self.resampler.reset_state();
         self.pd_demod = crate::mode_pd::PdDemod::new();
         self.snr_est = crate::snr::SnrEstimator::new();

--- a/src/error.rs
+++ b/src/error.rs
@@ -13,12 +13,6 @@ pub enum Error {
         /// The rate the caller passed.
         got: u32,
     },
-
-    /// VIS code does not map to a known SSTV mode.
-    ///
-    /// The `u8` value is the raw 7-bit VIS byte read from the audio stream.
-    #[error("VIS code {0:#04x} does not map to a known SSTV mode")]
-    UnknownVisCode(u8),
 }
 
 /// Convenient `Result` alias used throughout the crate.
@@ -37,12 +31,4 @@ mod tests {
         );
     }
 
-    #[test]
-    fn unknown_vis_code_renders_in_hex() {
-        let e = Error::UnknownVisCode(0x42);
-        assert_eq!(
-            e.to_string(),
-            "VIS code 0x42 does not map to a known SSTV mode"
-        );
-    }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -30,5 +30,4 @@ mod tests {
             "invalid sample rate: 0 (must be > 0 and ≤ 192000)"
         );
     }
-
 }

--- a/src/modespec.rs
+++ b/src/modespec.rs
@@ -127,10 +127,11 @@ pub enum SyncPosition {
 /// returns `None`. In slowrx (`vis.c:172-174`), an unknown VIS code causes
 /// `GetVIS()` to return 0 and `Listen()` loops back to re-detect
 /// (`do { ... } while (Mode == 0)`). Rust's equivalent is `None` from
-/// this function: the caller in `SstvDecoder::process` drains the VIS
-/// detector's buffer and stays in `AwaitingVis`, which has the same
-/// effect as slowrx's re-detect loop. Both treat an unknown code as a
-/// silent "try again" rather than an error.
+/// this function: the caller in `SstvDecoder::process` emits
+/// `SstvEvent::UnknownVis`, reseeds the VIS detector on the post-stop-bit
+/// residue, and stays in `AwaitingVis` — the same "try again" effect as
+/// slowrx's re-detect loop (slowrx's `printf("Unknown VIS")` becomes the
+/// `UnknownVis` event). An unknown code is never an `Error`.
 #[must_use]
 pub fn lookup(vis_code: u8) -> Option<ModeSpec> {
     match vis_code {

--- a/src/vis.rs
+++ b/src/vis.rs
@@ -33,6 +33,15 @@ pub(crate) const WINDOW_SAMPLES: usize = (0.020 * WORKING_SAMPLE_RATE_HZ as f64)
 pub(crate) const FFT_LEN: usize = 512;
 pub(crate) const HISTORY_LEN: usize = 45; // slowrx HedrBuf size
 
+/// VIS code for the (unimplemented) Robot 12 B/W mode. R12BW inverts the
+/// parity bit (slowrx `vis.c:116`). No `ModeSpec` exists for it yet, so
+/// `crate::modespec::lookup` returns `None` for it; `match_vis_pattern`
+/// still classifies it so a future R12BW implementation that adds it to
+/// `lookup` works without re-touching the parity logic.
+//
+// TODO: when R12BW gains a `ModeSpec`, derive this from `modespec`.
+pub(crate) const R12BW_VIS_CODE: u8 = 0x06;
+
 const SEARCH_LO_HZ: f64 = 500.0;
 const SEARCH_HI_HZ: f64 = 3300.0;
 
@@ -375,16 +384,20 @@ fn match_vis_pattern(tones: &[f64; HISTORY_LEN]) -> Option<(u8, f64, usize)> {
                     code |= bit << k;
                     parity ^= bit;
                 } else {
-                    // R12BW (`0x06`) inverts parity per slowrx `vis.c:116`:
-                    // `if (VISmap[VIS] == R12BW) Parity = !Parity;`. V1
-                    // doesn't decode R12BW (lookup returns None for 0x06),
-                    // but the parity check must still pass so a future V2
-                    // implementation that adds R12BW to the lookup table
-                    // doesn't silently reject every R12BW burst.
-                    let expected = if code == 0x06 { bit ^ 1 } else { bit };
-                    if parity != expected {
+                    // `bit` is the received parity bit. R12BW flips the
+                    // *accumulated* parity per slowrx `vis.c:116`:
+                    // `if (VISmap[VIS] == R12BW) Parity = !Parity;`. No
+                    // `ModeSpec` exists for R12BW yet (`lookup` returns
+                    // `None` for `R12BW_VIS_CODE`), but the parity check
+                    // must still pass so a future R12BW implementation that
+                    // adds it to `lookup` is not silently broken.
+                    if code == R12BW_VIS_CODE {
+                        parity ^= 1;
+                    }
+                    if parity != bit {
                         bit_ok = false;
                     }
+                    break; // k == 7 is the last iteration; explicit break mirrors the classify-fail arm
                 }
             }
             if bit_ok {
@@ -490,11 +503,11 @@ pub mod tests {
             parity ^= bit;
             emit(bit_freq(bit), 0.030, &mut out);
         }
-        // R12BW (code 0x06) inverts the parity bit per slowrx `vis.c:116`.
+        // R12BW (`R12BW_VIS_CODE`) inverts the parity bit per slowrx `vis.c:116`.
         // The detector's `match_vis_pattern` does the same inversion when
         // checking, so synthetic bursts must follow the same convention or
         // they'd fail parity at the receiver.
-        let parity_bit = if code == 0x06 { parity ^ 1 } else { parity };
+        let parity_bit = if code == R12BW_VIS_CODE { parity ^ 1 } else { parity };
         emit(bit_freq(parity_bit), 0.030, &mut out);
         emit(break_f, 0.030, &mut out);
         out
@@ -661,7 +674,7 @@ pub mod tests {
         emit(break_f, 0.030, &mut out);
         let mut parity = 0u8;
         for b in 0..7 {
-            let bit = (0x06_u8 >> b) & 1;
+            let bit = (R12BW_VIS_CODE >> b) & 1;
             parity ^= bit;
             emit(bit_freq(bit), 0.030, &mut out);
         }

--- a/src/vis.rs
+++ b/src/vis.rs
@@ -516,7 +516,11 @@ pub mod tests {
             p0 ^= b;
             t[18 + 3 * k] = bit_freq(b);
         }
-        let p0 = if phase0_code == R12BW_VIS_CODE { p0 ^ 1 } else { p0 };
+        let p0 = if phase0_code == R12BW_VIS_CODE {
+            p0 ^ 1
+        } else {
+            p0
+        };
         t[39] = bit_freq(p0);
         // Phase i=1: data bits at tones[19 + 3k], parity at tones[40].
         if let Some(c) = phase1_code {
@@ -579,7 +583,11 @@ pub mod tests {
         // The detector's `match_vis_pattern` does the same inversion when
         // checking, so synthetic bursts must follow the same convention or
         // they'd fail parity at the receiver.
-        let parity_bit = if code == R12BW_VIS_CODE { parity ^ 1 } else { parity };
+        let parity_bit = if code == R12BW_VIS_CODE {
+            parity ^ 1
+        } else {
+            parity
+        };
         emit(bit_freq(parity_bit), 0.030, &mut out);
         emit(break_f, 0.030, &mut out);
         out

--- a/src/vis.rs
+++ b/src/vis.rs
@@ -64,6 +64,11 @@ pub(crate) struct VisDetector {
     /// Hops FFT'd; combined with `audio_origin_sample` it locates each window.
     hops_completed: u64,
     detected: Option<DetectedVis>,
+    /// `|c| crate::modespec::lookup(c).is_some()` — passed to
+    /// [`match_vis_pattern`] so the matcher keeps searching alignments for a
+    /// *known* VIS code (issue #89 A3). An `fn` pointer: the closure captures
+    /// nothing, so it coerces.
+    is_known_vis: fn(u8) -> bool,
 }
 
 /// Result of a successful VIS detection.
@@ -82,7 +87,7 @@ pub(crate) struct DetectedVis {
 impl VisDetector {
     /// Construct a fresh VIS detector. Allocates the FFT plan + reusable
     /// buffers; reuse across many `process` calls.
-    pub fn new() -> Self {
+    pub fn new(is_known_vis: fn(u8) -> bool) -> Self {
         let mut planner = FftPlanner::<f32>::new();
         let fft = planner.plan_fft_forward(FFT_LEN);
         let scratch_len = fft.get_inplace_scratch_len();
@@ -98,6 +103,7 @@ impl VisDetector {
             history_filled: 0,
             hops_completed: 0,
             detected: None,
+            is_known_vis,
         }
     }
 
@@ -130,7 +136,7 @@ impl VisDetector {
 
             if self.history_filled >= HISTORY_LEN {
                 if let Some((code, hedr_shift_hz, i_match)) =
-                    match_vis_pattern(&self.rotated_history())
+                    match_vis_pattern(&self.rotated_history(), self.is_known_vis)
                 {
                     // Stop-bit hop = `tone[14*3+i]` = `(2-i)` hops back
                     // from the latest. The bit is 30 ms = 3 hops long,
@@ -330,8 +336,9 @@ fn estimate_peak_freq(spectrum: &[Complex<f32>]) -> f64 {
 }
 
 /// Match the 14-window VIS pattern in a 45-entry frequency history.
-/// Tries 9 alignments (i × j, 3 phases × 3 leader candidates). Returns
-/// `(vis_code, hedr_shift_hz, i)` on detection (`hedr_shift_hz =
+/// Tries 9 alignments (i × j, 3 phases × 3 leader candidates). Returns the
+/// first **known** parity-passing alignment as `(vis_code, hedr_shift_hz, i)`
+/// (or the first parity-passing **unknown** code as a fallback) (`hedr_shift_hz =
 /// observed_leader - 1900`, `i` is the matched phase). Uses relative
 /// ±25 Hz tolerance — slowrx vis.c lines 82-104. (Indices like `3 + i`
 /// spell out slowrx's `tone[1*3+i]` so parity with C is one-to-one.)
@@ -347,8 +354,22 @@ fn estimate_peak_freq(spectrum: &[Complex<f32>]) -> f64 {
 /// exit is a quirk of its `HedrShift`-set-before-parity-check pattern. The
 /// difference only manifests on mistuned radios (`HedrShift` ≠ 0) where the
 /// first pattern match has parity failure — a rare edge case in practice.
-fn match_vis_pattern(tones: &[f64; HISTORY_LEN]) -> Option<(u8, f64, usize)> {
+///
+/// **Keep-searching for a known code (issue #89, A3):** like slowrx (`vis.c`),
+/// this tries all 9 alignments and returns the *first known* code (`is_known`).
+/// A clean burst whose only parity-passing alignment maps to an *unknown* code
+/// (a real R12BW transmission, or an unimplemented mode) is still returned — as
+/// the `first_unknown` fallback — so the caller can surface it via
+/// `SstvEvent::UnknownVis` (added in #89 — note: a plain code span, not an
+/// intra-doc link, since `vis` is below `decoder` in the module graph). See
+/// `docs/intentional-deviations.md`
+/// ("VIS: keep-searching for a known code; surface clean unknown bursts").
+fn match_vis_pattern(
+    tones: &[f64; HISTORY_LEN],
+    is_known: impl Fn(u8) -> bool,
+) -> Option<(u8, f64, usize)> {
     let tol = TONE_TOLERANCE_HZ;
+    let mut first_unknown: Option<(u8, f64, usize)> = None;
     for i in 0..3 {
         for j in 0..3 {
             let leader = tones[j];
@@ -401,11 +422,15 @@ fn match_vis_pattern(tones: &[f64; HISTORY_LEN]) -> Option<(u8, f64, usize)> {
                 }
             }
             if bit_ok {
-                return Some((code, leader - LEADER_HZ, i));
+                let m = (code, leader - LEADER_HZ, i);
+                if is_known(code) {
+                    return Some(m); // slowrx breaks on the first known code
+                }
+                first_unknown.get_or_insert(m);
             }
         }
     }
-    None
+    first_unknown
 }
 
 #[inline]
@@ -466,6 +491,53 @@ pub mod tests {
             .collect()
     }
 
+    /// Build a 45-entry tone history (`HedrBuf` order: `[0]` oldest) that the
+    /// matcher reads as `phase0_code` at phase `i = 0` and, if `phase1_code`
+    /// is `Some(c)`, as `c` at phase `i = 1`. Phase `i = 2`'s bit slots are
+    /// left as leader tones, so it fails bit classification (never matches).
+    /// All leader / break slots are positioned so phases 0 and 1 pass those
+    /// checks. Tones are at the un-shifted (`hedr_shift = 0`) frequencies.
+    fn synth_tone_history(phase0_code: u8, phase1_code: Option<u8>) -> [f64; HISTORY_LEN] {
+        let leader = LEADER_HZ;
+        let break_f = leader + BREAK_HZ_OFFSET;
+        let zero_f = leader + BIT_ZERO_OFFSET;
+        let one_f = leader + BIT_ONE_OFFSET;
+        let bit_freq = |b: u8| if b == 1 { one_f } else { zero_f };
+        let mut t = [leader; HISTORY_LEN];
+        // Break tones — checked at indices 15+i and 42+i for i in 0..3.
+        t[15] = break_f;
+        t[16] = break_f;
+        t[42] = break_f;
+        t[43] = break_f;
+        // Phase i=0: data bits at tones[18 + 3k] (k=0..6), parity at tones[39].
+        let mut p0 = 0u8;
+        for k in 0..7 {
+            let b = (phase0_code >> k) & 1;
+            p0 ^= b;
+            t[18 + 3 * k] = bit_freq(b);
+        }
+        let p0 = if phase0_code == R12BW_VIS_CODE { p0 ^ 1 } else { p0 };
+        t[39] = bit_freq(p0);
+        // Phase i=1: data bits at tones[19 + 3k], parity at tones[40].
+        if let Some(c) = phase1_code {
+            let mut p1 = 0u8;
+            for k in 0..7 {
+                let b = (c >> k) & 1;
+                p1 ^= b;
+                t[19 + 3 * k] = bit_freq(b);
+            }
+            let p1 = if c == R12BW_VIS_CODE { p1 ^ 1 } else { p1 };
+            t[40] = bit_freq(p1);
+        }
+        t
+    }
+
+    /// `is_known` predicate as used in production: a 7-bit VIS code is "known"
+    /// iff it maps to a `ModeSpec`.
+    fn vis_known(code: u8) -> bool {
+        crate::modespec::lookup(code).is_some()
+    }
+
     /// Build a synthetic VIS burst encoding `code` with even parity.
     /// `freq_offset_hz` shifts every tone (mistuned-radio test fixture).
     /// Continuous-phase: avoids bit-boundary discontinuities that would
@@ -520,7 +592,7 @@ pub mod tests {
 
     /// Helper: feed `audio` into a fresh detector and return the result.
     fn run(audio: &[f32]) -> Option<DetectedVis> {
-        let mut det = VisDetector::new();
+        let mut det = VisDetector::new(vis_known);
         det.process(audio, audio.len() as u64);
         det.take_detected()
     }
@@ -701,6 +773,38 @@ pub mod tests {
         }
         audio.extend(std::iter::repeat_n(0.0_f32, 256));
         assert!(run(&audio).is_none());
+    }
+
+    #[test]
+    fn match_vis_pattern_clean_known_code() {
+        // 0x5F == PD120 is in the lookup table.
+        let tones = synth_tone_history(0x5F, None);
+        let m = match_vis_pattern(&tones, vis_known).expect("known code matches");
+        assert_eq!(m.0, 0x5F);
+        assert!(m.1.abs() < 1e-9, "hedr_shift should be 0, got {}", m.1);
+        assert_eq!(m.2, 0, "matched at phase i = 0");
+    }
+
+    #[test]
+    fn match_vis_pattern_clean_unknown_code_falls_back() {
+        // 0x01 is a valid 7-bit code with parity 1, but maps to no mode.
+        assert!(crate::modespec::lookup(0x01).is_none());
+        let tones = synth_tone_history(0x01, None);
+        let m = match_vis_pattern(&tones, vis_known)
+            .expect("an unknown-but-parity-passing code is still returned (fallback)");
+        assert_eq!(m.0, 0x01);
+        assert_eq!(m.2, 0);
+    }
+
+    #[test]
+    fn match_vis_pattern_prefers_known_over_earlier_unknown() {
+        // Phase i=0 spells unknown 0x01; phase i=1 spells known 0x5F.
+        // The (i,j) loop hits i=0 first — the old code returned 0x01 there;
+        // the fix must skip it and return 0x5F at i=1.
+        let tones = synth_tone_history(0x01, Some(0x5F));
+        let m = match_vis_pattern(&tones, vis_known).expect("known code at a later alignment");
+        assert_eq!(m.0, 0x5F, "should skip the earlier unknown 0x01 alignment");
+        assert_eq!(m.2, 1, "matched at phase i = 1");
     }
 
     #[cfg(test)]

--- a/src/vis.rs
+++ b/src/vis.rs
@@ -360,9 +360,7 @@ fn estimate_peak_freq(spectrum: &[Complex<f32>]) -> f64 {
 /// A clean burst whose only parity-passing alignment maps to an *unknown* code
 /// (a real R12BW transmission, or an unimplemented mode) is still returned — as
 /// the `first_unknown` fallback — so the caller can surface it via
-/// `SstvEvent::UnknownVis` (added in #89 — note: a plain code span, not an
-/// intra-doc link, since `vis` is below `decoder` in the module graph). See
-/// `docs/intentional-deviations.md`
+/// `SstvEvent::UnknownVis`. See `docs/intentional-deviations.md`
 /// ("VIS: keep-searching for a known code; surface clean unknown bursts").
 fn match_vis_pattern(
     tones: &[f64; HISTORY_LEN],

--- a/tests/unknown_vis.rs
+++ b/tests/unknown_vis.rs
@@ -33,8 +33,18 @@ fn decoder_emits_unknown_vis_then_recovers() {
         .unwrap_or_else(|| panic!("no UnknownVis event for 0x{UNKNOWN_CODE:02x}; got {events:?}"));
     let detected_at = events
         .iter()
-        .position(|e| matches!(e, SstvEvent::VisDetected { mode: SstvMode::Pd120, .. }))
-        .unwrap_or_else(|| panic!("no VisDetected for PD120 after the unknown burst; got {events:?}"));
+        .position(|e| {
+            matches!(
+                e,
+                SstvEvent::VisDetected {
+                    mode: SstvMode::Pd120,
+                    ..
+                }
+            )
+        })
+        .unwrap_or_else(|| {
+            panic!("no VisDetected for PD120 after the unknown burst; got {events:?}")
+        });
     assert!(
         unknown_at < detected_at,
         "UnknownVis should precede the recovered VisDetected; got {events:?}"

--- a/tests/unknown_vis.rs
+++ b/tests/unknown_vis.rs
@@ -1,0 +1,54 @@
+//! `SstvDecoder` must surface an unrecognized-but-well-formed VIS burst as
+//! `SstvEvent::UnknownVis` (rather than dropping it silently) and then keep
+//! detecting subsequent valid VIS bursts — i.e. the unknown-code path reseeds
+//! the VIS detector per the `#40` re-anchor contract (audit #89: A1 + C1).
+
+#![cfg(feature = "test-support")]
+#![allow(clippy::expect_used, clippy::cast_possible_truncation, clippy::panic)]
+
+use slowrx::{SstvDecoder, SstvEvent, SstvMode, WORKING_SAMPLE_RATE_HZ};
+
+/// 0x01 is a valid 7-bit VIS code (parity 1) that maps to no SSTV mode.
+const UNKNOWN_CODE: u8 = 0x01;
+/// 0x5F == PD120.
+const PD120_CODE: u8 = 0x5F;
+
+#[test]
+fn decoder_emits_unknown_vis_then_recovers() {
+    // burst 1: a well-formed VIS for an unknown code.
+    // burst 2: a well-formed VIS for PD120, immediately following.
+    // trailing zeros so the resampler's FIR group delay still yields a full
+    // set of stop-bit windows for burst 2.
+    let mut audio = slowrx::__test_support::vis::synth_vis(UNKNOWN_CODE, 0.0);
+    audio.extend(slowrx::__test_support::vis::synth_vis(PD120_CODE, 0.0));
+    audio.extend(std::iter::repeat_n(0.0_f32, 512));
+
+    let mut decoder = SstvDecoder::new(WORKING_SAMPLE_RATE_HZ).expect("decoder construct");
+    let events = decoder.process(&audio);
+
+    // Expect: UnknownVis { code: 0x01, .. } then VisDetected { mode: Pd120, .. }.
+    let unknown_at = events
+        .iter()
+        .position(|e| matches!(e, SstvEvent::UnknownVis { code, .. } if *code == UNKNOWN_CODE))
+        .unwrap_or_else(|| panic!("no UnknownVis event for 0x{UNKNOWN_CODE:02x}; got {events:?}"));
+    let detected_at = events
+        .iter()
+        .position(|e| matches!(e, SstvEvent::VisDetected { mode: SstvMode::Pd120, .. }))
+        .unwrap_or_else(|| panic!("no VisDetected for PD120 after the unknown burst; got {events:?}"));
+    assert!(
+        unknown_at < detected_at,
+        "UnknownVis should precede the recovered VisDetected; got {events:?}"
+    );
+
+    // The recovered detection's sample_offset should be a sane working-rate
+    // index (non-zero, and not wildly past the end of the fed audio). Exact
+    // semantics post-restart (relative-to-restart vs absolute) are tracked
+    // separately; this is only a gross-corruption guard.
+    if let SstvEvent::VisDetected { sample_offset, .. } = &events[detected_at] {
+        assert!(
+            *sample_offset > 0 && (*sample_offset as usize) <= audio.len(),
+            "VisDetected.sample_offset = {sample_offset} out of [1, {}]",
+            audio.len()
+        );
+    }
+}


### PR DESCRIPTION
Closes #89 (audit bundle 5 of 12 — IDs A1, A3, C1, C5, C15). Design/plan: `docs/superpowers/specs/2026-05-11-issue-89-vis-detector-fidelity-design.md` + `docs/superpowers/plans/2026-05-11-issue-89-vis-detector-fidelity.md`.

### Changes

- **A1 (High) — reseed the VIS detector after an unknown code.** `SstvDecoder::process`'s unknown-VIS branch drained the detector's residual buffer but never reconstructed `self.vis`, violating the `#40` re-anchor contract documented on `VisDetector::take_residual_buffer` (`hops_completed` / `history` carried over → next detection corrupted). It's now reseeded via a new `restart_vis_detection` associated fn that the post-image reseed path also uses (DRY, no behavior change there).
- **A3 — keep searching for a *known* VIS code.** `match_vis_pattern` took the first parity-passing `(i,j)` alignment regardless of mode. Now it takes an `is_known` predicate, tries all 9 alignments, returns the first *known* code (like slowrx, which breaks on the first known one), and falls back to the first parity-passing *unknown* code so the caller can still report it. `VisDetector` stores the predicate as a `fn(u8) -> bool` field; `SstvDecoder` holds the one value in `const IS_KNOWN_VIS`.
- **C1 — surface unknown VIS bursts.** New `SstvEvent::UnknownVis { code, hedr_shift_hz, sample_offset }` (additive — `SstvEvent` is `#[non_exhaustive]`); the decoder emits it then reseeds & re-scans. Removed the never-constructed `Error::UnknownVisCode`. (`process()` doesn't return `Result`; this is the slowrx `printf("Unknown VIS")` equivalent.)
- **C5 — `R12BW_VIS_CODE` named constant** replacing bare `0x06` literals.
- **C15 — faithful parity-check shape** in `match_vis_pattern`: flip the *accumulated* parity for R12BW (matching slowrx `vis.c:116`'s `Parity = !Parity`) instead of flipping the expected bit, with an explicit `break` so the bit loop's two exits are symmetric. Functionally identical for all codes.

### Tests

- `tests/unknown_vis.rs::decoder_emits_unknown_vis_then_recovers` — feeds `[unknown VIS][PD120 VIS][pad]` in one `process()` call; asserts `UnknownVis{0x01}` then `VisDetected{Pd120}` with a sane `sample_offset` (fails on the old stale-detector / drop-residual / `break` path).
- 3 new `match_vis_pattern` unit tests in `vis.rs` (`clean_known_code`, `clean_unknown_code_falls_back`, `prefers_known_over_earlier_unknown` — the last is the load-bearing A3 regression; verified to fail against the old body).
- Full suite green in release: 115 lib + 11 roundtrip + 1 integration + 1 doctest + the no_vis / cli.

### Docs

- New `docs/intentional-deviations.md` section ("VIS: keep-searching for a known code; surface clean unknown bursts").
- `CHANGELOG.md` `[Unreleased]` (Added / Fixed / Removed / Internal).
- `modespec::lookup` `#27` note refreshed.

### Out of scope (deferred to other audit issues)

- The post-image `break`-vs-`continue` and `mem::take`-vs-`split_off` of the decoded audio buffer (#90).
- `sample_offset` absolute-vs-relative-after-restart semantics (#90).
- Wider `vis.rs` decomposition (#88).

CI gate passes locally: `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --all-features --locked --release`, `RUSTDOCFLAGS=-D warnings cargo doc --no-deps --all-features`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Unknown VIS codes that pass validation checks now surface as dedicated events, providing visibility into unrecognized signals.

* **Bug Fixes**
  * Fixed decoder state management issue that prevented continued VIS detection following an unknown code encounter.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jasonherald/slowrx.rs/pull/98)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->