### PR TITLE
chore(release): 0.5.2 — VIS detector fidelity (#89) + multi-image streaming (#90)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.2] - 2026-05-11
+
+The first two items off the post-V2.4 code-review audit backlog (epic #97):
+**VIS detector fidelity** (#89) and **multi-image streaming** (#90). Adds the
+`SstvEvent::UnknownVis` event for unrecognized-but-well-formed VIS bursts; the
+only removal is the never-constructed `Error::UnknownVisCode` variant. No
+change to decodable modes — still PD120/180/240 + Robot 24/36/72 + Scottie
+1/2/DX + Martin 1/2.
+
 ### Added
 
 - **`SstvEvent::UnknownVis { code, hedr_shift_hz, sample_offset }`** — a VIS

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -707,7 +707,7 @@ checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "slowrx"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slowrx"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2021"
 rust-version = "1.85"
 description = "Pure-Rust SSTV (Slow-Scan TV) decoder library — a port of slowrx by Oona Räisänen"

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 ## Status
 
-🛰️ **0.5.0 — V2.4 published.** PD120, PD180, PD240, Robot 24, Robot 36, Robot 72, Scottie 1, Scottie 2, Scottie DX, Martin 1, and Martin 2 decoding from raw audio. All four V2 mode families landed; the [V2 roadmap](https://github.com/jasonherald/slowrx.rs/issues/9) is closed.
+🛰️ **0.5.2 — V2.4 published.** PD120, PD180, PD240, Robot 24, Robot 36, Robot 72, Scottie 1, Scottie 2, Scottie DX, Martin 1, and Martin 2 decoding from raw audio. All four V2 mode families landed; the [V2 roadmap](https://github.com/jasonherald/slowrx.rs/issues/9) is closed. Post-V2.4 cleanup (code-review audit backlog, [epic #97](https://github.com/jasonherald/slowrx.rs/issues/97)) is in progress.
 
 PD120, PD180, and Robot 36 are validated end-to-end against real-radio
 captures: PD120/PD180 against the ARISS Dec-2017 corpus (6 of 7


### PR DESCRIPTION
Cuts **0.5.2**, bundling the first two items off the post-V2.4 code-review audit backlog ([epic #97](https://github.com/jasonherald/slowrx.rs/issues/97)) that landed in #98 and #100:

- **#89 — VIS detector fidelity** (A1/A3/C1/C5/C15): reseed the VIS detector after an unknown code (the `#40` re-anchor contract); `match_vis_pattern` keeps searching its 9 alignments for a *known* code, slowrx-style; new `SstvEvent::UnknownVis { code, hedr_shift_hz, sample_offset }`; removed the never-constructed `Error::UnknownVisCode`; `R12BW_VIS_CODE` const + faithful parity-check shape.
- **#90 — Multi-image streaming** (A2/D4): back-to-back transmissions decode every image within one `process()` call (`process` re-enters VIS detection in-place after `ImageComplete` instead of `break`-ing); the post-image VIS-detector re-arm scans only the tail of the decoded image audio, not the whole ~1.4–3 M-sample buffer.

### This PR

- `Cargo.toml` / `Cargo.lock`: `0.5.1` → `0.5.2`.
- `CHANGELOG.md`: `[Unreleased]` queue finalized into `## [0.5.2] - 2026-05-11` (Added / Fixed / Performance / Removed / Internal).
- `README.md`: status line `0.5.0` → `0.5.2`, note the audit-backlog work in progress.
- No code change.

### Semver note

`Error::UnknownVisCode` removal is technically a breaking change to the `#[non_exhaustive]` `Error` enum, but the variant was **never constructed** (`SstvDecoder::process` doesn't return `Result`; unknown codes are now reported via `SstvEvent::UnknownVis`, which is an additive variant on `#[non_exhaustive] SstvEvent`). Treated as a patch bump for a 0.x crate; flagged in the CHANGELOG `### Removed` section.

### After merge

`git tag -a v0.5.2 -m "..."` on the merge commit → push tag → `cargo publish`. (Heads-up: `cargo publish --dry-run` fails *locally* because the gitignored `original/` vendored slowrx C source is present in the working tree and cargo wants to package `original/slowrx/README.md`; CI's `publish-dryrun` job clones fresh without `original/` so it passes. For the actual publish, do it from a fresh clone or pass `--allow-dirty` — and consider a follow-up to verify the `include` allowlist actually excludes `original/` from published `.crate` files.)

CI gate passes locally: `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --all-features --locked --release` (full suite green), `RUSTDOCFLAGS=-D warnings cargo doc --no-deps --all-features`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Released version 0.5.2 with documented VIS detector fidelity improvements and multi-image streaming support
  * Updated release notes and status to reflect all four V2 mode families now available
  * V2 roadmap closed; post-V2.4 code review cleanup currently in progress

* **Chores**
  * Version bumped to 0.5.2

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jasonherald/slowrx.rs/pull/101)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->