### PR TITLE
refactor(test_tone): extract continuous-phase FM tone generator + encoders off public API (#86)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Internal
 
+- **Extracted `crate::test_tone`** — the continuous-phase FM tone generator
+  (`SYNC_HZ` / `PORCH_HZ` / `SEPTR_HZ` / `BLACK_HZ` / `WHITE_HZ` consts,
+  `lum_to_freq`, the `ToneWriter` struct with cumulative-target `fill_to` and
+  per-tone-duration `fill_secs` methods) — shared by `pd_test_encoder` /
+  `robot_test_encoder` / `scottie_test_encoder` / `vis::tests` (four prior
+  copies; audit B9). Tightened the three test-encoder modules to `pub(crate)
+  mod` so `slowrx::pd_test_encoder::*` / `robot_test_encoder::*` /
+  `scottie_test_encoder::*` are no longer reachable externally; `__test_support`
+  switched from `pub use` re-exports to thin `pub fn` wrappers (the sole
+  consumer-facing path for the synthetic encoders — audit B10). Plus the
+  scottie double-doc-comment fix (E2), pointed smoke tests for `encode_pd` /
+  `encode_robot` (F11), and `unreachable!`/`assert!` cleanup in
+  `robot_test_encoder` (C17). Pure refactor: identical behavior; the
+  `slowrx::__test_support::mode_*::encode_*` paths are stable for existing
+  consumers (`tests/roundtrip.rs` unchanged). (#86; audit B9/B10/E2/F11/C17.)
+
 - **Extracted `crate::demod` and `crate::dsp` from `mode_pd.rs` / `snr.rs` /
   `vis.rs`.** `crate::demod` now owns the per-channel demod machinery
   (`ChannelDemod` — renamed from `PdDemod`, `decode_one_channel_into`,

--- a/docs/superpowers/plans/2026-05-14-issue-86-shared-test-tone-module.md
+++ b/docs/superpowers/plans/2026-05-14-issue-86-shared-test-tone-module.md
@@ -1,0 +1,833 @@
+# Issue #86 — Shared test-tone module + encoders off public API — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract `crate::test_tone` for the continuous-phase FM tone generator (B9 — consolidates four pre-#86 copies across `pd_test_encoder` / `robot_test_encoder` / `scottie_test_encoder` / `vis::tests`). Tighten the test-encoder modules to `pub(crate) mod` and switch `__test_support` to thin wrapper fns so `slowrx::pd_test_encoder::*` (etc.) is no longer reachable externally (B10). Plus E2 (scottie double-doc fix), F11 (encoder smoke tests), C17 partial (`unreachable!`/`expect!` cleanup).
+
+**Architecture:** Bottom-up migration. T1 creates `src/test_tone.rs` and migrates every consumer (3 encoders + `vis::tests`) atomically — no duplicate-then-delete intermediate state. T2 flips `pub mod *_test_encoder` → `pub(crate) mod` and replaces the `__test_support` `pub use` re-exports with thin `pub fn` wrappers. T3 cleans up the scottie double-doc and the `unreachable!`/`expect` redundancies. T4 adds encoder smoke tests. T5 lands CHANGELOG + final gate. After each task the crate compiles and the full release test suite passes.
+
+**Tech Stack:** Rust 2021, MSRV 1.85. Clippy config: `clippy::all`/`pedantic` = warn, `unwrap_used`/`panic`/`expect_used` = warn. CI gate: `cargo test --all-features --locked --release`, `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `RUSTDOCFLAGS=-D warnings cargo doc --no-deps --all-features`. No GPG signing.
+
+**Reference docs:**
+- Spec: `docs/superpowers/specs/2026-05-14-issue-86-shared-test-tone-module-design.md`
+- Audit: `docs/audits/2026-05-11-deep-code-review-audit.md` (IDs B9, B10, E2, F11, C17 partial)
+
+---
+
+## File Structure
+
+| File | Status | Role |
+|------|--------|------|
+| `src/test_tone.rs` | **new** (T1) | Generic continuous-phase FM tone generator: `SYNC_HZ` / `PORCH_HZ` / `SEPTR_HZ` / `BLACK_HZ` / `WHITE_HZ` consts, `lum_to_freq`, `ToneWriter` struct (with `new`/`with_pre_silence_samples`/`with_capacity`/`fill_to`/`fill_secs`/`len`/`into_vec`). Gated `cfg(any(test, feature = "test-support"))`. |
+| `src/pd_test_encoder.rs` | modify | Drop local consts + `lum_to_freq` + `fill_to`; import from `test_tone`. Use `ToneWriter`. `pub fn` → `pub(crate) fn` (T2). |
+| `src/robot_test_encoder.rs` | modify | Same as PD. |
+| `src/scottie_test_encoder.rs` | modify | Same as PD. Plus E2 (delete stale doc paragraph), `pub fn` → `pub(crate) fn` (T2). |
+| `src/vis.rs` | modify (tests only) | `synth_vis_with_offset` + `r12bw_rejects_standard_parity` use `ToneWriter::fill_secs`. |
+| `src/lib.rs` | modify | Add `pub(crate) mod test_tone;` (T1). Flip the three `pub mod *_test_encoder;` to `pub(crate) mod` (T2). Switch `__test_support::mode_{pd,robot,scottie}` `pub use` re-exports to thin `pub fn` wrappers (T2). |
+| `CHANGELOG.md` | modify | `[Unreleased]` `### Internal` bullet (T5). |
+
+Task order: **T1** → **T2** → **T3** → **T4** → **T5**. Each task leaves a working state (crate compiles, full release suite passes).
+
+**Verification after each task** (the rule for this PR):
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test --all-features --locked --release
+RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features
+```
+
+---
+
+## Task 1: Create `src/test_tone.rs` and migrate all 4 consumers atomically
+
+Create the new module populated and switch every consumer in one task so there's no duplicate-then-delete intermediate state.
+
+**Files:**
+- Create: `src/test_tone.rs`
+- Modify: `src/lib.rs`, `src/pd_test_encoder.rs`, `src/robot_test_encoder.rs`, `src/scottie_test_encoder.rs`, `src/vis.rs`
+
+- [ ] **Step 1: Create `src/test_tone.rs`**
+
+```rust
+//! Continuous-phase FM tone generator for the synthetic test encoders.
+//!
+//! Consolidates the four pre-#86 copies in `pd_test_encoder.rs`,
+//! `robot_test_encoder.rs`, `scottie_test_encoder.rs`, and
+//! `vis.rs::tests`. The SSTV-specific frequency constants (`SYNC_HZ` =
+//! 1200 Hz, the 1500 Hz `PORCH_HZ` / `SEPTR_HZ` / `BLACK_HZ`, the 2300 Hz
+//! `WHITE_HZ`) live here too, as does the `lum_to_freq(lum) → Hz`
+//! mapping.
+//!
+//! [`ToneWriter`] owns the output `Vec<f32>` and a running `phase`
+//! accumulator. Two emission forms share the same `phase`:
+//! [`ToneWriter::fill_to`] (cumulative absolute sample target — used by
+//! the encoders; prevents per-tone rounding drift across a multi-channel
+//! line) and [`ToneWriter::fill_secs`] (per-tone wall-clock duration —
+//! used by VIS bursts where each tone has a fixed duration).
+//!
+//! Gated under `cfg(any(test, feature = "test-support"))` — not part of
+//! the published API.
+
+use std::f64::consts::PI;
+
+use crate::resample::WORKING_SAMPLE_RATE_HZ;
+
+pub(crate) const SYNC_HZ: f64 = 1200.0;
+pub(crate) const PORCH_HZ: f64 = 1500.0;
+/// Same value as `PORCH_HZ` / `BLACK_HZ` (1500 Hz), named for SSTV-spec clarity.
+pub(crate) const SEPTR_HZ: f64 = 1500.0;
+pub(crate) const BLACK_HZ: f64 = 1500.0;
+pub(crate) const WHITE_HZ: f64 = 2300.0;
+
+/// Map an 8-bit luminance value to its FM frequency in Hz.
+/// Linear interpolation between [`BLACK_HZ`] (lum=0) and [`WHITE_HZ`] (lum=255).
+#[must_use]
+pub(crate) fn lum_to_freq(lum: u8) -> f64 {
+    BLACK_HZ + (WHITE_HZ - BLACK_HZ) * f64::from(lum) / 255.0
+}
+
+/// Continuous-phase FM tone writer. Owns the output `Vec<f32>` and a
+/// running `phase` accumulator so consecutive tones produce no audible
+/// discontinuity at boundaries.
+pub(crate) struct ToneWriter {
+    out: Vec<f32>,
+    phase: f64,
+}
+
+impl ToneWriter {
+    pub fn new() -> Self {
+        Self {
+            out: Vec::new(),
+            phase: 0.0,
+        }
+    }
+
+    /// Construct with `n` zero samples already in `out` (encoder pre-silence
+    /// or VIS pre-silence). Phase starts at 0.
+    pub fn with_pre_silence_samples(n: usize) -> Self {
+        Self {
+            out: vec![0.0; n],
+            phase: 0.0,
+        }
+    }
+
+    /// Construct with capacity pre-reserved (no samples emitted).
+    pub fn with_capacity(cap: usize) -> Self {
+        Self {
+            out: Vec::with_capacity(cap),
+            phase: 0.0,
+        }
+    }
+
+    /// Emit samples up to absolute output index `target_n` (exclusive) at
+    /// `freq_hz`. Cumulative-target form — call repeatedly with increasing
+    /// `target_n` across a multi-channel line; per-pixel rounding error
+    /// never compounds.
+    #[allow(clippy::cast_precision_loss)]
+    pub fn fill_to(&mut self, freq_hz: f64, target_n: usize) {
+        let dphi = 2.0 * PI * freq_hz / f64::from(WORKING_SAMPLE_RATE_HZ);
+        while self.out.len() < target_n {
+            self.out.push(self.phase.sin() as f32);
+            self.phase += dphi;
+            if self.phase > 2.0 * PI {
+                self.phase -= 2.0 * PI;
+            }
+        }
+    }
+
+    /// Emit `secs` seconds at `freq_hz`. Per-tone-duration form. Used by
+    /// VIS bursts where each tone has a fixed wall-clock duration.
+    #[allow(clippy::cast_precision_loss, clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    pub fn fill_secs(&mut self, freq_hz: f64, secs: f64) {
+        let n = (secs * f64::from(WORKING_SAMPLE_RATE_HZ)).round() as usize;
+        let target = self.out.len() + n;
+        self.fill_to(freq_hz, target);
+    }
+
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.out.len()
+    }
+
+    #[must_use]
+    pub fn into_vec(self) -> Vec<f32> {
+        self.out
+    }
+}
+
+impl Default for ToneWriter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::float_cmp, clippy::cast_precision_loss)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lum_to_freq_endpoints_match_black_and_white() {
+        assert_eq!(lum_to_freq(0), BLACK_HZ);
+        assert_eq!(lum_to_freq(255), WHITE_HZ);
+        // Midpoint (lum=128) is just under (BLACK+WHITE)/2.
+        let mid = lum_to_freq(128);
+        let target = (BLACK_HZ + WHITE_HZ) / 2.0;
+        assert!((mid - target).abs() < 5.0, "mid={mid} ≉ {target}");
+    }
+
+    #[test]
+    fn fill_to_advances_to_exact_target() {
+        let mut tone = ToneWriter::new();
+        tone.fill_to(1200.0, 100);
+        assert_eq!(tone.len(), 100);
+        tone.fill_to(1500.0, 250);
+        assert_eq!(tone.len(), 250);
+    }
+
+    #[test]
+    fn fill_to_and_fill_secs_are_equivalent_for_matching_durations() {
+        // Pick a duration that gives an integer sample count (avoids `.round()` ambiguity).
+        let secs = 100.0 / f64::from(WORKING_SAMPLE_RATE_HZ); // 100 samples
+        let mut a = ToneWriter::new();
+        a.fill_secs(1200.0, secs);
+        let mut b = ToneWriter::new();
+        b.fill_to(1200.0, 100);
+        let av = a.into_vec();
+        let bv = b.into_vec();
+        assert_eq!(av.len(), bv.len());
+        for (i, (&x, &y)) in av.iter().zip(bv.iter()).enumerate() {
+            assert!((x - y).abs() < 1e-6, "sample {i}: {x} vs {y}");
+        }
+    }
+
+    #[test]
+    fn phase_is_continuous_across_tone_boundaries() {
+        // Fill 100 samples at 1200 Hz then 100 more at 1500 Hz. The
+        // sample-to-sample step at the boundary should be roughly the
+        // dphi of the SECOND tone, not a huge phase jump.
+        let mut tone = ToneWriter::new();
+        tone.fill_to(1200.0, 100);
+        tone.fill_to(1500.0, 200);
+        let v = tone.into_vec();
+        // Maximum sample-to-sample absolute delta across the whole signal:
+        // for a continuous-phase signal with the highest tone freq we use
+        // here (1500 Hz at 11025 Hz SR), dphi ≈ 0.855 rad/sample → max
+        // |Δ sin(phase)| ≤ |dphi| ≈ 0.855. Add a margin → < 1.0.
+        for w in v.windows(2) {
+            let delta = (w[1] - w[0]).abs();
+            assert!(delta < 1.0, "sample-to-sample delta {delta} > 1.0 — phase discontinuity");
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Wire `test_tone` into `src/lib.rs`**
+
+Open `src/lib.rs`. The module-declaration block (lines ~40-66) currently has the three `pub mod *_test_encoder;` declarations gated on `cfg(any(test, feature = "test-support"))`. Add immediately above the first of them (above `pub mod pd_test_encoder;`):
+
+```rust
+#[cfg(any(test, feature = "test-support"))]
+pub(crate) mod test_tone;
+```
+
+(Same gating as the encoders. `pub(crate)` — never visible externally; `#[doc(hidden)]` is unnecessary on `pub(crate)`.)
+
+- [ ] **Step 3: Migrate `src/pd_test_encoder.rs` to `ToneWriter`**
+
+Open `src/pd_test_encoder.rs`. Apply these edits:
+
+(a) **At the top of the file**, add (just below the existing `use` block, before `const SYNC_HZ`):
+
+```rust
+use crate::test_tone::{lum_to_freq, ToneWriter, PORCH_HZ, SYNC_HZ};
+```
+
+(PD doesn't use `SEPTR_HZ` in the body — septr_seconds is 0 for PD modes — but it does use `BLACK_HZ` / `WHITE_HZ` indirectly through `lum_to_freq`. Importing `lum_to_freq` suffices; the encoder doesn't reference `BLACK_HZ` / `WHITE_HZ` by name.)
+
+(b) **Delete** the local definitions (currently around lines 19-43):
+- `const SYNC_HZ: f64 = 1200.0;`
+- `const PORCH_HZ: f64 = 1500.0;`
+- `const BLACK_HZ: f64 = 1500.0;`
+- `const WHITE_HZ: f64 = 2300.0;`
+- `fn lum_to_freq(lum: u8) -> f64 { ... }`
+- `fn fill_to(out: &mut Vec<f32>, freq_hz: f64, target_n: usize, phase: &mut f64) { ... }` (with its preceding doc comment)
+
+(c) In `encode_pd`, the body currently allocates an output Vec and a phase scalar, then calls `fill_to(&mut out, freq, target_n, &mut phase)` many times, returning `out` at the end. Apply this textual substitution throughout the fn:
+
+- `let mut out: Vec<f32> = Vec::with_capacity(...);` → `let mut tone = ToneWriter::with_capacity(...);`
+  (or `Vec::new()` → `ToneWriter::new()` if no capacity hint is used. Check the actual current init.)
+- `let mut phase = 0.0_f64;` → delete (it lives on `ToneWriter` now).
+- Each `fill_to(&mut out, freq, target_n, &mut phase);` → `tone.fill_to(freq, target_n);`.
+- Final `out` (the return expression) → `tone.into_vec()`.
+
+If the function does any direct writes to `out` like `out.push(...)` or `out.extend(...)` outside `fill_to` (it shouldn't — PD encoder only emits via `fill_to`), STOP and report so we can extend `ToneWriter` instead of bypassing it.
+
+- [ ] **Step 4: Migrate `src/robot_test_encoder.rs` to `ToneWriter`**
+
+Same shape as Step 3. Open `src/robot_test_encoder.rs`:
+
+(a) Add at top (below existing `use` block):
+
+```rust
+use crate::test_tone::{lum_to_freq, ToneWriter, PORCH_HZ, SEPTR_HZ, SYNC_HZ};
+```
+
+(Robot72 uses septr between Y/U/V; Robot36/24 uses septr between Y and chroma. So `SEPTR_HZ` is needed here even though robot_test_encoder didn't have a local `SEPTR_HZ` constant — it likely used `PORCH_HZ` as a stand-in for the septr tone since they share value. Verify when editing: if the code emits a septr tone at `PORCH_HZ`, change to `SEPTR_HZ` for spec-clarity. If it never emits a septr tone, drop `SEPTR_HZ` from the import.)
+
+(b) Delete the local definitions (currently lines 27-48):
+- `const SYNC_HZ: f64 = 1200.0;`
+- `const PORCH_HZ: f64 = 1500.0;`
+- `const BLACK_HZ: f64 = 1500.0;`
+- `const WHITE_HZ: f64 = 2300.0;`
+- `fn lum_to_freq(...)`.
+- `fn fill_to(...)`.
+
+(c) In `encode_robot`, apply the same `out` → `tone` substitution as Step 3(c).
+
+- [ ] **Step 5: Migrate `src/scottie_test_encoder.rs` to `ToneWriter`**
+
+Same shape. Open `src/scottie_test_encoder.rs`:
+
+(a) Add at top:
+
+```rust
+use crate::test_tone::{lum_to_freq, ToneWriter, PORCH_HZ, SEPTR_HZ, SYNC_HZ};
+```
+
+(b) Delete the local definitions (currently lines 35-65):
+- `const SYNC_HZ`, `PORCH_HZ`, `SEPTR_HZ`, `BLACK_HZ`, `WHITE_HZ`.
+- `fn lum_to_freq(...)`.
+- `fn fill_to(...)`.
+
+(c) In `encode_scottie`, apply the same `out` → `tone` substitution.
+
+- [ ] **Step 6: Migrate `src/vis.rs::tests` to `ToneWriter`**
+
+Open `src/vis.rs`. Two sites use a per-tone phase-advance closure: `synth_vis_with_offset` (around lines 462-501) and `r12bw_rejects_standard_parity` (around lines 638-670).
+
+(a) **`synth_vis_with_offset`** — the current body looks like:
+
+```rust
+let mut out: Vec<f32> = vec![0.0; (pre_silence_secs * sr).round() as usize];
+let mut phase = 0.0_f64;
+let mut emit = |freq: f64, secs: f64, out: &mut Vec<f32>| {
+    let dphi = 2.0 * PI * freq / sr;
+    for _ in 0..(secs * sr).round() as usize {
+        out.push(phase.sin() as f32);
+        phase += dphi;
+        if phase > 2.0 * PI {
+            phase -= 2.0 * PI;
+        }
+    }
+};
+// ... VIS frequency math (leader, break_f, bit_freq) ...
+emit(leader, 0.300, &mut out);
+emit(break_f, 0.030, &mut out);
+// ... 7 bit emits + parity + trailing break ...
+out
+```
+
+Replace with:
+
+```rust
+let mut tone = crate::test_tone::ToneWriter::with_pre_silence_samples(
+    (pre_silence_secs * f64::from(WORKING_SAMPLE_RATE_HZ)).round() as usize,
+);
+// ... VIS frequency math (leader, break_f, bit_freq) stays here ...
+tone.fill_secs(leader, 0.300);
+tone.fill_secs(break_f, 0.030);
+// ... 7 bit fill_secs + parity + trailing break ...
+tone.into_vec()
+```
+
+The VIS frequency math (the `leader = LEADER_HZ + freq_offset_hz` line, `break_f = leader + BREAK_HZ_OFFSET`, the `bit_freq` closure) STAYS — those are VIS-classifier offsets, not encoder consts.
+
+If the body has `let sr = f64::from(WORKING_SAMPLE_RATE_HZ);` as a local binding used only by the `emit` closure: delete it (no longer needed once `emit` is gone, since `tone.fill_secs` reads `WORKING_SAMPLE_RATE_HZ` internally). If it's used elsewhere in the function (e.g. the `pre_silence_secs * sr` line), keep it or inline `f64::from(WORKING_SAMPLE_RATE_HZ)`.
+
+(b) **`r12bw_rejects_standard_parity`** — same closure pattern (with its own inline `let mut out = ...; let mut emit = |...| {...};`). Apply the same substitution: build a `tone = ToneWriter::with_pre_silence_samples(0)` (or `ToneWriter::new()` if there's no pre-silence in this test), then `tone.fill_secs(freq, secs)` instead of `emit(freq, secs, &mut out)`, and `tone.into_vec()` at the end.
+
+**Important:** the per-tone wall-clock durations and VIS-classifier frequency math stay identical — this is a pure mechanism swap, not a behavior change.
+
+- [ ] **Step 7: Run the gate**
+
+```bash
+cargo fmt --all
+cargo fmt --all -- --check
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test --all-features --locked --release
+RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features
+```
+
+All four must pass. `cargo test --release` is load-bearing — `tests/roundtrip.rs` exercises all three encoders end-to-end on every supported mode; any drift in tone math, phase continuity, or channel ordering surfaces as a roundtrip pixel-diff regression. `vis::tests`'s VIS-detection tests exercise `synth_vis_with_offset` and `r12bw_rejects_standard_parity`.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add -A
+git commit -m "refactor(test_tone): extract continuous-phase FM tone generator + ToneWriter (#86 B9)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Flip `pub mod *_test_encoder` to `pub(crate) mod` and switch `__test_support` to wrapper fns
+
+Kill the duplicate stable path. The three `slowrx::pd_test_encoder::*` / `robot_test_encoder::*` / `scottie_test_encoder::*` external paths disappear; `__test_support` becomes the sole consumer-facing entry point.
+
+**Files:**
+- Modify: `src/lib.rs`, `src/pd_test_encoder.rs`, `src/robot_test_encoder.rs`, `src/scottie_test_encoder.rs`
+
+- [ ] **Step 1: Flip the three module declarations in `src/lib.rs`**
+
+The three declarations currently read:
+
+```rust
+#[cfg(any(test, feature = "test-support"))]
+#[doc(hidden)]
+pub mod pd_test_encoder;
+
+#[cfg(any(test, feature = "test-support"))]
+#[doc(hidden)]
+pub mod robot_test_encoder;
+
+#[cfg(any(test, feature = "test-support"))]
+#[doc(hidden)]
+pub mod scottie_test_encoder;
+```
+
+Replace each with:
+
+```rust
+#[cfg(any(test, feature = "test-support"))]
+pub(crate) mod pd_test_encoder;
+
+#[cfg(any(test, feature = "test-support"))]
+pub(crate) mod robot_test_encoder;
+
+#[cfg(any(test, feature = "test-support"))]
+pub(crate) mod scottie_test_encoder;
+```
+
+`#[doc(hidden)]` is no longer needed — `pub(crate)` items don't appear in `cargo doc` at all.
+
+- [ ] **Step 2: Tighten the encoder fn visibilities**
+
+In each encoder source file (`src/pd_test_encoder.rs`, `src/robot_test_encoder.rs`, `src/scottie_test_encoder.rs`):
+
+(a) Change `pub fn encode_<mode>(...)` to `pub(crate) fn encode_<mode>(...)`. The outer module is `pub(crate)` so `pub` is unnecessary.
+
+(b) Drop the `#[doc(hidden)]` attribute on each `encode_*` fn (if present) — redundant with `pub(crate)`. Keep all other attributes (`#[must_use]`, any `#[allow(...)]`).
+
+Run after this step: `grep -n "pub fn encode_pd\|pub fn encode_robot\|pub fn encode_scottie\|#\[doc(hidden)\]" src/pd_test_encoder.rs src/robot_test_encoder.rs src/scottie_test_encoder.rs` — should print nothing for the `pub fn` patterns (all should be `pub(crate) fn` now), and `#[doc(hidden)]` should only appear if attached to *internal* items inside the modules (not the `encode_*` fns themselves).
+
+- [ ] **Step 3: Rewrite `__test_support::mode_pd::encode_pd` as a wrapper fn**
+
+In `src/lib.rs`, find the `pub mod __test_support` block. The `mode_pd` sub-module currently is:
+
+```rust
+pub mod mode_pd {
+    pub use crate::demod::ycbcr_to_rgb;
+    pub use crate::pd_test_encoder::encode_pd;
+}
+```
+
+Replace with:
+
+```rust
+pub mod mode_pd {
+    pub use crate::demod::ycbcr_to_rgb;
+
+    /// Thin wrapper around the now-`pub(crate)` `crate::pd_test_encoder::encode_pd`.
+    /// `__test_support` is the sole consumer-facing path for the synthetic
+    /// PD encoder (#86 B10).
+    #[doc(hidden)]
+    #[must_use]
+    pub fn encode_pd(mode: crate::modespec::SstvMode, ycrcb: &[[u8; 3]]) -> Vec<f32> {
+        crate::pd_test_encoder::encode_pd(mode, ycrcb)
+    }
+}
+```
+
+**Verify the wrapper signature matches the underlying fn exactly** — read the current `pub(crate) fn encode_pd(...) -> Vec<f32>` signature from `src/pd_test_encoder.rs` (after T1+Step 2 above) and ensure the wrapper's parameter types match (in particular: `&[[u8; 3]]` is the slice form; if the underlying takes something else, mirror it).
+
+- [ ] **Step 4: Rewrite `__test_support::mode_robot::encode_robot` as a wrapper fn**
+
+In `src/lib.rs`, the `mode_robot` sub-module:
+
+```rust
+pub mod mode_robot {
+    pub use crate::robot_test_encoder::encode_robot;
+}
+```
+
+Replace with:
+
+```rust
+pub mod mode_robot {
+    /// Thin wrapper around the now-`pub(crate)` `crate::robot_test_encoder::encode_robot`.
+    /// `__test_support` is the sole consumer-facing path for the synthetic
+    /// Robot encoder (#86 B10).
+    #[doc(hidden)]
+    #[must_use]
+    pub fn encode_robot(mode: crate::modespec::SstvMode, ycrcb: &[[u8; 3]]) -> Vec<f32> {
+        crate::robot_test_encoder::encode_robot(mode, ycrcb)
+    }
+}
+```
+
+(Again, verify the wrapper signature matches the underlying `encode_robot` exactly.)
+
+- [ ] **Step 5: Rewrite `__test_support::mode_scottie::encode_scottie` as a wrapper fn**
+
+In `src/lib.rs`, the `mode_scottie` sub-module:
+
+```rust
+pub mod mode_scottie {
+    pub use crate::scottie_test_encoder::encode_scottie;
+}
+```
+
+Replace with:
+
+```rust
+pub mod mode_scottie {
+    /// Thin wrapper around the now-`pub(crate)` `crate::scottie_test_encoder::encode_scottie`.
+    /// `__test_support` is the sole consumer-facing path for the synthetic
+    /// Scottie/Martin encoder (#86 B10).
+    #[doc(hidden)]
+    #[must_use]
+    pub fn encode_scottie(mode: crate::modespec::SstvMode, rgb: &[[u8; 3]]) -> Vec<f32> {
+        crate::scottie_test_encoder::encode_scottie(mode, rgb)
+    }
+}
+```
+
+(Verify signature — note Scottie's param name is `rgb` rather than `ycrcb`. Match the underlying fn.)
+
+- [ ] **Step 6: Run the gate**
+
+```bash
+cargo fmt --all
+cargo fmt --all -- --check
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test --all-features --locked --release
+RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features
+```
+
+`cargo test --release` confirms `tests/roundtrip.rs` etc. still resolve `slowrx::__test_support::mode_*::encode_*` correctly — those consumer paths are stable through the wrappers.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add -A
+git commit -m "refactor(test-encoders): pub(crate) modules + __test_support wrapper fns (#86 B10)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: E2 (scottie double-doc) + C17 partial (`unreachable!`/`expect!` cleanup)
+
+**Files:**
+- Modify: `src/scottie_test_encoder.rs` (E2 + possibly C17), `src/pd_test_encoder.rs` (C17 if present), `src/robot_test_encoder.rs` (C17 if present)
+
+- [ ] **Step 1: Fix the scottie double-doc-comment (E2)**
+
+Open `src/scottie_test_encoder.rs`. The `encode_scottie` fn currently has TWO `///` doc-comment paragraphs straddling `#[must_use]`:
+
+```rust
+/// (paragraph 1 — stale Scottie-only: starts with "Encode an image as Scottie 1 / 2 / DX audio.
+/// `rgb` is row-major..." and ends with "Per radio line, emits in this order: 1. Septr 1 ...")
+#[must_use]
+/// (paragraph 2 — accurate Scottie-OR-Martin: starts with "Encode an RGB image as continuous-phase
+/// FM audio for either Scottie (S1/S2/DX) or Martin (M1/M2)..." and ends with "Panics if `mode` is
+/// not one of the five supported variants or if `rgb.len() != line_pixels * image_lines`.")
+#[doc(hidden)]
+#[allow(dead_code, clippy::too_many_lines)]
+pub(crate) fn encode_scottie(mode: SstvMode, rgb: &[[u8; 3]]) -> Vec<f32> {
+```
+
+(After T2 the fn is `pub(crate) fn` and `#[doc(hidden)]` may already be gone from Step 2(b). Verify.)
+
+Replace with:
+
+```rust
+/// (paragraph 2 verbatim — the accurate Scottie-OR-Martin doc.)
+#[must_use]
+#[allow(dead_code, clippy::too_many_lines)]
+pub(crate) fn encode_scottie(mode: SstvMode, rgb: &[[u8; 3]]) -> Vec<f32> {
+```
+
+Concretely: **delete** paragraph 1 in full (every `///` line from the start of the doc block down to and including the "Per radio line, emits in this order" enumeration); **keep** paragraph 2 verbatim; **move** `#[must_use]` to sit with the other attributes (after the doc comment, before `pub(crate) fn`).
+
+- [ ] **Step 2: C17 — audit each encoder for redundant `assert!(matches!(...))` + later `unreachable!()`/`.expect(...)`**
+
+Run: `grep -nE "assert!\(matches!|unreachable!\(\)|\.expect\(\".*mode" src/pd_test_encoder.rs src/robot_test_encoder.rs src/scottie_test_encoder.rs`
+
+For each hit, look at the surrounding code. Each encoder typically opens with something like:
+
+```rust
+assert!(matches!(mode, SstvMode::Pd120 | SstvMode::Pd180 | SstvMode::Pd240),
+    "encode_pd: unsupported mode {mode:?}");
+```
+
+…and later has a `match mode { ... _ => unreachable!() }` or similar on the same variant set. Two redundant guards.
+
+**Resolution per site:**
+
+- If the `match` doesn't use a wildcard arm and uses only the variants the `assert!` covers, the `assert!` is genuinely redundant — **delete the leading `assert!(matches!(...))`** and let the `match`'s exhaustiveness (over the constrained variants) do the work. Caveat: `SstvMode` is `#[non_exhaustive]`, so an explicit `match` on just `Pd120 | Pd180 | Pd240` requires a wildcard, which lands back in `unreachable!()` territory. In that case…
+- …**delete the leading `assert!(matches!(...))`** and **keep the `unreachable!()` arm** with a one-line comment explaining: `// unreachable! — guarded by the modespec dispatch in SstvDecoder; SstvMode is #[non_exhaustive] so the wildcard is structurally required.` (The `unreachable!()` is a runtime guard for the non-exhaustive enum; the leading `assert!` was a redundant doubling.)
+- If a site has only an `assert!(matches!(...))` with no later `unreachable!()` / `.expect(...)`: **leave it** (the `assert!` IS the only guard — not redundant).
+- If a site has only `unreachable!()` / `.expect(...)` with no leading `assert!(matches!(...))`: **leave it** (likewise — not redundant).
+
+Don't add `#[allow]`s. Don't add `panic!()` calls. The goal is to remove one guard per double-guarded site, not to add or restructure.
+
+- [ ] **Step 3: Run the gate**
+
+```bash
+cargo fmt --all
+cargo fmt --all -- --check
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test --all-features --locked --release
+RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features
+```
+
+All four must pass. The scottie doc fix is a behavior-preserving cleanup; the C17 cleanup deletes redundant guards without changing the surviving guard's behavior, so `tests/roundtrip.rs` is unaffected.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add -A
+git commit -m "refactor(test-encoders): scottie double-doc fix + drop redundant assert!/unreachable! pairs (#86 E2/C17)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: F11 — encoder smoke tests
+
+Add `encode_pd` and `encode_robot` unit tests that catch channel-order / septr-placement regressions with a pointed assertion (vs the fuzzy `mean ≥ 5.0` from `tests/roundtrip.rs`). Update existing `scottie_test_encoder::tests` to use the new `crate::test_tone::*` const paths.
+
+**Files:**
+- Modify: `src/pd_test_encoder.rs`, `src/robot_test_encoder.rs`, `src/scottie_test_encoder.rs`
+
+- [ ] **Step 1: Add `pd_test_encoder::tests`**
+
+In `src/pd_test_encoder.rs`, append at the end of the file:
+
+```rust
+#[cfg(test)]
+#[allow(clippy::cast_precision_loss, clippy::cast_possible_truncation, clippy::cast_sign_loss, clippy::cast_possible_wrap)]
+mod tests {
+    use super::*;
+    use crate::modespec::{for_mode, SstvMode};
+
+    /// A regression in channel order surfaces here as a pointed failure
+    /// instead of a fuzzy roundtrip pixel-diff.
+    #[test]
+    fn encode_pd120_first_tone_is_sync_hz() {
+        let spec = for_mode(SstvMode::Pd120);
+        let img = vec![[128_u8, 128, 128]; (spec.line_pixels * spec.image_lines) as usize];
+        let audio = encode_pd(SstvMode::Pd120, &img);
+        let sync_samples =
+            (spec.sync_seconds * f64::from(crate::resample::WORKING_SAMPLE_RATE_HZ)) as usize;
+        assert!(audio.len() >= sync_samples, "audio too short");
+        let p_sync = crate::dsp::goertzel_power(&audio[..sync_samples], crate::test_tone::SYNC_HZ);
+        let p_porch = crate::dsp::goertzel_power(&audio[..sync_samples], crate::test_tone::PORCH_HZ);
+        assert!(
+            p_sync > 10.0 * p_porch,
+            "PD line starts with SYNC tone (p_sync={p_sync}, p_porch={p_porch})"
+        );
+    }
+
+    /// Catches structural drift — extra/missing septr, wrong channel count —
+    /// without round-tripping.
+    #[test]
+    fn encode_pd120_length_matches_radio_frames() {
+        let spec = for_mode(SstvMode::Pd120);
+        let img = vec![[0_u8; 3]; (spec.line_pixels * spec.image_lines) as usize];
+        let audio = encode_pd(SstvMode::Pd120, &img);
+        // PD packs 2 image rows / radio frame.
+        let radio_frames = f64::from(spec.image_lines) / 2.0;
+        let expected = (radio_frames
+            * spec.line_seconds
+            * f64::from(crate::resample::WORKING_SAMPLE_RATE_HZ)) as usize;
+        let diff = (audio.len() as i64 - expected as i64).abs();
+        assert!(
+            diff < 64,
+            "PD120 audio len {} ≉ {expected} (diff {})",
+            audio.len(),
+            diff
+        );
+    }
+}
+```
+
+- [ ] **Step 2: Add `robot_test_encoder::tests`**
+
+In `src/robot_test_encoder.rs`, append at the end of the file:
+
+```rust
+#[cfg(test)]
+#[allow(clippy::cast_precision_loss, clippy::cast_possible_truncation, clippy::cast_sign_loss, clippy::cast_possible_wrap)]
+mod tests {
+    use super::*;
+    use crate::modespec::{for_mode, SstvMode};
+
+    /// A regression in Robot channel order surfaces here as a pointed
+    /// failure instead of a fuzzy roundtrip pixel-diff. Tests Robot72
+    /// (simplest of the three Robot variants — 3 channels, no chroma
+    /// alternation).
+    #[test]
+    fn encode_robot72_first_tone_is_sync_hz() {
+        let spec = for_mode(SstvMode::Robot72);
+        let img = vec![[128_u8, 128, 128]; (spec.line_pixels * spec.image_lines) as usize];
+        let audio = encode_robot(SstvMode::Robot72, &img);
+        let sync_samples =
+            (spec.sync_seconds * f64::from(crate::resample::WORKING_SAMPLE_RATE_HZ)) as usize;
+        assert!(audio.len() >= sync_samples, "audio too short");
+        let p_sync = crate::dsp::goertzel_power(&audio[..sync_samples], crate::test_tone::SYNC_HZ);
+        let p_porch = crate::dsp::goertzel_power(&audio[..sync_samples], crate::test_tone::PORCH_HZ);
+        assert!(
+            p_sync > 10.0 * p_porch,
+            "Robot72 line starts with SYNC tone (p_sync={p_sync}, p_porch={p_porch})"
+        );
+    }
+
+    #[test]
+    fn encode_robot72_length_matches_radio_lines() {
+        let spec = for_mode(SstvMode::Robot72);
+        let img = vec![[0_u8; 3]; (spec.line_pixels * spec.image_lines) as usize];
+        let audio = encode_robot(SstvMode::Robot72, &img);
+        // Robot: 1 image row per radio line.
+        let radio_lines = f64::from(spec.image_lines);
+        let expected = (radio_lines
+            * spec.line_seconds
+            * f64::from(crate::resample::WORKING_SAMPLE_RATE_HZ)) as usize;
+        let diff = (audio.len() as i64 - expected as i64).abs();
+        assert!(
+            diff < 64,
+            "Robot72 audio len {} ≉ {expected} (diff {})",
+            audio.len(),
+            diff
+        );
+    }
+}
+```
+
+- [ ] **Step 3: Update existing `scottie_test_encoder::tests` to use `crate::test_tone::*`**
+
+In `src/scottie_test_encoder.rs`'s `#[cfg(test)] mod tests` (the existing 2 tests): if any of them references `SYNC_HZ` / `PORCH_HZ` / `SEPTR_HZ` / `BLACK_HZ` / `WHITE_HZ` / `lum_to_freq` — those names no longer resolve locally (T1 deleted them). Change references to fully-qualified `crate::test_tone::SYNC_HZ` etc., or add a `use crate::test_tone::*;` line at the top of the test module.
+
+(After T1 / T2 cleanly the existing tests probably compile already — they may not reference those names. Verify with `grep -nE "SYNC_HZ|PORCH_HZ|SEPTR_HZ|BLACK_HZ|WHITE_HZ|lum_to_freq" src/scottie_test_encoder.rs`. Any hits inside `mod tests` need the import; hits outside `mod tests` should have already been fixed by T1.)
+
+- [ ] **Step 4: Run the gate**
+
+```bash
+cargo fmt --all
+cargo fmt --all -- --check
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test --all-features --locked --release
+RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features
+```
+
+The new F11 tests should be in the `cargo test --release` output's lib test count (was 116 + 4 from `test_tone::tests` in T1 = 120 → now 124 after the 4 new F11 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "test(encoders): F11 — pointed smoke tests for encode_pd and encode_robot (#86)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: CHANGELOG + sanity grep + final gate
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Add the `CHANGELOG.md` `[Unreleased]` entry**
+
+In `CHANGELOG.md`, under the `## [Unreleased]` header, add (or merge into an existing `### Internal` subsection — `[Unreleased]` is currently empty after #85's merge into 0.5.x or the latest release; either way, add as `### Internal`):
+
+```markdown
+### Internal
+
+- **Extracted `crate::test_tone`** — the continuous-phase FM tone generator
+  (`SYNC_HZ` / `PORCH_HZ` / `SEPTR_HZ` / `BLACK_HZ` / `WHITE_HZ` consts,
+  `lum_to_freq`, the `ToneWriter` struct with cumulative-target `fill_to` and
+  per-tone-duration `fill_secs` methods) — shared by `pd_test_encoder` /
+  `robot_test_encoder` / `scottie_test_encoder` / `vis::tests` (four prior
+  copies; audit B9). Tightened the three test-encoder modules to `pub(crate)
+  mod` so `slowrx::pd_test_encoder::*` / `robot_test_encoder::*` /
+  `scottie_test_encoder::*` are no longer reachable externally; `__test_support`
+  switched from `pub use` re-exports to thin `pub fn` wrappers (the sole
+  consumer-facing path for the synthetic encoders — audit B10). Plus the
+  scottie double-doc-comment fix (E2), smoke tests for `encode_pd` /
+  `encode_robot` (F11), and `unreachable!`/`expect!` cleanup in the test
+  encoders (C17 partial). Pure refactor: identical behavior; the
+  `slowrx::__test_support::mode_*::encode_*` paths are stable for existing
+  consumers (`tests/roundtrip.rs` unchanged). (#86; audit B9/B10/E2/F11/C17.)
+```
+
+- [ ] **Step 2: Sanity grep**
+
+Run:
+
+```bash
+grep -rn "fn lum_to_freq\|fn fill_to\|const SYNC_HZ\|const PORCH_HZ\|const BLACK_HZ\|const WHITE_HZ\|const SEPTR_HZ\|^pub mod pd_test_encoder\|^pub mod robot_test_encoder\|^pub mod scottie_test_encoder\|pub use crate::pd_test_encoder\|pub use crate::robot_test_encoder\|pub use crate::scottie_test_encoder" src/
+```
+
+Expected: hits **only** in `src/test_tone.rs` (the canonical `fn lum_to_freq` definition + the 5 `const *_HZ` definitions). Every other file should have zero hits.
+
+(The `^` anchors on `pub mod *_test_encoder` are deliberate — we want to catch a `pub mod` line at column 0 if one survived; the `pub(crate) mod` declarations are fine and won't match.)
+
+- [ ] **Step 3: Run the full CI gate**
+
+```bash
+cargo fmt --all
+cargo fmt --all -- --check
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test --all-features --locked --release
+RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features
+```
+
+All four must pass. The `cargo doc` step verifies that no doc-link references `slowrx::pd_test_encoder::*` etc. (those paths are now `pub(crate)`, so external doc-links to them would warn).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CHANGELOG.md
+git commit -m "docs(refactor): CHANGELOG for the test_tone extraction + B10 path tightening (#86)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+(If Step 2's sanity grep found unexpected hits and you fixed them, fold those fixes into this commit.)
+
+---
+
+## Self-review notes (for the implementer / reviewers)
+
+- **Spec coverage:** B9 (extract `test_tone` + `ToneWriter`) → T1; B10 (`pub(crate) mod` + wrapper fns) → T2; E2 (scottie double-doc) → T3 Step 1; C17 partial (`unreachable!`/`expect` cleanup) → T3 Step 2; F11 (encoder smoke tests) → T4; CHANGELOG → T5 Step 1.
+
+- **Why the order matters:** T1 must be atomic (create + migrate) so the crate compiles after each commit — `test_tone.rs` items would be `dead_code` if T1 stopped after Step 2. T2 depends on T1 (the encoder fns must already use `crate::test_tone` consts before they become `pub(crate)`, otherwise the consts are unreachable from `__test_support` wrappers in T2 Step 3). T3 and T4 are independent of each other but both depend on T2 (they touch the encoder files; T2's `pub fn` → `pub(crate) fn` and `#[doc(hidden)]` drops must land first). T5 depends on everything.
+
+- **`pub(crate) → pub` "private item in public interface" risk:** the wrapper fns in T2 Steps 3-5 are `pub fn` (not `pub use`), so they don't re-export a `pub(crate)` item at a `pub` path — they're plain public fns that internally call `pub(crate)` ones. Legal under all rustc visibility rules.
+
+- **F11 SYNC-first thresholds:** `p_sync > 10.0 * p_porch` — at PD's `sync_seconds` (~9 ms ≈ 99 samples at 11025 Hz), Goertzel power at 1200 Hz vs 1500 Hz on a pure 1200 Hz tone gives a ratio of many orders of magnitude. 10× is wildly conservative; any encoder regression that emits PORCH first instead of SYNC inverts the ratio and the test fails clearly.
+
+- **No new tests in T1's `test_tone::tests` exercise full-encoder behavior** — those tests target `ToneWriter` itself (phase continuity, `fill_to`/`fill_secs` equivalence, `lum_to_freq` endpoints). The encoders are exercised end-to-end by `tests/roundtrip.rs` (existing) and the new F11 smoke tests (T4).
+
+- **Out of scope** (deliberate — tracked separately under epic #97):
+  - Moving encoders entirely out of `src/` to `tests/common/` (B10 "better" option) — rejected during brainstorming.
+  - The remaining audit cleanups not in #86's bundle (#87 resampler, #88 find_sync, #91 ModeSpec, #92 API hygiene, #93 perf, #94 docs, #95 CI, #96 standalone).
+  - `vis::tests::synth_vis` / `synth_tone` / `synth_tone_n` — the bare-tone helpers that don't carry phase. Staying in `vis::tests`.

--- a/docs/superpowers/plans/2026-05-14-issue-86-shared-test-tone-module.md
+++ b/docs/superpowers/plans/2026-05-14-issue-86-shared-test-tone-module.md
@@ -18,7 +18,7 @@
 
 | File | Status | Role |
 |------|--------|------|
-| `src/test_tone.rs` | **new** (T1) | Generic continuous-phase FM tone generator: `SYNC_HZ` / `PORCH_HZ` / `SEPTR_HZ` / `BLACK_HZ` / `WHITE_HZ` consts, `lum_to_freq`, `ToneWriter` struct (with `new`/`with_pre_silence_samples`/`with_capacity`/`fill_to`/`fill_secs`/`len`/`into_vec`). Gated `cfg(any(test, feature = "test-support"))`. |
+| `src/test_tone.rs` | **new** (T1) | Generic continuous-phase FM tone generator: `SYNC_HZ` / `PORCH_HZ` / `SEPTR_HZ` / `BLACK_HZ` / `WHITE_HZ` consts, `lum_to_freq`, `ToneWriter` struct (with `new`/`with_pre_silence_samples`/`fill_to`/`fill_secs`/`len`/`into_vec`). Gated `cfg(any(test, feature = "test-support"))`. |
 | `src/pd_test_encoder.rs` | modify | Drop local consts + `lum_to_freq` + `fill_to`; import from `test_tone`. Use `ToneWriter`. `pub fn` → `pub(crate) fn` (T2). |
 | `src/robot_test_encoder.rs` | modify | Same as PD. |
 | `src/scottie_test_encoder.rs` | modify | Same as PD. Plus E2 (delete stale doc paragraph), `pub fn` → `pub(crate) fn` (T2). |
@@ -108,14 +108,6 @@ impl ToneWriter {
     pub fn with_pre_silence_samples(n: usize) -> Self {
         Self {
             out: vec![0.0; n],
-            phase: 0.0,
-        }
-    }
-
-    /// Construct with capacity pre-reserved (no samples emitted).
-    pub fn with_capacity(cap: usize) -> Self {
-        Self {
-            out: Vec::with_capacity(cap),
             phase: 0.0,
         }
     }
@@ -256,8 +248,8 @@ use crate::test_tone::{lum_to_freq, ToneWriter, PORCH_HZ, SYNC_HZ};
 
 (c) In `encode_pd`, the body currently allocates an output Vec and a phase scalar, then calls `fill_to(&mut out, freq, target_n, &mut phase)` many times, returning `out` at the end. Apply this textual substitution throughout the fn:
 
-- `let mut out: Vec<f32> = Vec::with_capacity(...);` → `let mut tone = ToneWriter::with_capacity(...);`
-  (or `Vec::new()` → `ToneWriter::new()` if no capacity hint is used. Check the actual current init.)
+- `let mut out: Vec<f32> = Vec::new();` → `let mut tone = ToneWriter::new();`
+  (or `vec![0.0; n]` → `ToneWriter::with_pre_silence_samples(n)` if the encoder pre-pads with silence.)
 - `let mut phase = 0.0_f64;` → delete (it lives on `ToneWriter` now).
 - Each `fill_to(&mut out, freq, target_n, &mut phase);` → `tone.fill_to(freq, target_n);`.
 - Final `out` (the return expression) → `tone.into_vec()`.

--- a/docs/superpowers/specs/2026-05-14-issue-86-shared-test-tone-module-design.md
+++ b/docs/superpowers/specs/2026-05-14-issue-86-shared-test-tone-module-design.md
@@ -48,7 +48,6 @@ pub(crate) struct ToneWriter {
 impl ToneWriter {
     pub fn new() -> Self;
     pub fn with_pre_silence_samples(n: usize) -> Self;
-    pub fn with_capacity(cap: usize) -> Self;
 
     /// Emit samples up to absolute output index `target_n` (exclusive) at
     /// `freq_hz`. Cumulative-target — call repeatedly with increasing
@@ -169,7 +168,7 @@ The three wrapper signatures match the underlying fns exactly (verify against th
 The encoder body pattern changes from:
 
 ```rust
-let mut out: Vec<f32> = Vec::with_capacity(estimated_total_samples);
+let mut out: Vec<f32> = Vec::new();
 let mut phase = 0.0_f64;
 // ... many fill_to(&mut out, freq, target_n, &mut phase) calls ...
 out
@@ -178,7 +177,7 @@ out
 to:
 
 ```rust
-let mut tone = ToneWriter::with_capacity(estimated_total_samples);
+let mut tone = ToneWriter::new();
 // ... many tone.fill_to(freq, target_n) calls ...
 tone.into_vec()
 ```

--- a/docs/superpowers/specs/2026-05-14-issue-86-shared-test-tone-module-design.md
+++ b/docs/superpowers/specs/2026-05-14-issue-86-shared-test-tone-module-design.md
@@ -1,0 +1,300 @@
+# Issue #86 — Shared test-tone module + encoders off the public API — design
+
+**Issue:** [#86](https://github.com/jasonherald/slowrx.rs/issues/86) (audit bundle 2 of 12 — IDs B9, B10, E2, F11, C17 partial)
+**Source of record:** `docs/audits/2026-05-11-deep-code-review-audit.md`
+**Scope:** the test-encoder-side complement to #85. Pure refactor — identical behavior, no public-API change for stable consumers.
+
+## Background
+
+The audit found:
+
+- **B9** — the continuous-phase FM tone generator (`SYNC_HZ` / `PORCH_HZ` / `SEPTR_HZ` / `BLACK_HZ` / `WHITE_HZ` consts + `lum_to_freq` + `fill_to`) is duplicated nearly byte-for-byte across `pd_test_encoder.rs`, `robot_test_encoder.rs`, `scottie_test_encoder.rs`, and `vis::tests::synth_vis_with_offset` (+ a second inline copy in `vis::tests::r12bw_rejects_standard_parity`). ~100+ LOC of duplication.
+- **B10** — the test-only encoders sit on the *published* API surface with two stable-looking paths each: `slowrx::pd_test_encoder::encode_pd` (via the `pub mod pd_test_encoder;` declaration in `lib.rs`) AND `slowrx::__test_support::mode_pd::encode_pd` (via the `pub use` re-export). Both reachable with `test-support` on. The audit wants only `__test_support` as the consumer-facing path.
+- **E2** — `scottie_test_encoder::encode_scottie` has TWO `///` doc-comment paragraphs straddling `#[must_use]`; the first is stale Scottie-only, the second is the accurate Scottie-or-Martin one. rustdoc concatenates both.
+- **F11** — only `scottie_test_encoder` has unit tests (2 of them). `pd_test_encoder` and `robot_test_encoder` have none — a regression in channel order or septr placement surfaces only as a fuzzy `mean ≥ 5.0` in `tests/roundtrip.rs`, not a pointed failure.
+- **C17 partial** — the test encoders have `unreachable!()` / `.expect()` arms after `assert!(matches!(mode, ...))` guards on the same variant set — redundant.
+
+## Design
+
+### Part 1 — Module structure
+
+**New: `src/test_tone.rs`** — `cfg(any(test, feature = "test-support"))`-gated, `pub(crate) mod test_tone;` in `lib.rs`. Contains the consolidated tone generator:
+
+```rust
+//! Continuous-phase FM tone generator for the synthetic test encoders.
+//! Consolidates the four pre-#86 copies in `pd_test_encoder.rs`,
+//! `robot_test_encoder.rs`, `scottie_test_encoder.rs`, and `vis::tests`.
+
+pub(crate) const SYNC_HZ:  f64 = 1200.0;
+pub(crate) const PORCH_HZ: f64 = 1500.0;
+pub(crate) const SEPTR_HZ: f64 = 1500.0;  // same value as PORCH_HZ/BLACK_HZ; named for SSTV-spec clarity
+pub(crate) const BLACK_HZ: f64 = 1500.0;
+pub(crate) const WHITE_HZ: f64 = 2300.0;
+
+pub(crate) fn lum_to_freq(lum: u8) -> f64 {
+    BLACK_HZ + (WHITE_HZ - BLACK_HZ) * f64::from(lum) / 255.0
+}
+
+/// Continuous-phase FM tone writer. Owns the output `Vec<f32>` and a running
+/// `phase` accumulator. Both [`fill_to`] (cumulative-target — encoder style,
+/// prevents per-tone rounding drift across a 640-pixel line) and [`fill_secs`]
+/// (per-tone duration — VIS-burst style) advance the same `phase` so
+/// consecutive tones never produce an audible discontinuity.
+pub(crate) struct ToneWriter {
+    out: Vec<f32>,
+    phase: f64,
+}
+
+impl ToneWriter {
+    pub fn new() -> Self;
+    pub fn with_pre_silence_samples(n: usize) -> Self;
+    pub fn with_capacity(cap: usize) -> Self;
+
+    /// Emit samples up to absolute output index `target_n` (exclusive) at
+    /// `freq_hz`. Cumulative-target — call repeatedly with increasing
+    /// `target_n` across a multi-channel line; per-pixel rounding error
+    /// never compounds.
+    pub fn fill_to(&mut self, freq_hz: f64, target_n: usize);
+
+    /// Emit `secs` seconds at `freq_hz`. Per-tone-duration form. Used by VIS
+    /// bursts where each tone has a fixed wall-clock duration.
+    pub fn fill_secs(&mut self, freq_hz: f64, secs: f64);
+
+    pub fn len(&self) -> usize;
+    pub fn into_vec(self) -> Vec<f32>;
+}
+```
+
+`fill_to` and `fill_secs` share the same body shape (advance `phase` by `2π·freq/sr` per sample, wrap when `phase > 2π`); they differ only in the stopping condition (`out.len() < target_n` vs an explicit sample count derived from `secs * sr`).
+
+Plus `#[cfg(test)] mod tests` with three unit tests:
+- `tone_writer_phase_is_continuous_across_tone_boundaries` — fill two consecutive different-freq tones, assert no discontinuity at the boundary (sample-to-sample delta < expected per-sample step + margin).
+- `lum_to_freq_endpoints` — `lum_to_freq(0) == BLACK_HZ`, `lum_to_freq(255) == WHITE_HZ`.
+- `fill_to_and_fill_secs_produce_equivalent_output_for_same_duration` — `fill_to(freq, n)` and `fill_secs(freq, n_as_secs)` produce identical samples (modulo `.round()`).
+
+**`pub mod` → `pub(crate) mod` flip** in `src/lib.rs`. The three lines
+
+```rust
+#[cfg(any(test, feature = "test-support"))]
+#[doc(hidden)]
+pub mod pd_test_encoder;
+
+#[cfg(any(test, feature = "test-support"))]
+#[doc(hidden)]
+pub mod robot_test_encoder;
+
+#[cfg(any(test, feature = "test-support"))]
+#[doc(hidden)]
+pub mod scottie_test_encoder;
+```
+
+become:
+
+```rust
+#[cfg(any(test, feature = "test-support"))]
+pub(crate) mod pd_test_encoder;
+
+#[cfg(any(test, feature = "test-support"))]
+pub(crate) mod robot_test_encoder;
+
+#[cfg(any(test, feature = "test-support"))]
+pub(crate) mod scottie_test_encoder;
+```
+
+`#[doc(hidden)]` is no longer needed — `pub(crate)` doesn't appear in `cargo doc` at all. The `slowrx::pd_test_encoder::*` / `robot_test_encoder::*` / `scottie_test_encoder::*` external paths disappear entirely.
+
+**`__test_support` switches from `pub use` to thin wrapper fns.** `pub use crate::pd_test_encoder::encode_pd;` of a `pub(crate)`-effective item from inside `pub mod __test_support` would trip rustc's "private item in public interface" check (same issue as `ycbcr_to_rgb` in #85). The fix: wrap each encoder in a thin `pub fn` whose body just delegates to the now-`pub(crate)` implementation.
+
+Today:
+
+```rust
+pub mod __test_support {
+    pub mod vis { pub use crate::vis::tests::synth_vis; }
+    pub mod mode_pd {
+        pub use crate::demod::ycbcr_to_rgb;
+        pub use crate::pd_test_encoder::encode_pd;
+    }
+    pub mod mode_robot { pub use crate::robot_test_encoder::encode_robot; }
+    pub mod mode_scottie { pub use crate::scottie_test_encoder::encode_scottie; }
+}
+```
+
+After:
+
+```rust
+pub mod __test_support {
+    pub mod vis {
+        // synth_vis stays a `pub use` — vis::tests is `pub mod tests` with
+        // a `pub fn synth_vis`, so re-exporting at a `pub` path is legal.
+        pub use crate::vis::tests::synth_vis;
+    }
+    pub mod mode_pd {
+        // ycbcr_to_rgb is pub + #[doc(hidden)] (from #85); the `pub use` works.
+        pub use crate::demod::ycbcr_to_rgb;
+
+        /// Thin wrapper around the now-`pub(crate)` `crate::pd_test_encoder::encode_pd`.
+        /// `__test_support` is the sole consumer-facing path for the synthetic
+        /// PD encoder (#86 B10).
+        #[doc(hidden)]
+        #[must_use]
+        pub fn encode_pd(mode: crate::modespec::SstvMode, ycrcb: &[[u8; 3]]) -> Vec<f32> {
+            crate::pd_test_encoder::encode_pd(mode, ycrcb)
+        }
+    }
+    pub mod mode_robot {
+        #[doc(hidden)]
+        #[must_use]
+        pub fn encode_robot(mode: crate::modespec::SstvMode, ycrcb: &[[u8; 3]]) -> Vec<f32> {
+            crate::robot_test_encoder::encode_robot(mode, ycrcb)
+        }
+    }
+    pub mod mode_scottie {
+        #[doc(hidden)]
+        #[must_use]
+        pub fn encode_scottie(mode: crate::modespec::SstvMode, rgb: &[[u8; 3]]) -> Vec<f32> {
+            crate::scottie_test_encoder::encode_scottie(mode, rgb)
+        }
+    }
+}
+```
+
+The three wrapper signatures match the underlying fns exactly (verify against the current `pub fn encode_*` definitions; preserve the exact parameter types). Consumer paths (`slowrx::__test_support::mode_pd::encode_pd` etc.) are stable; `tests/roundtrip.rs` keeps working without changes.
+
+**Inside each encoder module:** `pub fn encode_*` → `pub(crate) fn encode_*` (outer module is now `pub(crate)`, so `pub` is unnecessary). The `#[doc(hidden)]` attributes on the fns become redundant — drop them. Other `#[allow]`s (`dead_code`, `too_many_lines` on scottie) stay.
+
+### Part 2 — `ToneWriter` consumption + `vis::tests` migration
+
+**Each encoder** loses its local `SYNC_HZ` / `PORCH_HZ` / `SEPTR_HZ` / `BLACK_HZ` / `WHITE_HZ` consts, its local `fn lum_to_freq`, and its local `fn fill_to`. They get an `use crate::test_tone::{...}` import at the top instead.
+
+The encoder body pattern changes from:
+
+```rust
+let mut out: Vec<f32> = Vec::with_capacity(estimated_total_samples);
+let mut phase = 0.0_f64;
+// ... many fill_to(&mut out, freq, target_n, &mut phase) calls ...
+out
+```
+
+to:
+
+```rust
+let mut tone = ToneWriter::with_capacity(estimated_total_samples);
+// ... many tone.fill_to(freq, target_n) calls ...
+tone.into_vec()
+```
+
+`scottie_test_encoder` if it currently pre-pads with silence (`let mut out: Vec<f32> = vec![0.0; pre_silence_samples];`) uses `ToneWriter::with_pre_silence_samples(...)` instead. (Verify during implementation; if pd / robot encoders also do this, same substitution.)
+
+**`vis::tests::synth_vis_with_offset`** currently rolls a per-tone `emit` closure (`fill_secs`-style — wall-clock duration). After the refactor:
+
+```rust
+// Before:
+let mut out: Vec<f32> = vec![0.0; (pre_silence_secs * sr).round() as usize];
+let mut phase = 0.0_f64;
+let mut emit = |freq, secs, out: &mut Vec<f32>| { /* ~10-line phase-advance loop */ };
+emit(leader, 0.300, &mut out);
+emit(break_f, 0.030, &mut out);
+// ... 7 bit emits + parity + trailing break ...
+out
+
+// After:
+let mut tone = crate::test_tone::ToneWriter::with_pre_silence_samples(
+    (pre_silence_secs * f64::from(WORKING_SAMPLE_RATE_HZ)).round() as usize,
+);
+tone.fill_secs(leader, 0.300);
+tone.fill_secs(break_f, 0.030);
+// ... 7 bit fill_secs + parity + trailing break ...
+tone.into_vec()
+```
+
+The VIS frequency math (`leader + BREAK_HZ_OFFSET`, `bit_freq(bit)`, etc.) stays in `synth_vis_with_offset` — those are VIS-classifier-relative offsets, not encoder consts. `ToneWriter` is freq-in-Hz-only.
+
+**`vis::tests::r12bw_rejects_standard_parity`** has a second inline `emit`-closure copy (audit's note). Same substitution.
+
+`vis::tests::synth_tone` / `synth_tone_n` (the bare-tone helpers, no phase carry) are unrelated to `ToneWriter` — they stay as-is.
+
+### Part 3 — E2, F11, C17, CHANGELOG, verification
+
+**E2 — scottie double-doc fix.** `scottie_test_encoder::encode_scottie` currently has:
+
+```rust
+/// (paragraph 1 — stale Scottie-only "Per radio line, emits in this order: ...")
+#[must_use]
+/// (paragraph 2 — accurate Scottie-or-Martin "Encode an RGB image as continuous-phase FM ...")
+#[doc(hidden)]
+#[allow(dead_code, clippy::too_many_lines)]
+pub fn encode_scottie(...)
+```
+
+After: delete paragraph 1 entirely; `#[doc(hidden)]` drops (visibility tightens to `pub(crate)`); keep `#[must_use]`, `#[allow(...)]`:
+
+```rust
+/// (paragraph 2 — kept verbatim, the accurate Scottie-OR-Martin doc.)
+#[must_use]
+#[allow(dead_code, clippy::too_many_lines)]
+pub(crate) fn encode_scottie(...)
+```
+
+**F11 — encoder smoke tests.** Add to `pd_test_encoder::tests` and `robot_test_encoder::tests`:
+
+```rust
+// First-tone-is-SYNC check — a regression in channel order surfaces as a
+// pointed failure here instead of a fuzzy roundtrip pixel-diff.
+#[test]
+fn encode_<mode>_emits_expected_first_tone_at_sync_hz() {
+    let spec = crate::modespec::for_mode(SstvMode::Pd120 /* or Robot72 */);
+    let img = vec![[128, 128, 128]; (spec.line_pixels * spec.image_lines) as usize];
+    let audio = encode_<pd|robot>(SstvMode::Pd120 /* or Robot72 */, &img);
+    let sync_samples = (spec.sync_seconds * f64::from(crate::resample::WORKING_SAMPLE_RATE_HZ)) as usize;
+    let p_sync  = crate::dsp::goertzel_power(&audio[..sync_samples], crate::test_tone::SYNC_HZ);
+    let p_porch = crate::dsp::goertzel_power(&audio[..sync_samples], crate::test_tone::PORCH_HZ);
+    assert!(p_sync > 10.0 * p_porch, "line starts with SYNC tone");
+}
+
+// Length-matches-radio-frames check — catches a structural drift (extra/missing
+// septr, wrong channel count) without round-tripping.
+#[test]
+fn encode_<mode>_length_matches_radio_frames() {
+    let spec = crate::modespec::for_mode(SstvMode::Pd120 /* or Robot72 */);
+    let img = vec![[0_u8; 3]; (spec.line_pixels * spec.image_lines) as usize];
+    let audio = encode_<pd|robot>(SstvMode::Pd120 /* or Robot72 */, &img);
+    // PD packs 2 image rows / radio frame, so denominator is 2; Robot is 1.
+    let radio_frames = f64::from(spec.image_lines) / /* 2.0 for PD, 1.0 for Robot */;
+    let expected = (radio_frames * spec.line_seconds * f64::from(crate::resample::WORKING_SAMPLE_RATE_HZ)) as usize;
+    assert!((audio.len() as i64 - expected as i64).abs() < 64, "audio len {} ≉ {}", audio.len(), expected);
+}
+```
+
+For Robot, the SYNC-first check targets one of the three Robot variants (pick Robot72 — 3 channels, no chroma alternation, simplest test setup). Existing `scottie_test_encoder` tests stay (update `SYNC_HZ` etc. references to `crate::test_tone::SYNC_HZ`).
+
+**C17 partial — `unreachable!()` / `expect()` after `assert!(matches!(...))`.** Each encoder opens with `assert!(matches!(mode, ...))` to constrain the supported variants, then later has `_ => unreachable!()` / `.expect("...")` arms on the same set. Resolution per site:
+
+- If the `unreachable!()` arm is on a `match` that already covers all supported variants exhaustively (no wildcard needed because the assert already proved exhaustiveness): replace the `match` with a closed form that doesn't need a wildcard.
+- If the wildcard is structurally required (e.g. `SstvMode` is `#[non_exhaustive]` — which it is): leave the `unreachable!()` but drop the redundant leading `assert!(matches!(...))` — the `unreachable!()` is sufficient (and will panic with a clearer message at the actual problem site instead of pre-emptively in the assert).
+
+The implementer picks the cleaner shape per site. Don't add new `#[allow]`s. If neither cleanup applies cleanly, leave both AND add an inline comment noting why both stay.
+
+**CHANGELOG `[Unreleased]` `### Internal`** entry:
+
+> Extracted `crate::test_tone` (continuous-phase FM tone generator) — consolidates the four pre-#86 copies in `pd_test_encoder` / `robot_test_encoder` / `scottie_test_encoder` / `vis::tests`. Tightened the test-encoder modules to `pub(crate) mod` so `slowrx::pd_test_encoder::*` (and `robot_test_encoder::*` / `scottie_test_encoder::*`) are no longer reachable externally; `__test_support` switched from `pub use` re-exports to thin `pub fn` wrappers (the sole consumer-facing path). Plus the scottie double-doc fix (E2), smoke tests for `encode_pd` / `encode_robot` (F11), and `unreachable!`/`expect` cleanup in the test encoders (C17 partial). Pure refactor: identical behavior, `slowrx::__test_support::mode_*::encode_*` paths stable for existing consumers. (#86; audit B9/B10/E2/F11/C17.)
+
+**Verification** — full local CI gate per repo convention:
+- `cargo test --all-features --locked --release` — `tests/roundtrip.rs` exercises all three encoders end-to-end on every mode; any drift in tone math or channel ordering surfaces here. Plus the new F11 smoke tests.
+- `cargo fmt --all -- --check`
+- `cargo clippy --all-targets --all-features -- -D warnings`
+- `RUSTDOCFLAGS=-D warnings cargo doc --no-deps --all-features`
+- Sanity grep — empty after the refactor:
+  ```bash
+  grep -rn "fn lum_to_freq\|fn fill_to\|SYNC_HZ:\s*f64\|PORCH_HZ:\s*f64\|BLACK_HZ:\s*f64\|WHITE_HZ:\s*f64\|SEPTR_HZ:\s*f64\|pub mod pd_test_encoder\|pub mod robot_test_encoder\|pub mod scottie_test_encoder" src/
+  ```
+  (`crate::test_tone` itself is the one legitimate definition site for the consts and `lum_to_freq`; the encoder modules are now `pub(crate) mod`.)
+
+## Out of scope
+
+- The remaining audit cleanups not in #86's bundle (#87 / #88 / #91-96) — separate.
+- `vis::tests::synth_vis` / `synth_tone` / `synth_tone_n` (the bare-tone helpers that don't carry phase) — staying in `vis::tests`; only the `synth_vis_with_offset` continuous-phase emitter migrates to `ToneWriter`.
+- The audit's deeper "move encoders to `tests/common/`" option — considered, rejected during brainstorming in favor of the lighter `pub(crate) mod` + wrapper-fn resolution that achieves the same B10 outcome without restructuring integration tests.
+
+## Files touched
+
+`src/test_tone.rs` (new), `src/lib.rs` (module decl flips + `__test_support` wrapper fns), `src/pd_test_encoder.rs`, `src/robot_test_encoder.rs`, `src/scottie_test_encoder.rs`, `src/vis.rs` (the `tests` module's `synth_vis_with_offset` + `r12bw_rejects_standard_parity` emit closures), `CHANGELOG.md`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,16 +57,13 @@ pub mod vis;
 pub(crate) mod test_tone;
 
 #[cfg(any(test, feature = "test-support"))]
-#[doc(hidden)]
-pub mod pd_test_encoder;
+pub(crate) mod pd_test_encoder;
 
 #[cfg(any(test, feature = "test-support"))]
-#[doc(hidden)]
-pub mod robot_test_encoder;
+pub(crate) mod robot_test_encoder;
 
 #[cfg(any(test, feature = "test-support"))]
-#[doc(hidden)]
-pub mod scottie_test_encoder;
+pub(crate) mod scottie_test_encoder;
 
 pub use crate::decoder::{SstvDecoder, SstvEvent};
 pub use crate::error::{Error, Result};
@@ -87,12 +84,34 @@ pub mod __test_support {
     }
     pub mod mode_pd {
         pub use crate::demod::ycbcr_to_rgb;
-        pub use crate::pd_test_encoder::encode_pd;
+
+        /// Thin wrapper around the now-`pub(crate)` `crate::pd_test_encoder::encode_pd`.
+        /// `__test_support` is the sole consumer-facing path for the synthetic
+        /// PD encoder (#86 B10).
+        #[doc(hidden)]
+        #[must_use]
+        pub fn encode_pd(mode: crate::modespec::SstvMode, ycrcb: &[[u8; 3]]) -> Vec<f32> {
+            crate::pd_test_encoder::encode_pd(mode, ycrcb)
+        }
     }
     pub mod mode_robot {
-        pub use crate::robot_test_encoder::encode_robot;
+        /// Thin wrapper around the now-`pub(crate)` `crate::robot_test_encoder::encode_robot`.
+        /// `__test_support` is the sole consumer-facing path for the synthetic
+        /// Robot encoder (#86 B10).
+        #[doc(hidden)]
+        #[must_use]
+        pub fn encode_robot(mode: crate::modespec::SstvMode, ycrcb: &[[u8; 3]]) -> Vec<f32> {
+            crate::robot_test_encoder::encode_robot(mode, ycrcb)
+        }
     }
     pub mod mode_scottie {
-        pub use crate::scottie_test_encoder::encode_scottie;
+        /// Thin wrapper around the now-`pub(crate)` `crate::scottie_test_encoder::encode_scottie`.
+        /// `__test_support` is the sole consumer-facing path for the synthetic
+        /// Scottie/Martin encoder (#86 B10).
+        #[doc(hidden)]
+        #[must_use]
+        pub fn encode_scottie(mode: crate::modespec::SstvMode, rgb: &[[u8; 3]]) -> Vec<f32> {
+            crate::scottie_test_encoder::encode_scottie(mode, rgb)
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,9 @@ pub(crate) mod sync;
 pub mod vis;
 
 #[cfg(any(test, feature = "test-support"))]
+pub(crate) mod test_tone;
+
+#[cfg(any(test, feature = "test-support"))]
 #[doc(hidden)]
 pub mod pd_test_encoder;
 

--- a/src/pd_test_encoder.rs
+++ b/src/pd_test_encoder.rs
@@ -21,9 +21,8 @@ use crate::test_tone::{lum_to_freq, ToneWriter, PORCH_HZ, SYNC_HZ};
 /// of rows share averaged chroma, matching how the decoder will recover
 /// them.
 #[must_use]
-#[doc(hidden)]
 #[allow(dead_code)]
-pub fn encode_pd(mode: SstvMode, ycrcb: &[[u8; 3]]) -> Vec<f32> {
+pub(crate) fn encode_pd(mode: SstvMode, ycrcb: &[[u8; 3]]) -> Vec<f32> {
     assert!(matches!(
         mode,
         SstvMode::Pd120 | SstvMode::Pd180 | SstvMode::Pd240

--- a/src/pd_test_encoder.rs
+++ b/src/pd_test_encoder.rs
@@ -14,33 +14,7 @@
 
 use crate::modespec::SstvMode;
 use crate::resample::WORKING_SAMPLE_RATE_HZ;
-use std::f64::consts::PI;
-
-const SYNC_HZ: f64 = 1200.0;
-const PORCH_HZ: f64 = 1500.0;
-const BLACK_HZ: f64 = 1500.0;
-const WHITE_HZ: f64 = 2300.0;
-
-fn lum_to_freq(lum: u8) -> f64 {
-    BLACK_HZ + (WHITE_HZ - BLACK_HZ) * f64::from(lum) / 255.0
-}
-
-/// Encoder helper: emit samples up to sample index `target_n` (exclusive)
-/// at frequency `freq_hz`, advancing both the running sample count `n`
-/// and the running phase. Using cumulative sample targets prevents the
-/// per-tone rounding error that would otherwise compound over the line
-/// (640 pixels × ~0.094 sample/pixel rounding error per pixel adds up to
-/// 60+ samples per line at PD120, breaking decoder line alignment).
-fn fill_to(out: &mut Vec<f32>, freq_hz: f64, target_n: usize, phase: &mut f64) {
-    let dphi = 2.0 * PI * freq_hz / f64::from(WORKING_SAMPLE_RATE_HZ);
-    while out.len() < target_n {
-        out.push(phase.sin() as f32);
-        *phase += dphi;
-        if *phase > 2.0 * PI {
-            *phase -= 2.0 * PI;
-        }
-    }
-}
+use crate::test_tone::{lum_to_freq, ToneWriter, PORCH_HZ, SYNC_HZ};
 
 /// Encode an image as PD-family audio (PD120 / PD180 / PD240). `ycrcb`
 /// is row-major `[Y, Cr, Cb]` triples of length `width * height`. Pairs
@@ -61,8 +35,7 @@ pub fn encode_pd(mode: SstvMode, ycrcb: &[[u8; 3]]) -> Vec<f32> {
     assert_eq!(h % 2, 0);
 
     let sr = f64::from(WORKING_SAMPLE_RATE_HZ);
-    let mut out = Vec::new();
-    let mut phase = 0.0_f64;
+    let mut tone = ToneWriter::new();
 
     // Cumulative time tracker (seconds). Targets are computed as
     // `(running_t * sr).round()` so per-event rounding doesn't drift.
@@ -73,63 +46,33 @@ pub fn encode_pd(mode: SstvMode, ycrcb: &[[u8; 3]]) -> Vec<f32> {
     };
 
     for y_pair in 0..h / 2 {
-        fill_to(
-            &mut out,
-            SYNC_HZ,
-            advance(&mut t, spec.sync_seconds),
-            &mut phase,
-        );
-        fill_to(
-            &mut out,
-            PORCH_HZ,
-            advance(&mut t, spec.porch_seconds),
-            &mut phase,
-        );
+        tone.fill_to(SYNC_HZ, advance(&mut t, spec.sync_seconds));
+        tone.fill_to(PORCH_HZ, advance(&mut t, spec.porch_seconds));
 
         // Y(odd row).
         for x in 0..w {
             let lum = ycrcb[((y_pair * 2) * w + x) as usize][0];
-            fill_to(
-                &mut out,
-                lum_to_freq(lum),
-                advance(&mut t, spec.pixel_seconds),
-                &mut phase,
-            );
+            tone.fill_to(lum_to_freq(lum), advance(&mut t, spec.pixel_seconds));
         }
         // Cr (averaged across pair).
         for x in 0..w {
             let cr_a = ycrcb[((y_pair * 2) * w + x) as usize][1];
             let cr_b = ycrcb[((y_pair * 2 + 1) * w + x) as usize][1];
             let cr = u8::midpoint(cr_a, cr_b);
-            fill_to(
-                &mut out,
-                lum_to_freq(cr),
-                advance(&mut t, spec.pixel_seconds),
-                &mut phase,
-            );
+            tone.fill_to(lum_to_freq(cr), advance(&mut t, spec.pixel_seconds));
         }
         // Cb (averaged).
         for x in 0..w {
             let cb_a = ycrcb[((y_pair * 2) * w + x) as usize][2];
             let cb_b = ycrcb[((y_pair * 2 + 1) * w + x) as usize][2];
             let cb = u8::midpoint(cb_a, cb_b);
-            fill_to(
-                &mut out,
-                lum_to_freq(cb),
-                advance(&mut t, spec.pixel_seconds),
-                &mut phase,
-            );
+            tone.fill_to(lum_to_freq(cb), advance(&mut t, spec.pixel_seconds));
         }
         // Y(even row).
         for x in 0..w {
             let lum = ycrcb[((y_pair * 2 + 1) * w + x) as usize][0];
-            fill_to(
-                &mut out,
-                lum_to_freq(lum),
-                advance(&mut t, spec.pixel_seconds),
-                &mut phase,
-            );
+            tone.fill_to(lum_to_freq(lum), advance(&mut t, spec.pixel_seconds));
         }
     }
-    out
+    tone.into_vec()
 }

--- a/src/pd_test_encoder.rs
+++ b/src/pd_test_encoder.rs
@@ -75,3 +75,55 @@ pub(crate) fn encode_pd(mode: SstvMode, ycrcb: &[[u8; 3]]) -> Vec<f32> {
     }
     tone.into_vec()
 }
+
+#[cfg(test)]
+#[allow(
+    clippy::cast_precision_loss,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    clippy::cast_possible_wrap
+)]
+mod tests {
+    use super::*;
+    use crate::modespec::{for_mode, SstvMode};
+
+    /// A regression in channel order surfaces here as a pointed failure
+    /// instead of a fuzzy roundtrip pixel-diff.
+    #[test]
+    fn encode_pd120_first_tone_is_sync_hz() {
+        let spec = for_mode(SstvMode::Pd120);
+        let img = vec![[128_u8, 128, 128]; (spec.line_pixels * spec.image_lines) as usize];
+        let audio = encode_pd(SstvMode::Pd120, &img);
+        let sync_samples =
+            (spec.sync_seconds * f64::from(crate::resample::WORKING_SAMPLE_RATE_HZ)) as usize;
+        assert!(audio.len() >= sync_samples, "audio too short");
+        let p_sync = crate::dsp::goertzel_power(&audio[..sync_samples], crate::test_tone::SYNC_HZ);
+        let p_porch =
+            crate::dsp::goertzel_power(&audio[..sync_samples], crate::test_tone::PORCH_HZ);
+        assert!(
+            p_sync > 10.0 * p_porch,
+            "PD line starts with SYNC tone (p_sync={p_sync}, p_porch={p_porch})"
+        );
+    }
+
+    /// Catches structural drift — extra/missing septr, wrong channel count —
+    /// without round-tripping.
+    #[test]
+    fn encode_pd120_length_matches_radio_frames() {
+        let spec = for_mode(SstvMode::Pd120);
+        let img = vec![[0_u8; 3]; (spec.line_pixels * spec.image_lines) as usize];
+        let audio = encode_pd(SstvMode::Pd120, &img);
+        // PD packs 2 image rows / radio frame.
+        let radio_frames = f64::from(spec.image_lines) / 2.0;
+        let expected = (radio_frames
+            * spec.line_seconds
+            * f64::from(crate::resample::WORKING_SAMPLE_RATE_HZ)) as usize;
+        let diff = (audio.len() as i64 - expected as i64).abs();
+        assert!(
+            diff < 64,
+            "PD120 audio len {} ≉ {expected} (diff {})",
+            audio.len(),
+            diff
+        );
+    }
+}

--- a/src/robot_test_encoder.rs
+++ b/src/robot_test_encoder.rs
@@ -33,9 +33,8 @@ use crate::test_tone::{lum_to_freq, ToneWriter, PORCH_HZ, SEPTR_HZ, SYNC_HZ};
 /// the neighbor row, so the source ycrcb buffer must have adjacent rows
 /// share chroma (see file-level doc).
 #[must_use]
-#[doc(hidden)]
 #[allow(dead_code)]
-pub fn encode_robot(mode: SstvMode, ycrcb: &[[u8; 3]]) -> Vec<f32> {
+pub(crate) fn encode_robot(mode: SstvMode, ycrcb: &[[u8; 3]]) -> Vec<f32> {
     assert!(matches!(
         mode,
         SstvMode::Robot24 | SstvMode::Robot36 | SstvMode::Robot72

--- a/src/robot_test_encoder.rs
+++ b/src/robot_test_encoder.rs
@@ -54,9 +54,10 @@ pub(crate) fn encode_robot(mode: SstvMode, ycrcb: &[[u8; 3]]) -> Vec<f32> {
         SstvMode::Robot24 | SstvMode::Robot36 => {
             encode_r36_or_r24(&mut tone, &mut t, advance, &spec, ycrcb);
         }
-        // SstvMode is `#[non_exhaustive]` so the wildcard arm is structurally
-        // required even though the three Robot variants above are the only
-        // mode values this fn is meant to handle. (audit C17)
+        // `SstvMode` has variants beyond the three Robot ones (PD, Scottie,
+        // Martin) so the wildcard arm is structurally required by the
+        // exhaustiveness check — `encode_robot` is only meant to handle the
+        // three Robot variants matched above. (audit C17)
         _ => unreachable!("encode_robot called with non-Robot mode {mode:?}"),
     }
 

--- a/src/robot_test_encoder.rs
+++ b/src/robot_test_encoder.rs
@@ -22,30 +22,7 @@
 
 use crate::modespec::SstvMode;
 use crate::resample::WORKING_SAMPLE_RATE_HZ;
-use std::f64::consts::PI;
-
-const SYNC_HZ: f64 = 1200.0;
-const PORCH_HZ: f64 = 1500.0;
-const BLACK_HZ: f64 = 1500.0;
-const WHITE_HZ: f64 = 2300.0;
-
-fn lum_to_freq(lum: u8) -> f64 {
-    BLACK_HZ + (WHITE_HZ - BLACK_HZ) * f64::from(lum) / 255.0
-}
-
-/// Emit samples up to absolute sample index `target_n`, advancing phase.
-/// Cumulative-target pattern (matches `pd_test_encoder::fill_to`) so
-/// per-tone rounding doesn't compound across the line.
-fn fill_to(out: &mut Vec<f32>, freq_hz: f64, target_n: usize, phase: &mut f64) {
-    let dphi = 2.0 * PI * freq_hz / f64::from(WORKING_SAMPLE_RATE_HZ);
-    while out.len() < target_n {
-        out.push(phase.sin() as f32);
-        *phase += dphi;
-        if *phase > 2.0 * PI {
-            *phase -= 2.0 * PI;
-        }
-    }
-}
+use crate::test_tone::{lum_to_freq, ToneWriter, PORCH_HZ, SEPTR_HZ, SYNC_HZ};
 
 /// Encode an image as Robot 24 / 36 / 72 audio. `ycrcb` is row-major
 /// `[Y, Cr, Cb]` triples of length `width * height`.
@@ -69,8 +46,7 @@ pub fn encode_robot(mode: SstvMode, ycrcb: &[[u8; 3]]) -> Vec<f32> {
     assert_eq!(ycrcb.len() as u32, w * h);
 
     let sr = f64::from(WORKING_SAMPLE_RATE_HZ);
-    let mut out = Vec::new();
-    let mut phase = 0.0_f64;
+    let mut tone = ToneWriter::new();
 
     let mut t = 0.0_f64;
     let advance = |t: &mut f64, secs: f64| -> usize {
@@ -79,20 +55,18 @@ pub fn encode_robot(mode: SstvMode, ycrcb: &[[u8; 3]]) -> Vec<f32> {
     };
 
     match mode {
-        SstvMode::Robot72 => encode_r72(&mut out, &mut phase, &mut t, advance, &spec, ycrcb),
+        SstvMode::Robot72 => encode_r72(&mut tone, &mut t, advance, &spec, ycrcb),
         SstvMode::Robot24 | SstvMode::Robot36 => {
-            encode_r36_or_r24(&mut out, &mut phase, &mut t, advance, &spec, ycrcb);
+            encode_r36_or_r24(&mut tone, &mut t, advance, &spec, ycrcb);
         }
         _ => unreachable!(),
     }
 
-    out
+    tone.into_vec()
 }
 
-#[allow(clippy::too_many_arguments)]
 fn encode_r72(
-    out: &mut Vec<f32>,
-    phase: &mut f64,
+    tone: &mut ToneWriter,
     t: &mut f64,
     mut advance: impl FnMut(&mut f64, f64) -> usize,
     spec: &crate::modespec::ModeSpec,
@@ -102,31 +76,31 @@ fn encode_r72(
     let h = spec.image_lines;
     for y in 0..h {
         // Sync + porch.
-        fill_to(out, SYNC_HZ, advance(t, spec.sync_seconds), phase);
-        fill_to(out, PORCH_HZ, advance(t, spec.porch_seconds), phase);
+        tone.fill_to(SYNC_HZ, advance(t, spec.sync_seconds));
+        tone.fill_to(PORCH_HZ, advance(t, spec.porch_seconds));
 
         // Y channel.
         for x in 0..w {
             let lum = ycrcb[(y * w + x) as usize][0];
-            fill_to(out, lum_to_freq(lum), advance(t, spec.pixel_seconds), phase);
+            tone.fill_to(lum_to_freq(lum), advance(t, spec.pixel_seconds));
         }
 
         // Septr between Y and U (Cr).
-        fill_to(out, PORCH_HZ, advance(t, spec.septr_seconds), phase);
+        tone.fill_to(SEPTR_HZ, advance(t, spec.septr_seconds));
 
         // U (Cr) channel.
         for x in 0..w {
             let cr = ycrcb[(y * w + x) as usize][1];
-            fill_to(out, lum_to_freq(cr), advance(t, spec.pixel_seconds), phase);
+            tone.fill_to(lum_to_freq(cr), advance(t, spec.pixel_seconds));
         }
 
         // Septr between U and V.
-        fill_to(out, PORCH_HZ, advance(t, spec.septr_seconds), phase);
+        tone.fill_to(SEPTR_HZ, advance(t, spec.septr_seconds));
 
         // V (Cb) channel.
         for x in 0..w {
             let cb = ycrcb[(y * w + x) as usize][2];
-            fill_to(out, lum_to_freq(cb), advance(t, spec.pixel_seconds), phase);
+            tone.fill_to(lum_to_freq(cb), advance(t, spec.pixel_seconds));
         }
 
         // Pad to spec.line_seconds boundary. R72's per-line content
@@ -139,7 +113,7 @@ fn encode_r72(
         let line_end_target = f64::from(y + 1) * spec.line_seconds;
         let pad_secs = line_end_target - *t;
         if pad_secs > 0.0 {
-            fill_to(out, PORCH_HZ, advance(t, pad_secs), phase);
+            tone.fill_to(PORCH_HZ, advance(t, pad_secs));
         }
     }
 }
@@ -157,13 +131,11 @@ fn encode_r72(
 ///   - Porch at `PORCH_HZ`
 ///   - Y for image row N at `pixel_seconds * 2` per pixel (so total Y
 ///     duration = `pixel_seconds` * 2 * width = `ChanLen[0]`)
-///   - Septr at `PORCH_HZ`
+///   - Septr at `SEPTR_HZ`
 ///   - Chroma for image row N at `pixel_seconds` per pixel: Cr if `N%2==0`,
 ///     Cb if `N%2==1`
-#[allow(clippy::too_many_arguments)]
 fn encode_r36_or_r24(
-    out: &mut Vec<f32>,
-    phase: &mut f64,
+    tone: &mut ToneWriter,
     t: &mut f64,
     mut advance: impl FnMut(&mut f64, f64) -> usize,
     spec: &crate::modespec::ModeSpec,
@@ -173,36 +145,26 @@ fn encode_r36_or_r24(
     let h = spec.image_lines;
     for y in 0..h {
         // Sync + porch.
-        fill_to(out, SYNC_HZ, advance(t, spec.sync_seconds), phase);
-        fill_to(out, PORCH_HZ, advance(t, spec.porch_seconds), phase);
+        tone.fill_to(SYNC_HZ, advance(t, spec.sync_seconds));
+        tone.fill_to(PORCH_HZ, advance(t, spec.porch_seconds));
 
         // Y channel — emit at `pixel_seconds * 2` per source pixel so
         // the total Y allocation equals ChanLen[0] = pixel_seconds *
         // width * 2 per slowrx video.c:60-70 (R36/R24 case).
         for x in 0..w {
             let lum = ycrcb[(y * w + x) as usize][0];
-            fill_to(
-                out,
-                lum_to_freq(lum),
-                advance(t, spec.pixel_seconds * 2.0),
-                phase,
-            );
+            tone.fill_to(lum_to_freq(lum), advance(t, spec.pixel_seconds * 2.0));
         }
 
         // Septr between Y and chroma.
-        fill_to(out, PORCH_HZ, advance(t, spec.septr_seconds), phase);
+        tone.fill_to(SEPTR_HZ, advance(t, spec.septr_seconds));
 
         // Chroma — Cr (ycrcb index 1) on even rows, Cb (ycrcb index 2)
         // on odd. One sample per `pixel_seconds`.
         let chroma_idx = if y % 2 == 0 { 1_usize } else { 2_usize };
         for x in 0..w {
             let chroma = ycrcb[(y * w + x) as usize][chroma_idx];
-            fill_to(
-                out,
-                lum_to_freq(chroma),
-                advance(t, spec.pixel_seconds),
-                phase,
-            );
+            tone.fill_to(lum_to_freq(chroma), advance(t, spec.pixel_seconds));
         }
     }
 }

--- a/src/robot_test_encoder.rs
+++ b/src/robot_test_encoder.rs
@@ -35,10 +35,6 @@ use crate::test_tone::{lum_to_freq, ToneWriter, PORCH_HZ, SEPTR_HZ, SYNC_HZ};
 #[must_use]
 #[allow(dead_code)]
 pub(crate) fn encode_robot(mode: SstvMode, ycrcb: &[[u8; 3]]) -> Vec<f32> {
-    assert!(matches!(
-        mode,
-        SstvMode::Robot24 | SstvMode::Robot36 | SstvMode::Robot72
-    ));
     let spec = crate::modespec::for_mode(mode);
     let w = spec.line_pixels;
     let h = spec.image_lines;
@@ -58,7 +54,10 @@ pub(crate) fn encode_robot(mode: SstvMode, ycrcb: &[[u8; 3]]) -> Vec<f32> {
         SstvMode::Robot24 | SstvMode::Robot36 => {
             encode_r36_or_r24(&mut tone, &mut t, advance, &spec, ycrcb);
         }
-        _ => unreachable!(),
+        // SstvMode is `#[non_exhaustive]` so the wildcard arm is structurally
+        // required even though the three Robot variants above are the only
+        // mode values this fn is meant to handle. (audit C17)
+        _ => unreachable!("encode_robot called with non-Robot mode {mode:?}"),
     }
 
     tone.into_vec()

--- a/src/robot_test_encoder.rs
+++ b/src/robot_test_encoder.rs
@@ -166,3 +166,55 @@ fn encode_r36_or_r24(
         }
     }
 }
+
+#[cfg(test)]
+#[allow(
+    clippy::cast_precision_loss,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    clippy::cast_possible_wrap
+)]
+mod tests {
+    use super::*;
+    use crate::modespec::{for_mode, SstvMode};
+
+    /// A regression in Robot channel order surfaces here as a pointed
+    /// failure instead of a fuzzy roundtrip pixel-diff. Tests Robot72
+    /// (simplest of the three Robot variants — 3 channels, no chroma
+    /// alternation).
+    #[test]
+    fn encode_robot72_first_tone_is_sync_hz() {
+        let spec = for_mode(SstvMode::Robot72);
+        let img = vec![[128_u8, 128, 128]; (spec.line_pixels * spec.image_lines) as usize];
+        let audio = encode_robot(SstvMode::Robot72, &img);
+        let sync_samples =
+            (spec.sync_seconds * f64::from(crate::resample::WORKING_SAMPLE_RATE_HZ)) as usize;
+        assert!(audio.len() >= sync_samples, "audio too short");
+        let p_sync = crate::dsp::goertzel_power(&audio[..sync_samples], crate::test_tone::SYNC_HZ);
+        let p_porch =
+            crate::dsp::goertzel_power(&audio[..sync_samples], crate::test_tone::PORCH_HZ);
+        assert!(
+            p_sync > 10.0 * p_porch,
+            "Robot72 line starts with SYNC tone (p_sync={p_sync}, p_porch={p_porch})"
+        );
+    }
+
+    #[test]
+    fn encode_robot72_length_matches_radio_lines() {
+        let spec = for_mode(SstvMode::Robot72);
+        let img = vec![[0_u8; 3]; (spec.line_pixels * spec.image_lines) as usize];
+        let audio = encode_robot(SstvMode::Robot72, &img);
+        // Robot: 1 image row per radio line.
+        let radio_lines = f64::from(spec.image_lines);
+        let expected = (radio_lines
+            * spec.line_seconds
+            * f64::from(crate::resample::WORKING_SAMPLE_RATE_HZ)) as usize;
+        let diff = (audio.len() as i64 - expected as i64).abs();
+        assert!(
+            diff < 64,
+            "Robot72 audio len {} ≉ {expected} (diff {})",
+            audio.len(),
+            diff
+        );
+    }
+}

--- a/src/scottie_test_encoder.rs
+++ b/src/scottie_test_encoder.rs
@@ -18,7 +18,7 @@
 //!   [R pixels 1500-2300 Hz]
 //! ```
 //!
-//! Total per line = LineTime exactly (defensive pad fills the
+//! Total per line = `LineTime` exactly (defensive pad fills the
 //! boundary if float arithmetic rounds short).
 
 #![allow(
@@ -32,23 +32,13 @@ use crate::modespec::SstvMode;
 use crate::resample::WORKING_SAMPLE_RATE_HZ;
 use crate::test_tone::{lum_to_freq, ToneWriter, PORCH_HZ, SEPTR_HZ, SYNC_HZ};
 
-/// Encode an image as Scottie 1 / 2 / DX audio. `rgb` is row-major,
-/// `line_pixels × image_lines` `[R, G, B]` triples (320×256 for all
-/// three Scottie modes). Returns f32 PCM at [`WORKING_SAMPLE_RATE_HZ`]
-/// (11_025 Hz).
-///
-/// Per radio line, emits in this order:
-///   1. Septr 1 at `SEPTR_HZ`
-///   2. G channel at `pixel_seconds` per pixel
-///   3. Septr 2 at `SEPTR_HZ`
-///   4. B channel at `pixel_seconds` per pixel
-///   5. Sync at `SYNC_HZ` (mid-line, between B and R)
-///   6. Porch at `PORCH_HZ`
-///   7. R channel at `pixel_seconds` per pixel
-#[must_use]
 /// Encode an RGB image as continuous-phase FM audio for either
-/// Scottie (S1/S2/DX) or Martin (M1/M2). The per-line tone emission
-/// order branches on `spec.sync_position`:
+/// Scottie (S1/S2/DX) or Martin (M1/M2). `rgb` is row-major,
+/// `line_pixels × image_lines` `[R, G, B]` triples (320×256 for all
+/// Scottie modes). Returns f32 PCM at [`WORKING_SAMPLE_RATE_HZ`]
+/// (`11_025` Hz).
+///
+/// The per-line tone emission order branches on `spec.sync_position`:
 ///
 /// - [`crate::modespec::SyncPosition::Scottie`] —
 ///   `[septr][G][septr][B][SYNC][porch][R]` (sync mid-line).
@@ -58,9 +48,9 @@ use crate::test_tone::{lum_to_freq, ToneWriter, PORCH_HZ, SEPTR_HZ, SYNC_HZ};
 ///
 /// Panics if `mode` is not one of the five supported variants or if
 /// `rgb.len() != line_pixels * image_lines`.
-#[doc(hidden)]
+#[must_use]
 #[allow(dead_code, clippy::too_many_lines)]
-pub fn encode_scottie(mode: SstvMode, rgb: &[[u8; 3]]) -> Vec<f32> {
+pub(crate) fn encode_scottie(mode: SstvMode, rgb: &[[u8; 3]]) -> Vec<f32> {
     assert!(matches!(
         mode,
         SstvMode::Scottie1

--- a/src/scottie_test_encoder.rs
+++ b/src/scottie_test_encoder.rs
@@ -157,13 +157,11 @@ pub(crate) fn encode_scottie(mode: SstvMode, rgb: &[[u8; 3]]) -> Vec<f32> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_tone::{BLACK_HZ, WHITE_HZ};
 
-    #[test]
-    fn lum_to_freq_endpoints() {
-        assert!((lum_to_freq(0) - BLACK_HZ).abs() < 1e-9);
-        assert!((lum_to_freq(255) - WHITE_HZ).abs() < 1e-9);
-    }
+    // Note: `lum_to_freq` endpoint coverage lives in
+    // `crate::test_tone::tests::lum_to_freq_endpoints_match_black_and_white`
+    // (its canonical home post-#86). Testing it from a consumer is
+    // misleading about ownership.
 
     #[test]
     fn scottie1_encode_total_length() {

--- a/src/scottie_test_encoder.rs
+++ b/src/scottie_test_encoder.rs
@@ -30,31 +30,7 @@
 
 use crate::modespec::SstvMode;
 use crate::resample::WORKING_SAMPLE_RATE_HZ;
-use std::f64::consts::PI;
-
-const SYNC_HZ: f64 = 1200.0;
-const PORCH_HZ: f64 = 1500.0;
-const SEPTR_HZ: f64 = 1500.0;
-const BLACK_HZ: f64 = 1500.0;
-const WHITE_HZ: f64 = 2300.0;
-
-fn lum_to_freq(lum: u8) -> f64 {
-    BLACK_HZ + (WHITE_HZ - BLACK_HZ) * f64::from(lum) / 255.0
-}
-
-/// Emit samples up to absolute sample index `target_n`, advancing phase.
-/// Cumulative-target pattern (matches `robot_test_encoder::fill_to`) so
-/// per-tone rounding doesn't compound across the line.
-fn fill_to(out: &mut Vec<f32>, freq_hz: f64, target_n: usize, phase: &mut f64) {
-    let dphi = 2.0 * PI * freq_hz / f64::from(WORKING_SAMPLE_RATE_HZ);
-    while out.len() < target_n {
-        out.push(phase.sin() as f32);
-        *phase += dphi;
-        if *phase > 2.0 * PI {
-            *phase -= 2.0 * PI;
-        }
-    }
-}
+use crate::test_tone::{lum_to_freq, ToneWriter, PORCH_HZ, SEPTR_HZ, SYNC_HZ};
 
 /// Encode an image as Scottie 1 / 2 / DX audio. `rgb` is row-major,
 /// `line_pixels × image_lines` `[R, G, B]` triples (320×256 for all
@@ -99,8 +75,7 @@ pub fn encode_scottie(mode: SstvMode, rgb: &[[u8; 3]]) -> Vec<f32> {
     assert_eq!(rgb.len() as u32, w * h);
 
     let sr = f64::from(WORKING_SAMPLE_RATE_HZ);
-    let mut out: Vec<f32> = Vec::new();
-    let mut phase = 0.0_f64;
+    let mut tone = ToneWriter::new();
 
     let mut t = 0.0_f64;
     let advance = |t: &mut f64, secs: f64| -> usize {
@@ -112,68 +87,33 @@ pub fn encode_scottie(mode: SstvMode, rgb: &[[u8; 3]]) -> Vec<f32> {
         match spec.sync_position {
             crate::modespec::SyncPosition::Scottie => {
                 // Septr 1.
-                fill_to(
-                    &mut out,
-                    SEPTR_HZ,
-                    advance(&mut t, spec.septr_seconds),
-                    &mut phase,
-                );
+                tone.fill_to(SEPTR_HZ, advance(&mut t, spec.septr_seconds));
 
                 // G channel.
                 for x in 0..w {
                     let g = rgb[(y * w + x) as usize][1];
-                    fill_to(
-                        &mut out,
-                        lum_to_freq(g),
-                        advance(&mut t, spec.pixel_seconds),
-                        &mut phase,
-                    );
+                    tone.fill_to(lum_to_freq(g), advance(&mut t, spec.pixel_seconds));
                 }
 
                 // Septr 2.
-                fill_to(
-                    &mut out,
-                    SEPTR_HZ,
-                    advance(&mut t, spec.septr_seconds),
-                    &mut phase,
-                );
+                tone.fill_to(SEPTR_HZ, advance(&mut t, spec.septr_seconds));
 
                 // B channel.
                 for x in 0..w {
                     let b = rgb[(y * w + x) as usize][2];
-                    fill_to(
-                        &mut out,
-                        lum_to_freq(b),
-                        advance(&mut t, spec.pixel_seconds),
-                        &mut phase,
-                    );
+                    tone.fill_to(lum_to_freq(b), advance(&mut t, spec.pixel_seconds));
                 }
 
                 // Sync (mid-line, between B and R).
-                fill_to(
-                    &mut out,
-                    SYNC_HZ,
-                    advance(&mut t, spec.sync_seconds),
-                    &mut phase,
-                );
+                tone.fill_to(SYNC_HZ, advance(&mut t, spec.sync_seconds));
 
                 // Porch.
-                fill_to(
-                    &mut out,
-                    PORCH_HZ,
-                    advance(&mut t, spec.porch_seconds),
-                    &mut phase,
-                );
+                tone.fill_to(PORCH_HZ, advance(&mut t, spec.porch_seconds));
 
                 // R channel.
                 for x in 0..w {
                     let r = rgb[(y * w + x) as usize][0];
-                    fill_to(
-                        &mut out,
-                        lum_to_freq(r),
-                        advance(&mut t, spec.pixel_seconds),
-                        &mut phase,
-                    );
+                    tone.fill_to(lum_to_freq(r), advance(&mut t, spec.pixel_seconds));
                 }
             }
             crate::modespec::SyncPosition::LineStart => {
@@ -181,68 +121,33 @@ pub fn encode_scottie(mode: SstvMode, rgb: &[[u8; 3]]) -> Vec<f32> {
                 // G/septr/B/septr/R.
 
                 // Sync.
-                fill_to(
-                    &mut out,
-                    SYNC_HZ,
-                    advance(&mut t, spec.sync_seconds),
-                    &mut phase,
-                );
+                tone.fill_to(SYNC_HZ, advance(&mut t, spec.sync_seconds));
 
                 // Porch.
-                fill_to(
-                    &mut out,
-                    PORCH_HZ,
-                    advance(&mut t, spec.porch_seconds),
-                    &mut phase,
-                );
+                tone.fill_to(PORCH_HZ, advance(&mut t, spec.porch_seconds));
 
                 // G channel.
                 for x in 0..w {
                     let g = rgb[(y * w + x) as usize][1];
-                    fill_to(
-                        &mut out,
-                        lum_to_freq(g),
-                        advance(&mut t, spec.pixel_seconds),
-                        &mut phase,
-                    );
+                    tone.fill_to(lum_to_freq(g), advance(&mut t, spec.pixel_seconds));
                 }
 
                 // Septr 1.
-                fill_to(
-                    &mut out,
-                    SEPTR_HZ,
-                    advance(&mut t, spec.septr_seconds),
-                    &mut phase,
-                );
+                tone.fill_to(SEPTR_HZ, advance(&mut t, spec.septr_seconds));
 
                 // B channel.
                 for x in 0..w {
                     let b = rgb[(y * w + x) as usize][2];
-                    fill_to(
-                        &mut out,
-                        lum_to_freq(b),
-                        advance(&mut t, spec.pixel_seconds),
-                        &mut phase,
-                    );
+                    tone.fill_to(lum_to_freq(b), advance(&mut t, spec.pixel_seconds));
                 }
 
                 // Septr 2.
-                fill_to(
-                    &mut out,
-                    SEPTR_HZ,
-                    advance(&mut t, spec.septr_seconds),
-                    &mut phase,
-                );
+                tone.fill_to(SEPTR_HZ, advance(&mut t, spec.septr_seconds));
 
                 // R channel.
                 for x in 0..w {
                     let r = rgb[(y * w + x) as usize][0];
-                    fill_to(
-                        &mut out,
-                        lum_to_freq(r),
-                        advance(&mut t, spec.pixel_seconds),
-                        &mut phase,
-                    );
+                    tone.fill_to(lum_to_freq(r), advance(&mut t, spec.pixel_seconds));
                 }
             }
         }
@@ -252,16 +157,17 @@ pub fn encode_scottie(mode: SstvMode, rgb: &[[u8; 3]]) -> Vec<f32> {
         let line_end_target = f64::from(y + 1) * spec.line_seconds;
         let pad_secs = line_end_target - t;
         if pad_secs > 0.0 {
-            fill_to(&mut out, PORCH_HZ, advance(&mut t, pad_secs), &mut phase);
+            tone.fill_to(PORCH_HZ, advance(&mut t, pad_secs));
         }
     }
 
-    out
+    tone.into_vec()
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_tone::{BLACK_HZ, WHITE_HZ};
 
     #[test]
     fn lum_to_freq_endpoints() {

--- a/src/test_tone.rs
+++ b/src/test_tone.rs
@@ -1,0 +1,171 @@
+//! Continuous-phase FM tone generator for the synthetic test encoders.
+//!
+//! Consolidates the four pre-#86 copies in `pd_test_encoder.rs`,
+//! `robot_test_encoder.rs`, `scottie_test_encoder.rs`, and
+//! `vis.rs::tests`. The SSTV-specific frequency constants (`SYNC_HZ` =
+//! 1200 Hz, the 1500 Hz `PORCH_HZ` / `SEPTR_HZ` / `BLACK_HZ`, the 2300 Hz
+//! `WHITE_HZ`) live here too, as does the `lum_to_freq(lum) → Hz`
+//! mapping.
+//!
+//! [`ToneWriter`] owns the output `Vec<f32>` and a running `phase`
+//! accumulator. Two emission forms share the same `phase`:
+//! [`ToneWriter::fill_to`] (cumulative absolute sample target — used by
+//! the encoders; prevents per-tone rounding drift across a multi-channel
+//! line) and [`ToneWriter::fill_secs`] (per-tone wall-clock duration —
+//! used by VIS bursts where each tone has a fixed duration).
+//!
+//! Gated under `cfg(any(test, feature = "test-support"))` — not part of
+//! the published API.
+
+use std::f64::consts::PI;
+
+use crate::resample::WORKING_SAMPLE_RATE_HZ;
+
+pub(crate) const SYNC_HZ: f64 = 1200.0;
+pub(crate) const PORCH_HZ: f64 = 1500.0;
+/// Same value as `PORCH_HZ` / `BLACK_HZ` (1500 Hz), named for SSTV-spec clarity.
+pub(crate) const SEPTR_HZ: f64 = 1500.0;
+pub(crate) const BLACK_HZ: f64 = 1500.0;
+pub(crate) const WHITE_HZ: f64 = 2300.0;
+
+/// Map an 8-bit luminance value to its FM frequency in Hz.
+/// Linear interpolation between [`BLACK_HZ`] (lum=0) and [`WHITE_HZ`] (lum=255).
+#[must_use]
+pub(crate) fn lum_to_freq(lum: u8) -> f64 {
+    BLACK_HZ + (WHITE_HZ - BLACK_HZ) * f64::from(lum) / 255.0
+}
+
+/// Continuous-phase FM tone writer. Owns the output `Vec<f32>` and a
+/// running `phase` accumulator so consecutive tones produce no audible
+/// discontinuity at boundaries.
+pub(crate) struct ToneWriter {
+    out: Vec<f32>,
+    phase: f64,
+}
+
+impl ToneWriter {
+    pub fn new() -> Self {
+        Self {
+            out: Vec::new(),
+            phase: 0.0,
+        }
+    }
+
+    /// Construct with `n` zero samples already in `out` (encoder pre-silence
+    /// or VIS pre-silence). Phase starts at 0.
+    pub fn with_pre_silence_samples(n: usize) -> Self {
+        Self {
+            out: vec![0.0; n],
+            phase: 0.0,
+        }
+    }
+
+    /// Construct with capacity pre-reserved (no samples emitted).
+    #[allow(dead_code)]
+    pub fn with_capacity(cap: usize) -> Self {
+        Self {
+            out: Vec::with_capacity(cap),
+            phase: 0.0,
+        }
+    }
+
+    /// Emit samples up to absolute output index `target_n` (exclusive) at
+    /// `freq_hz`. Cumulative-target form — call repeatedly with increasing
+    /// `target_n` across a multi-channel line; per-pixel rounding error
+    /// never compounds.
+    #[allow(clippy::cast_precision_loss, clippy::cast_possible_truncation)]
+    pub fn fill_to(&mut self, freq_hz: f64, target_n: usize) {
+        let dphi = 2.0 * PI * freq_hz / f64::from(WORKING_SAMPLE_RATE_HZ);
+        while self.out.len() < target_n {
+            self.out.push(self.phase.sin() as f32);
+            self.phase += dphi;
+            if self.phase > 2.0 * PI {
+                self.phase -= 2.0 * PI;
+            }
+        }
+    }
+
+    /// Emit `secs` seconds at `freq_hz`. Per-tone-duration form. Used by
+    /// VIS bursts where each tone has a fixed wall-clock duration.
+    #[allow(
+        clippy::cast_precision_loss,
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss
+    )]
+    pub fn fill_secs(&mut self, freq_hz: f64, secs: f64) {
+        let n = (secs * f64::from(WORKING_SAMPLE_RATE_HZ)).round() as usize;
+        let target = self.out.len() + n;
+        self.fill_to(freq_hz, target);
+    }
+
+    #[must_use]
+    #[allow(dead_code)]
+    pub fn len(&self) -> usize {
+        self.out.len()
+    }
+
+    #[must_use]
+    pub fn into_vec(self) -> Vec<f32> {
+        self.out
+    }
+}
+
+impl Default for ToneWriter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::float_cmp, clippy::cast_precision_loss)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lum_to_freq_endpoints_match_black_and_white() {
+        assert_eq!(lum_to_freq(0), BLACK_HZ);
+        assert_eq!(lum_to_freq(255), WHITE_HZ);
+        let mid = lum_to_freq(128);
+        let target = f64::midpoint(BLACK_HZ, WHITE_HZ);
+        assert!((mid - target).abs() < 5.0, "mid={mid} ≉ {target}");
+    }
+
+    #[test]
+    fn fill_to_advances_to_exact_target() {
+        let mut tone = ToneWriter::new();
+        tone.fill_to(1200.0, 100);
+        assert_eq!(tone.len(), 100);
+        tone.fill_to(1500.0, 250);
+        assert_eq!(tone.len(), 250);
+    }
+
+    #[test]
+    fn fill_to_and_fill_secs_are_equivalent_for_matching_durations() {
+        let secs = 100.0 / f64::from(WORKING_SAMPLE_RATE_HZ);
+        let mut a = ToneWriter::new();
+        a.fill_secs(1200.0, secs);
+        let mut b = ToneWriter::new();
+        b.fill_to(1200.0, 100);
+        let av = a.into_vec();
+        let bv = b.into_vec();
+        assert_eq!(av.len(), bv.len());
+        for (i, (&x, &y)) in av.iter().zip(bv.iter()).enumerate() {
+            assert!((x - y).abs() < 1e-6, "sample {i}: {x} vs {y}");
+        }
+    }
+
+    #[test]
+    fn phase_is_continuous_across_tone_boundaries() {
+        let mut tone = ToneWriter::new();
+        tone.fill_to(1200.0, 100);
+        tone.fill_to(1500.0, 200);
+        let v = tone.into_vec();
+        for w in v.windows(2) {
+            let delta = (w[1] - w[0]).abs();
+            assert!(
+                delta < 1.0,
+                "sample-to-sample delta {delta} > 1.0 — phase discontinuity"
+            );
+        }
+    }
+}

--- a/src/test_tone.rs
+++ b/src/test_tone.rs
@@ -60,15 +60,6 @@ impl ToneWriter {
         }
     }
 
-    /// Construct with capacity pre-reserved (no samples emitted).
-    #[allow(dead_code)]
-    pub fn with_capacity(cap: usize) -> Self {
-        Self {
-            out: Vec::with_capacity(cap),
-            phase: 0.0,
-        }
-    }
-
     /// Emit samples up to absolute output index `target_n` (exclusive) at
     /// `freq_hz`. Cumulative-target form — call repeatedly with increasing
     /// `target_n` across a multi-channel line; per-pixel rounding error
@@ -98,8 +89,11 @@ impl ToneWriter {
         self.fill_to(freq_hz, target);
     }
 
-    #[must_use]
+    /// `#[allow(dead_code)]`: used only by `test_tone::tests`, so the
+    /// lib-target build sees no caller. Kept for symmetry with `into_vec` —
+    /// caller may want a partial-state probe without consuming the writer.
     #[allow(dead_code)]
+    #[must_use]
     pub fn len(&self) -> usize {
         self.out.len()
     }

--- a/src/vis.rs
+++ b/src/vis.rs
@@ -509,18 +509,9 @@ pub mod tests {
     pub fn synth_vis_with_offset(code: u8, pre_silence_secs: f64, freq_offset_hz: f64) -> Vec<f32> {
         assert!(code < 0x80, "VIS codes are 7 bits");
         let sr = f64::from(WORKING_SAMPLE_RATE_HZ);
-        let mut out: Vec<f32> = vec![0.0; (pre_silence_secs * sr).round() as usize];
-        let mut phase = 0.0_f64;
-        let mut emit = |freq: f64, secs: f64, out: &mut Vec<f32>| {
-            let dphi = 2.0 * PI * freq / sr;
-            for _ in 0..(secs * sr).round() as usize {
-                out.push(phase.sin() as f32);
-                phase += dphi;
-                if phase > 2.0 * PI {
-                    phase -= 2.0 * PI;
-                }
-            }
-        };
+        let mut tone = crate::test_tone::ToneWriter::with_pre_silence_samples(
+            (pre_silence_secs * sr).round() as usize,
+        );
         let leader = LEADER_HZ + freq_offset_hz;
         let break_f = leader + BREAK_HZ_OFFSET;
         let bit_freq = |bit: u8| -> f64 {
@@ -531,13 +522,13 @@ pub mod tests {
                     BIT_ZERO_OFFSET
                 }
         };
-        emit(leader, 0.300, &mut out);
-        emit(break_f, 0.030, &mut out);
+        tone.fill_secs(leader, 0.300);
+        tone.fill_secs(break_f, 0.030);
         let mut parity = 0u8;
         for b in 0..7 {
             let bit = (code >> b) & 1;
             parity ^= bit;
-            emit(bit_freq(bit), 0.030, &mut out);
+            tone.fill_secs(bit_freq(bit), 0.030);
         }
         // R12BW (`R12BW_VIS_CODE`) inverts the parity bit per slowrx `vis.c:116`.
         // The detector's `match_vis_pattern` does the same inversion when
@@ -548,9 +539,9 @@ pub mod tests {
         } else {
             parity
         };
-        emit(bit_freq(parity_bit), 0.030, &mut out);
-        emit(break_f, 0.030, &mut out);
-        out
+        tone.fill_secs(bit_freq(parity_bit), 0.030);
+        tone.fill_secs(break_f, 0.030);
+        tone.into_vec()
     }
 
     /// Convenience wrapper: zero-offset VIS burst.
@@ -666,19 +657,7 @@ pub mod tests {
         // Hand-emit a 0x06 burst with the standard (uninverted) parity
         // bit. The detector should now reject it (post-fix), proving the
         // inversion is doing real work and not a no-op.
-        let sr = f64::from(WORKING_SAMPLE_RATE_HZ);
-        let mut out: Vec<f32> = vec![0.0; 0];
-        let mut phase = 0.0_f64;
-        let mut emit = |freq: f64, secs: f64, out: &mut Vec<f32>| {
-            let dphi = 2.0 * PI * freq / sr;
-            for _ in 0..(secs * sr).round() as usize {
-                out.push(phase.sin() as f32);
-                phase += dphi;
-                if phase > 2.0 * PI {
-                    phase -= 2.0 * PI;
-                }
-            }
-        };
+        let mut tone = crate::test_tone::ToneWriter::new();
         let break_f = LEADER_HZ + BREAK_HZ_OFFSET;
         let bit_freq = |bit: u8| {
             LEADER_HZ
@@ -688,17 +667,18 @@ pub mod tests {
                     BIT_ZERO_OFFSET
                 }
         };
-        emit(LEADER_HZ, 0.300, &mut out);
-        emit(break_f, 0.030, &mut out);
+        tone.fill_secs(LEADER_HZ, 0.300);
+        tone.fill_secs(break_f, 0.030);
         let mut parity = 0u8;
         for b in 0..7 {
             let bit = (R12BW_VIS_CODE >> b) & 1;
             parity ^= bit;
-            emit(bit_freq(bit), 0.030, &mut out);
+            tone.fill_secs(bit_freq(bit), 0.030);
         }
         // Standard (non-R12BW-inverted) parity. Detector should reject.
-        emit(bit_freq(parity), 0.030, &mut out);
-        emit(break_f, 0.030, &mut out);
+        tone.fill_secs(bit_freq(parity), 0.030);
+        tone.fill_secs(break_f, 0.030);
+        let mut out = tone.into_vec();
         out.extend(std::iter::repeat_n(0.0_f32, 256));
         assert!(
             run(&out).is_none(),


### PR DESCRIPTION
Closes #86 (audit bundle 2 of 12 — IDs B9, B10, E2, F11, C17 partial). Design/plan in `docs/superpowers/specs/2026-05-14-issue-86-shared-test-tone-module-design.md` and `docs/superpowers/plans/2026-05-14-issue-86-shared-test-tone-module.md`.

**Pure refactor** — identical behavior; the `slowrx::__test_support::mode_*::encode_*` paths are stable for existing consumers (`tests/roundtrip.rs` unchanged). 142 tests pass (incl. all 11/11 per-mode `tests/roundtrip.rs` end-to-end checks).

### Changes

- **B9 — extract `crate::test_tone`.** New `src/test_tone.rs` (`pub(crate) mod`, `cfg(any(test, feature = "test-support"))`-gated) consolidates the four pre-#86 tone-generator copies from `pd_test_encoder` / `robot_test_encoder` / `scottie_test_encoder` / `vis::tests`. Owns the 5 SSTV consts (`SYNC_HZ` = 1200; `PORCH_HZ` / `SEPTR_HZ` / `BLACK_HZ` = 1500; `WHITE_HZ` = 2300), `lum_to_freq`, and a `ToneWriter` struct with `new` / `with_pre_silence_samples` / `fill_to` (cumulative-target, encoder style) / `fill_secs` (per-tone-duration, VIS style) / `into_vec` / `len`. Both `fill_to` and `fill_secs` advance the same `phase`, preserving continuous-phase semantics across calls. Plus 4 unit tests.
- **B10 — encoders off public API.** `pub mod *_test_encoder` → `pub(crate) mod`; `pub fn encode_*` → `pub(crate) fn encode_*` (redundant `#[doc(hidden)]` dropped). The `slowrx::pd_test_encoder::*` / `robot_test_encoder::*` / `scottie_test_encoder::*` external paths are gone. `__test_support::mode_*::encode_*` switched from `pub use` re-exports to thin `pub fn` wrappers (same visibility-juggle pattern as #85's `ycbcr_to_rgb` — `pub use pub(crate)::item` would trip rustc's "private item in public interface"; a `pub fn` wrapper is fine). Consumer-facing paths unchanged.
- **E2 — scottie double-doc fix.** `encode_scottie` had two `///` paragraphs split by `#[must_use]` (rustdoc concatenated both). Consolidated; `#[must_use]` moved to sit with the other attrs. Landed *incidentally* in T2 when `#[doc(hidden)]` came off and exposed pre-existing clippy doc lints — the T2 subagent flagged this honestly.
- **F11 — encoder smoke tests.** 2 new tests each in `pd_test_encoder::tests` and `robot_test_encoder::tests`: `encode_<mode>_first_tone_is_sync_hz` (Goertzel-based; `p_sync > 10 × p_porch` discriminator over the first `sync_seconds` of audio) and `encode_<mode>_length_matches_radio_frames` (audio length within ±64 samples of `radio_frames × line_seconds × sr`). Catches channel-order / septr-placement regressions with a pointed signal instead of `roundtrip.rs`'s fuzzy pixel-diff.
- **C17 partial — robot redundant-guard cleanup.** Dropped the leading `assert!(matches!(mode, Robot24 | Robot36 | Robot72))` in `encode_robot`; kept the wildcard `_ => unreachable!()` arm (structurally required by the exhaustiveness check on `SstvMode`'s 8 non-Robot variants) with a comment explaining why. PD and Scottie kept their single `assert!` — they had no later `unreachable!()` (no double-guard).
- Plus a T1 follow-up that dropped `ToneWriter::with_capacity` (genuinely unused — no consumer materialized) and a code-review-fix commit (deleted now-redundant `scottie::tests::lum_to_freq_endpoints` — `test_tone::tests` has stronger coverage; fixed an over-attributed comment about `#[non_exhaustive]`).

### Commits

9 commits (2 docs + 7 implementation/cleanup): T1 atomic `test_tone.rs` + 4-consumer migration (`0ec4baf`), T1 follow-up unused-method trim (`83b1ef2`), T2 `pub(crate) mod` + wrappers (`92f4c91`), T3 robot C17 (`e0cb850`), T4 F11 smoke tests (`03f2bb7`), T5 CHANGELOG (`f9b2090`), code-reviewer-pass fixups (`76bde60`).

### Verification

- `cargo fmt --all -- --check` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo test --all-features --locked --release` — **142 tests pass** (123 lib including the 4 new `test_tone::tests` + 4 new F11; 1 bin; 1 cli; 1 multi_image; 2 no_vis; 11 roundtrip; 1 unknown_vis; 1 doctest). 0 failed.
- `RUSTDOCFLAGS=-D warnings cargo doc --no-deps --all-features` — clean
- Sanity grep on every old path (`SYNC_HZ` / `PORCH_HZ` / `SEPTR_HZ` / `BLACK_HZ` / `WHITE_HZ` consts / `fn lum_to_freq` / `fn fill_to` defs, plus `^pub mod *_test_encoder` and `pub use crate::*_test_encoder::*`) — hits **only** in `src/test_tone.rs` (the canonical definitions).

### Process

Brainstorm → spec → plan → 5 subagent tasks (Opus 4.7 for the dense T1 atomic migration + T2 visibility juggle; T3 was inline; T4 mechanical Sonnet; T5 inline) → pre-PR code-reviewer pass → applied its 2 worthwhile minors. Same pattern that's been getting zero/minimal-rabbit PRs.

### Out of scope (tracked separately under epic #97)

- Moving encoders to `tests/common/` (the audit's "better" B10 option) — considered, rejected during brainstorming in favor of the lighter `pub(crate) mod` + wrapper-fn resolution.
- Remaining audit items: #87 / #88 / #91-96.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added design and plan docs describing the test-audio refactor and rollout steps.

* **Refactor**
  * Consolidated duplicated test-tone generation into a shared continuous-phase tone generator and tightened visibility of internal test encoders while keeping the public test-support API stable.

* **Tests**
  * Added/expanded encoder smoke and timing checks to verify sync tones and total audio lengths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jasonherald/slowrx.rs/pull/104)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->