### PR TITLE
chore(release): 0.5.3 — audit-cleanup refactor wave (epic #97)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.3] — 2026-05-14
+
+Epic #97 audit-cleanup follow-up: 5 internal refactor / test-coverage
+bundles. No public-API breaks (the two new `ModeSpec` fields are
+additive under `#[non_exhaustive]`); the CLI's `mode_tag` function is
+gone but filename slugs are byte-identical to the prior output.
+
 ### Internal
 
 - **`ModeSpec` as single source of truth** — adds two new fields

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -707,7 +707,7 @@ checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "slowrx"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slowrx"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2021"
 rust-version = "1.85"
 description = "Pure-Rust SSTV (Slow-Scan TV) decoder library — a port of slowrx by Oona Räisänen"


### PR DESCRIPTION
## Summary

Epic #97 audit-cleanup follow-up release. Five internal bundles since 0.5.2 (which shipped #89 + #90):

- **#85** — Extract `crate::demod` and `crate::dsp` (audit B1/B3/B5/B8/B16/C6/C20).
- **#86** — Shared `crate::test_tone` module; test encoders off the published API (audit B9/B10/E2/F11/C17).
- **#87** — Resampler polish: 256-phase polyphase bank, `needed_end` fix, group-delay + cutoff_hz docs, 5 new tests (audit D2/D2b/F6, D1 closed-as-phantom).
- **#88** — `find_sync` cleanup: three pure helpers, Scottie correction on `ModeSpec`, named consts, index closures, A6 off-by-one fix, deviation docs, F2/F3 tests (audit B2/B4/C2/C10/A6/A7/A8/F2/F3).
- **#91** — `ModeSpec` as single source of truth: `ALL_SPECS` table, `short_name`/`name` fields, `lookup` derived, CLI `mode_tag` deleted, doc normalization, F8 roundtrip (audit B7/B13/E1/E11/F8).

No public-API breaks (the two new `ModeSpec` fields are additive under `#[non_exhaustive]`); CLI filename slugs are byte-identical to the pre-#91 `mode_tag` output. Lib test count: 130 → **136**. `tests/roundtrip.rs` 11/11 unchanged.

**Epic #97 progress:** 7/12 audit bundles landed. Remaining 5: #92 (API hygiene), #93 (per-line allocations), #94 (docs sweep), #95 (CI hardening), #96 (standalone items).

## Test plan

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo test --all-features --locked --release` — 136 lib + 11/11 roundtrip + all integration green
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features` — clean
- [x] `cargo publish --dry-run --locked` — clean (28 files, 362.7 KiB / 106.9 KiB compressed)
- [ ] After merge: tag `v0.5.3` on `main`, push tag, run `cargo publish` manually for crates.io upload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version 0.5.3 released
  * Internal improvements and enhanced test coverage
  * CLI `mode_tag` function removed
  * Existing output formats remain compatible

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jasonherald/slowrx.rs/pull/108)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->