### PR TITLE
feat(decoder): perf — hoist per-channel/per-line allocations (D3/D6) (#93)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,19 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-
-- **`SstvEvent::LineDecoded` no longer carries `pixels: Vec<[u8; 3]>`.**
-  Consumers call the new `SstvDecoder::current_image() -> Option<&SstvImage>`
-  to borrow the in-progress image instead. Row `N` is fully populated
-  after the `LineDecoded { line_index: N, .. }` event fires. **Breaking
-  change** — bumps the next release to **0.6.0**. The migration is
-  one-line per call site: drop the `pixels` field from the match-arm
-  pattern; if pixel data was being used, fetch it via
-  `decoder.current_image().map(|img| &img.pixels[start..end])`.
-  Eliminates ~496 per-line `.to_vec()` allocations per PD240 image.
-  (#93; audit D5.)
-
 ### Internal
 
 - **Performance: hoist per-channel/per-line allocations into reusable
@@ -37,17 +24,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `scratch: &mut FindSyncScratch` parameter; ~7 existing `find_sync_*`
   tests construct `FindSyncScratch::new()` locally (audit D6.3);
   (3) `DecodingState.audio` / `.has_sync` use
-  `with_capacity(target_audio_samples)` instead of `Vec::new()`
-  (audit D6.1); (4) `run_findsync_and_decode` now takes
+  `with_capacity(target_audio_samples)` instead of `Vec::new()` (the
+  audio constructor preserves the residual move + reserves remaining
+  capacity) (audit D6.1); (4) `run_findsync_and_decode` now takes
   `DecodingState` by value and moves `d.image` directly into the
   `ImageComplete` event — eliminates the throwaway ~950 KB
   black-image `mem::replace` workaround (audit D6.2). Plus
   `out.reserve(image_lines + 1)` before the burst-emit loop saves
-  ~9 `Vec` growth reallocs. All hot-loop allocation patterns become
-  "0 allocs after first decode" instead of growing with image size.
-  `tests/roundtrip.rs` 11/11 unchanged — pixel output bit-identical.
-  Net new test: `current_image_is_none_when_awaiting_vis` (lib 136
-  → 137). (#93; audit D3/D6.)
+  ~9 `Vec` growth reallocs.
+  
+  D5's original "drop `LineDecoded.pixels`, expose `current_image()`"
+  framing was reverted late in the PR — `process()` batches all events
+  before returning, so `current_image()` would have returned `None` by
+  the time callers iterated `LineDecoded` events (CodeRabbit catch).
+  An architectural fix that preserves D5's perf win (Completed state
+  + `take_image()`) is incompatible with the multi-image-in-one-call
+  contract `tests/multi_image.rs` exercises. Keeping `LineDecoded.pixels`
+  loses only the ~496 small `to_vec()` allocs per PD240 image
+  (allocator-poolable; negligible vs the ~7000+ ChannelDemod allocs +
+  ~730 KB find_sync scratch + ~950 KB black-image throwaway we still
+  eliminate). PR stays non-breaking. `tests/roundtrip.rs` 11/11
+  unchanged — pixel output bit-identical. (#93; audit D3/D6;
+  D5 deferred to a future API-design pass.)
 
 - **API hygiene sweep** — eight small public-surface polishes (audit
   bundle 8 of 12). `#[must_use]` on `Resampler::{new, process}`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`SstvEvent::LineDecoded` no longer carries `pixels: Vec<[u8; 3]>`.**
+  Consumers call the new `SstvDecoder::current_image() -> Option<&SstvImage>`
+  to borrow the in-progress image instead. Row `N` is fully populated
+  after the `LineDecoded { line_index: N, .. }` event fires. **Breaking
+  change** — bumps the next release to **0.6.0**. The migration is
+  one-line per call site: drop the `pixels` field from the match-arm
+  pattern; if pixel data was being used, fetch it via
+  `decoder.current_image().map(|img| &img.pixels[start..end])`.
+  Eliminates ~496 per-line `.to_vec()` allocations per PD240 image.
+  (#93; audit D5.)
+
 ### Internal
+
+- **Performance: hoist per-channel/per-line allocations into reusable
+  scratch** (audit bundle 9 of 12). Three hot allocation sites moved
+  out of the decode hot path: (1) per-channel scratch (`pixel_times`,
+  `stored_lum`, `scratch_audio`, plus 4 PD line-pair luma/chroma
+  buffers `pd_y_odd`/`pd_y_even`/`pd_cr`/`pd_cb`) now lives on
+  `ChannelDemod` and is reused via `clear()` + `reserve()`/`resize()`/
+  `extend()` (or `std::mem::take`+restore for the buffers that need
+  to coexist with `&mut self` calls into `pixel_freq`); ~7000
+  allocations per PD240 image eliminated (audit D3); (2) `find_sync`'s
+  `sync_img` / `lines` / `x_acc` buffers (~730 KB) moved to a new
+  `pub(crate) FindSyncScratch` struct owned by `SstvDecoder`;
+  `find_sync` + `hough_detect_slant` + `find_falling_edge` gain a
+  `scratch: &mut FindSyncScratch` parameter; ~7 existing `find_sync_*`
+  tests construct `FindSyncScratch::new()` locally (audit D6.3);
+  (3) `DecodingState.audio` / `.has_sync` use
+  `with_capacity(target_audio_samples)` instead of `Vec::new()`
+  (audit D6.1); (4) `run_findsync_and_decode` now takes
+  `DecodingState` by value and moves `d.image` directly into the
+  `ImageComplete` event — eliminates the throwaway ~950 KB
+  black-image `mem::replace` workaround (audit D6.2). Plus
+  `out.reserve(image_lines + 1)` before the burst-emit loop saves
+  ~9 `Vec` growth reallocs. All hot-loop allocation patterns become
+  "0 allocs after first decode" instead of growing with image size.
+  `tests/roundtrip.rs` 11/11 unchanged — pixel output bit-identical.
+  Net new test: `current_image_is_none_when_awaiting_vis` (lib 136
+  → 137). (#93; audit D3/D6.)
 
 - **API hygiene sweep** — eight small public-surface polishes (audit
   bundle 8 of 12). `#[must_use]` on `Resampler::{new, process}`,

--- a/docs/superpowers/plans/2026-05-15-issue-93-perf-scratch.md
+++ b/docs/superpowers/plans/2026-05-15-issue-93-perf-scratch.md
@@ -1,0 +1,1084 @@
+# Issue #93 — Perf: hoist per-channel/per-line allocations into reusable scratch — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Eliminate per-decode allocation churn at three sites — D3 per-channel scratch on `ChannelDemod`, D5 `LineDecoded.pixels` drop + `current_image()` exposure (breaking API), D6 `DecodingState` capacity + `find_sync` scratch hoist + throwaway-black-image fix.
+
+**Architecture:** Four sequential tasks. T1 lands `FindSyncScratch` and threads it through `find_sync` + helpers + `SstvDecoder` (D6.3). T2 hoists per-channel scratch onto `ChannelDemod` (D3). T3 is the API-breaking task: drops `LineDecoded.pixels`, adds `SstvDecoder::current_image()`, refactors `run_findsync_and_decode` to take `DecodingState` by value (D5 + D6.1 + D6.2), and migrates all consumers (CLI + 5 test files). T4 closes with CHANGELOG bullets (`### Changed` for D5 breaking, `### Internal` for the perf hoists) and the final gate.
+
+**Tech Stack:** Rust 2021, MSRV 1.85. CI gate: `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --all-features --locked --release`, `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`. No GPG signing.
+
+**Reference docs:**
+- Spec: `docs/superpowers/specs/2026-05-15-issue-93-perf-scratch-design.md`
+- Audit: `docs/audits/2026-05-11-deep-code-review-audit.md` (IDs D3, D5, D6)
+
+**Release implication:** D5 is a breaking change. After this PR merges, the next release is **0.6.0** (the release PR is a separate `chore/release-0.6.0` per the established pattern). This PR's CHANGELOG entry goes under `[Unreleased]`.
+
+---
+
+## File Structure
+
+| File | Status | Task |
+|------|--------|------|
+| `src/sync.rs` | modify | T1 (`FindSyncScratch` struct + `find_sync`/`hough_detect_slant`/`find_falling_edge` signature changes + tests update) |
+| `src/decoder.rs` | modify | T1 (`SstvDecoder.find_sync_scratch` field) + T3 (`LineDecoded` shape, `current_image()`, `run_findsync_and_decode` by-value refactor, `DecodingState::with_capacity`, `out.reserve`) |
+| `src/demod.rs` | modify | T2 (`ChannelDemod` scratch fields + `decode_one_channel_into` rewrites) |
+| `src/mode_pd.rs` | modify (if PD scratches live here) | T2 (4× PD line-pair `vec![0u8; width]` hoists, location TBD-by-grep) |
+| `src/bin/slowrx_cli.rs` | modify | T3 (consumer migration: drop `pixels` field from match arms; if used, call `decoder.current_image()`) |
+| `tests/roundtrip.rs` | modify | T3 (consumer migration) |
+| `tests/cli.rs` | modify (if uses `LineDecoded.pixels`) | T3 |
+| `tests/multi_image.rs` | modify (if uses `LineDecoded.pixels`) | T3 |
+| `tests/no_vis.rs` | modify (if uses `LineDecoded.pixels`) | T3 |
+| `tests/unknown_vis.rs` | modify (if uses `LineDecoded.pixels`) | T3 |
+| `CHANGELOG.md` | modify | T4 (`### Changed` for D5; `### Internal` for D3/D6) |
+
+Task order: **T1** (`FindSyncScratch` plumbing) → **T2** (`ChannelDemod` scratch) → **T3** (D5 API change + `run_findsync_and_decode` refactor + `DecodingState::with_capacity` + consumer migration) → **T4** (CHANGELOG + final gate).
+
+**Verification after each task:**
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test --all-features --locked --release
+RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features
+```
+
+Lib test counts at each checkpoint:
+- **Pre-#93 baseline:** 136 lib tests.
+- **Post-T1:** 136 (existing `find_sync_*` tests updated in place to construct local `FindSyncScratch`).
+- **Post-T2:** 136 (pure refactor).
+- **Post-T3:** 136 (API rename in match arms; no test count change).
+- **Post-T4:** 136.
+
+---
+
+## Task 1: D6.3 — `FindSyncScratch` struct + plumbing
+
+Hoist `find_sync`'s ~730 KB of per-call buffers (`sync_img`, `lines`, `x_acc`) onto a new `FindSyncScratch` struct owned by `SstvDecoder`. Thread `&mut scratch` through `find_sync` + helpers. Update the ~5 existing `find_sync_*` tests to construct a local scratch.
+
+**Files:**
+- Modify: `src/sync.rs` (new struct + signature changes + tests)
+- Modify: `src/decoder.rs` (new field on `SstvDecoder` + `find_sync` call site)
+
+- [ ] **Step 1: Add the `FindSyncScratch` struct in `src/sync.rs`**
+
+In `src/sync.rs`, locate the end of the const block (around line 84, after `SYNC_EDGE_KERNEL_LEN`). Append:
+
+```rust
+
+/// Scratch buffers for [`find_sync`] and its helpers. Hoisted onto
+/// [`crate::decoder::SstvDecoder`] so they're reused across decode
+/// passes — the largest two (`sync_img`, `x_acc`) are sized at
+/// construction and never resized; `lines` resizes per-call because
+/// `n_slant_bins × LINES_D_BINS` depends on the mode's `line_width`.
+/// (Audit #93 D6.)
+pub(crate) struct FindSyncScratch {
+    /// `[X_ACC_BINS × SYNC_IMG_Y_BINS]` flat buffer for the 2D sync image.
+    /// Sized once; `find_sync` calls `.fill(false)` each invocation.
+    pub(crate) sync_img: Vec<bool>,
+    /// `[LINES_D_BINS × n_slant_bins]` flat buffer for the Hough
+    /// accumulator. Resized per-call (`.clear() + .resize(...)`).
+    pub(crate) lines: Vec<u16>,
+    /// `[X_ACC_BINS]` column accumulator. Sized once; `.fill(0)` per call.
+    pub(crate) x_acc: Vec<u32>,
+}
+
+impl FindSyncScratch {
+    pub(crate) fn new() -> Self {
+        Self {
+            sync_img: vec![false; X_ACC_BINS * SYNC_IMG_Y_BINS],
+            lines: Vec::new(),
+            x_acc: vec![0; X_ACC_BINS],
+        }
+    }
+}
+
+impl Default for FindSyncScratch {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+```
+
+- [ ] **Step 2: Update `find_sync` signature and body in `src/sync.rs`**
+
+Locate `pub(crate) fn find_sync(has_sync: &[bool], initial_rate_hz: f64, spec: ModeSpec) -> SyncResult` (around line 225). Update the signature to add the scratch parameter:
+
+```rust
+#[must_use = "the SyncResult must be consumed; dropping it discards the slant + skip correction"]
+#[allow(
+    clippy::cast_precision_loss,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    clippy::cast_possible_wrap
+)]
+pub(crate) fn find_sync(
+    has_sync: &[bool],
+    initial_rate_hz: f64,
+    spec: ModeSpec,
+    scratch: &mut FindSyncScratch,
+) -> SyncResult {
+```
+
+Inside the function body, find the calls to `hough_detect_slant` and `find_falling_edge`. Pass `scratch` through:
+
+```rust
+// Existing call (approximate; locate via grep on `hough_detect_slant`):
+let Some((slant, adjusted)) = hough_detect_slant(has_sync, rate, spec, line_width) else {
+    break;
+};
+
+// Updated:
+let Some((slant, adjusted)) = hough_detect_slant(has_sync, rate, spec, line_width, scratch) else {
+    break;
+};
+
+// Existing call (approximate; locate via grep on `find_falling_edge`):
+let xmax = find_falling_edge(has_sync, rate, spec, num_lines);
+
+// Updated:
+let xmax = find_falling_edge(has_sync, rate, spec, num_lines, scratch);
+```
+
+- [ ] **Step 3: Update `hough_detect_slant` signature and body to use scratch**
+
+In `src/sync.rs`, locate `fn hough_detect_slant(has_sync: &[bool], rate_hz: f64, spec: ModeSpec, line_width: usize) -> Option<(f64, f64)>`. Add the scratch parameter and use it for `sync_img` and `lines`:
+
+```rust
+fn hough_detect_slant(
+    has_sync: &[bool],
+    rate_hz: f64,
+    spec: ModeSpec,
+    line_width: usize,
+    scratch: &mut FindSyncScratch,
+) -> Option<(f64, f64)> {
+    let n_slant_bins = ((MAX_SLANT_DEG - MIN_SLANT_DEG) / SLANT_STEP_DEG).round() as usize;
+    let num_lines = spec.image_lines as usize;
+
+    let sync_img_idx = |x: usize, y: usize| x * SYNC_IMG_Y_BINS + y;
+    let lines_idx = |d: usize, q: usize| d * n_slant_bins + q;
+
+    let probe_index = |t: f64| -> usize {
+        let raw = t * rate_hz / (SYNC_PROBE_STRIDE as f64);
+        if raw < 0.0 {
+            0
+        } else {
+            raw as usize
+        }
+    };
+
+    // Reset the hoisted scratch buffers (was: fresh Vec allocations).
+    scratch.sync_img.fill(false);
+    scratch.lines.clear();
+    scratch.lines.resize(LINES_D_BINS * n_slant_bins, 0);
+
+    // Draw the 2D sync signal at current rate.
+    for y in 0..num_lines.min(SYNC_IMG_Y_BINS) {
+        for x in 0..line_width.min(X_ACC_BINS) {
+            let t = ((y as f64) + (x as f64) / (line_width as f64)) * spec.line_seconds;
+            let idx = probe_index(t);
+            if idx < has_sync.len() {
+                scratch.sync_img[sync_img_idx(x, y)] = has_sync[idx];
+            }
+        }
+    }
+
+    // Linear Hough transform.
+    let mut q_most = 0_usize;
+    let mut max_count = 0_u16;
+    for cy in 0..num_lines.min(SYNC_IMG_Y_BINS) {
+        for cx in 0..line_width.min(X_ACC_BINS) {
+            if !scratch.sync_img[sync_img_idx(cx, cy)] {
+                continue;
+            }
+            for q in 0..n_slant_bins {
+                let theta = deg2rad(MIN_SLANT_DEG + (q as f64) * SLANT_STEP_DEG);
+                let d_signed = (line_width as f64)
+                    + (-(cx as f64) * theta.sin() + (cy as f64) * theta.cos()).round();
+                if d_signed > 0.0 && d_signed < (line_width as f64) {
+                    let d = d_signed as usize;
+                    if d < LINES_D_BINS {
+                        let cell = &mut scratch.lines[lines_idx(d, q)];
+                        *cell = cell.saturating_add(1);
+                        if *cell > max_count {
+                            max_count = *cell;
+                            q_most = q;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if max_count == 0 {
+        return None;
+    }
+
+    let slant_angle = MIN_SLANT_DEG + (q_most as f64) * SLANT_STEP_DEG;
+    let adjusted_rate =
+        rate_hz + (deg2rad(90.0 - slant_angle).tan() / (line_width as f64)) * rate_hz;
+    Some((slant_angle, adjusted_rate))
+}
+```
+
+Key changes from the existing body:
+- The two local `let mut sync_img = vec![...]` / `let mut lines = vec![...]` are gone.
+- `scratch.sync_img.fill(false)` + `scratch.lines.clear() + .resize(...)` at the top.
+- All `sync_img[...]` references become `scratch.sync_img[...]`; all `lines[...]` become `scratch.lines[...]`.
+- The function-level `#[allow(...)]` block (cast lints) stays.
+
+- [ ] **Step 4: Update `find_falling_edge` signature and body to use scratch**
+
+In `src/sync.rs`, locate `fn find_falling_edge(has_sync: &[bool], rate_hz: f64, spec: ModeSpec, num_lines: usize) -> i32`. Add the scratch parameter and use it for `x_acc`:
+
+```rust
+fn find_falling_edge(
+    has_sync: &[bool],
+    rate_hz: f64,
+    spec: ModeSpec,
+    num_lines: usize,
+    scratch: &mut FindSyncScratch,
+) -> i32 {
+    let probe_index = |t: f64| -> usize {
+        let raw = t * rate_hz / (SYNC_PROBE_STRIDE as f64);
+        if raw < 0.0 {
+            0
+        } else {
+            raw as usize
+        }
+    };
+
+    scratch.x_acc.fill(0);
+    for y in 0..num_lines {
+        for (x, slot) in scratch.x_acc.iter_mut().enumerate() {
+            let t = (y as f64) * spec.line_seconds
+                + ((x as f64) / (X_ACC_BINS as f64)) * spec.line_seconds;
+            let idx = probe_index(t);
+            if idx < has_sync.len() && has_sync[idx] {
+                *slot = slot.saturating_add(1);
+            }
+        }
+    }
+
+    falling_edge_from_x_acc(&scratch.x_acc)
+}
+```
+
+Key changes:
+- `let mut x_acc = vec![0u32; X_ACC_BINS]` is gone; `scratch.x_acc.fill(0)` replaces it.
+- All `x_acc.iter_mut()` / `&x_acc` references become `scratch.x_acc.iter_mut()` / `&scratch.x_acc`.
+- The function-level `#[allow(...)]` block stays.
+
+`falling_edge_from_x_acc` (the pure helper that takes `&[u32]`) stays UNCHANGED — it's already a pure function over a borrowed slice.
+
+- [ ] **Step 5: Add `find_sync_scratch` field to `SstvDecoder` in `src/decoder.rs`**
+
+In `src/decoder.rs`, locate `pub struct SstvDecoder` (around line 160 — the field list). Add a new field:
+
+```rust
+pub struct SstvDecoder {
+    resampler: Resampler,
+    vis: crate::vis::VisDetector,
+    channel_demod: crate::demod::ChannelDemod,
+    snr_est: crate::snr::SnrEstimator,
+    /// Scratch buffers for `find_sync` (sync_img / lines / x_acc).
+    /// Hoisted here so they're reused across decode passes instead of
+    /// being allocated fresh per call. (Audit #93 D6.)
+    find_sync_scratch: crate::sync::FindSyncScratch,
+    state: State,
+    samples_processed: u64,
+    working_samples_emitted: u64,
+}
+```
+
+(The existing fields ordering may differ slightly — insert `find_sync_scratch` between `snr_est` and `state` so it groups with the other internal-state fields.)
+
+Then update `SstvDecoder::new` (around line 247) to initialize it:
+
+```rust
+pub fn new(input_sample_rate_hz: u32) -> Result<Self> {
+    Ok(Self {
+        resampler: Resampler::new(input_sample_rate_hz)?,
+        vis: crate::vis::VisDetector::new(IS_KNOWN_VIS),
+        channel_demod: crate::demod::ChannelDemod::new(),
+        snr_est: crate::snr::SnrEstimator::new(),
+        find_sync_scratch: crate::sync::FindSyncScratch::new(),  // NEW
+        state: State::AwaitingVis,
+        samples_processed: 0,
+        working_samples_emitted: 0,
+    })
+}
+```
+
+The existing `reset()` method (around line 600) does NOT need to recreate `find_sync_scratch` — the buffers are state-free (cleared at every `find_sync` call). Leave `reset()` untouched.
+
+The hand-written `Debug for SstvDecoder` impl (added in #92) does NOT need to surface `find_sync_scratch` — it's pure scratch with no diagnostic value. The existing `.finish_non_exhaustive()` already signals "more fields exist."
+
+- [ ] **Step 6: Update the `find_sync` call site in `src/decoder.rs::run_findsync_and_decode`**
+
+In `src/decoder.rs::run_findsync_and_decode` (around line 478), update the function signature to accept a scratch parameter and pass it to `find_sync`:
+
+```rust
+fn run_findsync_and_decode(
+    d: &mut DecodingState,
+    channel_demod: &mut crate::demod::ChannelDemod,
+    snr_est: &mut crate::snr::SnrEstimator,
+    find_sync_scratch: &mut crate::sync::FindSyncScratch,  // NEW
+    out: &mut Vec<SstvEvent>,
+) {
+    let work_rate = f64::from(crate::resample::WORKING_SAMPLE_RATE_HZ);
+    let result = find_sync(&d.has_sync, work_rate, d.spec, find_sync_scratch);  // pass scratch
+    // ... rest of function unchanged ...
+```
+
+(T3 will further refactor this function's signature to take `d: DecodingState` by value; T1 keeps it as `&mut DecodingState` for now.)
+
+Then update the `run_findsync_and_decode` call site in `SstvDecoder::process` (around line 396 area — the match arm that detects buffer-full and dispatches). Pass `&mut self.find_sync_scratch`:
+
+```rust
+Self::run_findsync_and_decode(
+    d,
+    &mut self.channel_demod,
+    &mut self.snr_est,
+    &mut self.find_sync_scratch,  // NEW
+    &mut out,
+);
+```
+
+- [ ] **Step 7: Update the ~5 `find_sync_*` tests in `src/sync.rs::tests`**
+
+Run:
+```bash
+grep -n "find_sync(" /data/source/slowrx.rs/src/sync.rs | head -20
+```
+
+Identify the test sites (probably 5-6 calls in `mod tests`). For each `find_sync(&track, rate, spec)` call, insert a local scratch construction immediately above and pass `&mut scratch`:
+
+```rust
+// Before:
+let r = find_sync(&track, rate, spec);
+
+// After:
+let mut scratch = FindSyncScratch::new();
+let r = find_sync(&track, rate, spec, &mut scratch);
+```
+
+The existing test bodies otherwise stay identical — `FindSyncScratch::new()` is the same buffers that `find_sync` used to allocate internally, just owned by the test now.
+
+Touch points (approximate; verify with grep):
+- `find_sync_locks_clean_track_to_90_degrees`
+- `find_sync_empty_track_has_no_slant_detected`
+- `find_sync_recovers_known_offset`
+- `find_sync_handles_empty_track`
+- `find_sync_corrects_0p5pct_slant_at_pd120`
+- `find_sync_corrects_1pct_slant_via_retries`
+- `find_sync_scottie_applies_skip_correction`
+
+That's ~7 test sites. The `falling_edge_from_x_acc_*` tests (added in #88) are unaffected — they exercise the pure helper that still takes `&[u32]` directly.
+
+- [ ] **Step 8: Run the full gate**
+
+```bash
+cargo fmt --all
+cargo fmt --all -- --check
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test --all-features --locked --release
+RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features
+```
+
+All four must pass. Expected lib test count: **136** (no new tests; existing tests update in place).
+
+**Critical regression checks:**
+- All ~7 `find_sync_*` tests pass with the new scratch parameter.
+- `tests/roundtrip.rs` 11/11 (the perf hoist must not change pixel output).
+- `find_sync_off_by_one_a6` regression guard still asserts the A6 fix (xmax=345 on the constructed `x_acc`).
+
+If clippy fires `clippy::needless_pass_by_value` or `clippy::needless_pass_by_ref_mut` on the new `&mut scratch` parameters, the parameter IS used mutably — these lints should not fire. If they do, add a function-level `#[allow(...)]` at minimum scope or restructure the signature.
+
+If `Debug for FindSyncScratch` is needed (it's not derived by default), the new struct won't print under `dbg!(scratch)`. That's fine — no caller `Debug`s it. The struct is `pub(crate)` so external rustdoc concerns don't apply.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/sync.rs src/decoder.rs
+git commit -m "perf(sync): D6.3 — FindSyncScratch hoisted onto SstvDecoder (#93)
+
+Adds FindSyncScratch (sync_img/lines/x_acc buffers — ~730 KB) as a
+field on SstvDecoder. find_sync, hough_detect_slant, find_falling_edge
+gain a scratch: &mut FindSyncScratch parameter; the per-call vec! allocs
+are replaced with .fill() / .clear()+.resize() on the hoisted buffers.
+
+~7 existing find_sync_* tests update to construct a local
+FindSyncScratch::new() and pass &mut scratch.
+
+falling_edge_from_x_acc unchanged (already pure over &[u32]).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: D3 — Hoist per-channel scratch onto `ChannelDemod`
+
+Add `pixel_times`, `stored_lum`, `scratch_audio` (and any PD-specific line-pair scratches) as fields on `ChannelDemod`. Rewrite the allocation sites in `decode_one_channel_into` to use them.
+
+**Files:**
+- Modify: `src/demod.rs`
+- Modify (if PD scratches live here): `src/mode_pd.rs`
+
+- [ ] **Step 1: Add scratch fields to `ChannelDemod` in `src/demod.rs`**
+
+Locate `pub(crate) struct ChannelDemod` (around line 255). Add three scratch fields after the existing ones:
+
+```rust
+pub(crate) struct ChannelDemod {
+    fft: Arc<dyn rustfft::Fft<f32>>,
+    fft_buf: Vec<Complex<f32>>,
+    scratch: Vec<Complex<f32>>,
+    hann_bank: HannBank,
+    /// Per-channel scratch hoisted out of `decode_one_channel_into`.
+    /// Reused across calls via `clear() + reserve()/resize()/extend()`
+    /// at the top of each invocation. (Audit #93 D3.)
+    pixel_times: Vec<i64>,
+    stored_lum: Vec<u8>,
+    scratch_audio: Vec<f32>,
+}
+```
+
+Update `ChannelDemod::new` (around line 261) to initialize them as empty:
+
+```rust
+pub fn new() -> Self {
+    let mut planner = FftPlanner::<f32>::new();
+    let fft = planner.plan_fft_forward(FFT_LEN);
+    let scratch_len = fft.get_inplace_scratch_len();
+    Self {
+        fft,
+        fft_buf: vec![Complex { re: 0.0, im: 0.0 }; FFT_LEN],
+        // rustfft returns scratch_len = 0 for power-of-two sizes
+        // (FFT_LEN=1024 is radix-2). (Audit #92 C8.)
+        scratch: vec![Complex { re: 0.0, im: 0.0 }; scratch_len],
+        hann_bank: HannBank::new(),
+        pixel_times: Vec::new(),
+        stored_lum: Vec::new(),
+        scratch_audio: Vec::new(),
+    }
+}
+```
+
+- [ ] **Step 2: Rewrite the `pixel_times` allocation in `decode_one_channel_into`**
+
+In `src/demod.rs`, locate the function `pub(crate) fn decode_one_channel_into(...)` (search for `fn decode_one_channel_into`). The function takes `&mut ChannelDemod` (likely as `&mut self` if it's a method, or as a `demod: &mut ChannelDemod` parameter). Verify which form via:
+
+```bash
+grep -n "fn decode_one_channel_into" /data/source/slowrx.rs/src/demod.rs
+```
+
+Inside the function body, locate (around line 493):
+
+```rust
+let mut pixel_times: Vec<i64> = Vec::with_capacity(width);
+for x in 0..width {
+    // ... compute abs ...
+    pixel_times.push(abs);
+}
+```
+
+Replace with (assuming `&mut self` form; adjust to `demod.pixel_times` if the function takes `demod: &mut ChannelDemod`):
+
+```rust
+self.pixel_times.clear();
+self.pixel_times.reserve(width);
+for x in 0..width {
+    // ... compute abs ... (unchanged)
+    self.pixel_times.push(abs);
+}
+```
+
+All downstream references to the local `pixel_times` (e.g., `pixel_times[0]`, `pixel_times[width - 1]`, `pixel_times[x]`) become `self.pixel_times[...]`.
+
+- [ ] **Step 3: Rewrite the `stored_lum` allocation**
+
+In the same function, locate (around line 508):
+
+```rust
+let mut stored_lum = vec![0_u8; sweep_len];
+```
+
+Replace with:
+
+```rust
+self.stored_lum.clear();
+self.stored_lum.resize(sweep_len, 0);
+```
+
+All downstream references to `stored_lum[idx]`, `stored_lum[rel as usize]`, `stored_lum.len()` become `self.stored_lum[...]` / `self.stored_lum.len()`.
+
+- [ ] **Step 4: Rewrite the `scratch_audio` allocation**
+
+In the same function, locate (around line 548):
+
+```rust
+let scratch_audio: Vec<f32> = (sweep_start..sweep_end).map(read_audio).collect();
+```
+
+Replace with:
+
+```rust
+self.scratch_audio.clear();
+self.scratch_audio.extend((sweep_start..sweep_end).map(read_audio));
+```
+
+Downstream reference (around line 587) `&scratch_audio` becomes `&self.scratch_audio`.
+
+- [ ] **Step 5: Locate and hoist the 4× PD line-pair `vec![0u8; width]` sites**
+
+Run:
+
+```bash
+grep -n "vec!\[0u8" /data/source/slowrx.rs/src/demod.rs /data/source/slowrx.rs/src/mode_pd.rs 2>/dev/null
+```
+
+The audit references `mode_pd.rs:345-348, 423, 437, 479` for 4 buffers — these are per-PD-line-pair luma/chroma accumulators (likely something like `y_odd_lum`, `y_even_lum`, `cr_lum`, `cb_lum`).
+
+**If the 4 sites are in `src/mode_pd.rs`** (a separate file from `src/demod.rs`):
+
+Add 4 scratch fields to `ChannelDemod` (in `src/demod.rs`, alongside the three added in Step 1):
+
+```rust
+    /// PD line-pair scratch buffers — luma + 2 chroma + 2nd luma
+    /// accumulators per line pair. Hoisted out of decode_pd_line_pair.
+    /// (Audit #93 D3.)
+    pd_y_odd: Vec<u8>,
+    pd_y_even: Vec<u8>,
+    pd_cr: Vec<u8>,
+    pd_cb: Vec<u8>,
+```
+
+Update `ChannelDemod::new` to initialize them as empty (`Vec::new()`).
+
+In `src/mode_pd.rs::decode_pd_line_pair`, replace the 4 `let mut <name> = vec![0u8; width];` (or equivalent) lines with `clear() + resize(width, 0)` calls on the corresponding `ChannelDemod` field. The exact variable names depend on the existing code — use whatever the existing locals are called (just prepend `self.` or `demod.` as the function takes `ChannelDemod`).
+
+**If the 4 sites are inline in `src/demod.rs`** (e.g., merged into `decode_one_channel_into` or a sibling fn in the same file): hoist them the same way, just edit `src/demod.rs` only.
+
+**If only some of the 4 exist post-#85** (the audit's line numbers are pre-extraction): hoist what's there, document the count in the commit message, mark any missing as "audit reference was pre-#85 extraction; verified absent in current code."
+
+- [ ] **Step 6: Run the full gate**
+
+```bash
+cargo fmt --all
+cargo fmt --all -- --check
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test --all-features --locked --release
+RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features
+```
+
+All four must pass. Expected lib test count: **136** (pure refactor; no test changes).
+
+**Critical regression checks:**
+- `tests/roundtrip.rs` 11/11 — the per-channel scratch hoist must not change pixel output. Each `decode_one_channel_into` call must produce identical `stored_lum` content as before; the `clear() + reserve()/resize()` pattern guarantees this since the buffers are fully overwritten at each call.
+- All existing per-mode tests in `modespec::tests` pass (unchanged).
+- `find_sync_*` tests from T1 still pass.
+
+If clippy fires `clippy::needless_pass_by_value` on the `&mut ChannelDemod` parameter (or `&mut self`), that's because the scratch fields are read across the function and the borrow checker is happy — no action needed.
+
+If `clippy::cast_*` lints fire on any new arithmetic, the function already carries `#[allow(...)]` blocks from prior audits; extend if necessary.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/demod.rs src/mode_pd.rs
+git commit -m "perf(demod): D3 — hoist per-channel scratch onto ChannelDemod (#93)
+
+Adds pixel_times / stored_lum / scratch_audio (+ 4× PD line-pair
+luma/chroma scratches if present in current source) as fields on
+ChannelDemod. The 3 per-channel + 4 per-pair Vec allocations inside
+decode_one_channel_into and decode_pd_line_pair (~7000 allocs per PD240
+image) are replaced with clear() + reserve()/resize()/extend() on the
+hoisted buffers.
+
+tests/roundtrip.rs 11/11 unchanged.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+(Adjust the commit body to reflect whether 4 PD scratches were hoisted, fewer, or none — based on what grep finds in Step 5.)
+
+---
+
+## Task 3: D5 + D6.1 + D6.2 — Drop `LineDecoded.pixels`, add `current_image()`, refactor `run_findsync_and_decode`, `DecodingState` `with_capacity`
+
+The big task. Public API change + consumer migration + ownership refactor + capacity hint.
+
+**Files:**
+- Modify: `src/decoder.rs` (the bulk)
+- Modify: `src/bin/slowrx_cli.rs` (consumer migration)
+- Modify: `tests/roundtrip.rs`, `tests/cli.rs`, `tests/multi_image.rs`, `tests/no_vis.rs`, `tests/unknown_vis.rs` (scan + update if they touch `LineDecoded.pixels`)
+
+- [ ] **Step 1: Drop `pixels` from `SstvEvent::LineDecoded` in `src/decoder.rs`**
+
+Locate `pub enum SstvEvent` (around line 17). Current `LineDecoded` variant (around line 68):
+
+```rust
+    LineDecoded {
+        mode: SstvMode,
+        line_index: u32,
+        pixels: Vec<[u8; 3]>,
+    },
+```
+
+Replace with:
+
+```rust
+    /// One image row has been fully decoded. Pixel data lives on the
+    /// decoder's in-progress image; call
+    /// [`SstvDecoder::current_image`] to borrow it.
+    /// Row `line_index` is fully populated after this event fires.
+    /// (Audit #93 D5.)
+    LineDecoded {
+        mode: SstvMode,
+        line_index: u32,
+    },
+```
+
+The doc-comment above the variant changes to point at `current_image()`. (The exact pre-edit doc text may vary; preserve whatever rationale was there and append the new framing.)
+
+- [ ] **Step 2: Add `SstvDecoder::current_image()` method in `src/decoder.rs`**
+
+Locate the `impl SstvDecoder` block. After `SstvDecoder::new` and before `pub fn process` (or anywhere inside the impl that fits the existing layout), add:
+
+```rust
+    /// Borrow the in-progress image. Returns `Some(&image)` while the
+    /// decoder is in the `Decoding` state (after a `VisDetected` event
+    /// and before the `ImageComplete` event); `None` while
+    /// `AwaitingVis`. Row `N` is fully populated after the
+    /// `LineDecoded { line_index: N, .. }` event for that row has been
+    /// emitted by the most recent [`process`] call. (Audit #93 D5.)
+    ///
+    /// [`process`]: SstvDecoder::process
+    #[must_use]
+    pub fn current_image(&self) -> Option<&SstvImage> {
+        match &self.state {
+            State::Decoding(d) => Some(&d.image),
+            State::AwaitingVis => None,
+        }
+    }
+```
+
+- [ ] **Step 3: Update `DecodingState` construction to use `with_capacity` (D6.1)**
+
+In `src/decoder.rs::process`, locate the State::Decoding construction (around line 326 — the spot where `target_audio_samples: target` is set). Update the `audio` and `has_sync` fields:
+
+```rust
+// Before:
+audio: Vec::new(),
+has_sync: Vec::new(),
+target_audio_samples: target,
+
+// After:
+audio: Vec::with_capacity(target),
+has_sync: Vec::with_capacity(target / crate::sync::SYNC_PROBE_STRIDE),
+target_audio_samples: target,
+```
+
+(If `target` is computed slightly differently or named differently in the actual code, use whatever local variable holds the value — the principle is "use the known target instead of letting the Vec grow from 0.")
+
+- [ ] **Step 4: Refactor `run_findsync_and_decode` to take `DecodingState` by value (D6.2)**
+
+In `src/decoder.rs`, locate `fn run_findsync_and_decode(d: &mut DecodingState, ...)` (around line 478). Change the signature to take `d` by value:
+
+```rust
+fn run_findsync_and_decode(
+    mut d: DecodingState,
+    channel_demod: &mut crate::demod::ChannelDemod,
+    snr_est: &mut crate::snr::SnrEstimator,
+    find_sync_scratch: &mut crate::sync::FindSyncScratch,
+    out: &mut Vec<SstvEvent>,
+) {
+    let work_rate = f64::from(crate::resample::WORKING_SAMPLE_RATE_HZ);
+    let result = find_sync(&d.has_sync, work_rate, d.spec, find_sync_scratch);
+    let rate = result.adjusted_rate_hz;
+    let skip = result.skip_samples;
+
+    // Image-complete burst: image_lines LineDecoded events + 1 ImageComplete.
+    // Pre-reserve to avoid ~9 Vec growth reallocs. (Audit #93 D5.)
+    out.reserve(d.spec.image_lines as usize + 1);
+
+    let line_pixels = d.spec.line_pixels as usize;
+    match d.spec.channel_layout {
+        crate::modespec::ChannelLayout::PdYcbcr => {
+            let pair_count = d.spec.image_lines / 2;
+            for pair in 0..pair_count {
+                let pair_seconds = f64::from(pair) * d.spec.line_seconds;
+                crate::mode_pd::decode_pd_line_pair(
+                    d.spec,
+                    pair,
+                    &d.audio,
+                    skip,
+                    pair_seconds,
+                    rate,
+                    &mut d.image,
+                    channel_demod,
+                    snr_est,
+                    d.hedr_shift_hz,
+                );
+                let row0 = pair * 2;
+                let row1 = row0 + 1;
+                for r in [row0, row1] {
+                    out.push(SstvEvent::LineDecoded {
+                        mode: d.mode,
+                        line_index: r,
+                    });
+                }
+            }
+        }
+        crate::modespec::ChannelLayout::RobotYuv => {
+            for line in 0..d.spec.image_lines {
+                let line_seconds_offset = f64::from(line) * d.spec.line_seconds;
+                crate::mode_robot::decode_line(
+                    d.spec,
+                    d.mode,
+                    line,
+                    &d.audio,
+                    skip,
+                    line_seconds_offset,
+                    rate,
+                    &mut d.image,
+                    d.chroma_planes.as_mut(),
+                    channel_demod,
+                    snr_est,
+                    d.hedr_shift_hz,
+                );
+                out.push(SstvEvent::LineDecoded {
+                    mode: d.mode,
+                    line_index: line,
+                });
+            }
+        }
+        crate::modespec::ChannelLayout::RgbSequential => {
+            for line in 0..d.spec.image_lines {
+                let line_seconds_offset = f64::from(line) * d.spec.line_seconds;
+                crate::mode_scottie::decode_line(
+                    d.spec,
+                    d.mode,
+                    line,
+                    &d.audio,
+                    skip,
+                    line_seconds_offset,
+                    rate,
+                    &mut d.image,
+                    channel_demod,
+                    snr_est,
+                    d.hedr_shift_hz,
+                );
+                out.push(SstvEvent::LineDecoded {
+                    mode: d.mode,
+                    line_index: line,
+                });
+            }
+        }
+    }
+
+    // Move the now-populated image into the ImageComplete event.
+    // No more mem::replace + fresh black SstvImage allocation. (Audit #93 D6.2.)
+    out.push(SstvEvent::ImageComplete {
+        image: d.image,
+        partial: false,
+    });
+}
+```
+
+Key changes:
+- Signature: `d: &mut DecodingState` → `mut d: DecodingState` (by value).
+- New `find_sync_scratch: &mut FindSyncScratch` parameter (already added in T1 Step 6).
+- `out.reserve(d.spec.image_lines as usize + 1)` near the top.
+- Each `out.push(SstvEvent::LineDecoded { ..., pixels: d.image.pixels[start..end].to_vec() })` drops the `pixels:` field and the slice-clone.
+- The `let row0/row1 ... let start ... let end` locals for PD are gone (no slice needed).
+- The closing `mem::replace + SstvImage::new(...)` block is REPLACED with a direct `out.push(SstvEvent::ImageComplete { image: d.image, partial: false })` — moves `d.image` into the event.
+
+- [ ] **Step 5: Update the `run_findsync_and_decode` call site in `SstvDecoder::process`**
+
+In `src/decoder.rs::process`, locate where `run_findsync_and_decode` is invoked (the burst-emit transition; around the `audio.len() >= target_audio_samples` branch). Currently looks like:
+
+```rust
+// Before (approximate):
+match &mut self.state {
+    State::Decoding(d) if d.audio.len() >= d.target_audio_samples => {
+        Self::run_findsync_and_decode(d, &mut self.channel_demod, &mut self.snr_est, &mut self.find_sync_scratch, &mut out);
+        self.state = State::AwaitingVis;
+    }
+    // ... other arms ...
+}
+```
+
+Refactor to swap `self.state` BEFORE calling, so we own `d` by value:
+
+```rust
+// After:
+let buffer_full = matches!(
+    &self.state,
+    State::Decoding(d) if d.audio.len() >= d.target_audio_samples
+);
+if buffer_full {
+    let State::Decoding(d) = std::mem::replace(&mut self.state, State::AwaitingVis) else {
+        unreachable!("matches!() guard ensures Decoding");
+    };
+    Self::run_findsync_and_decode(
+        *d,  // unbox; pass DecodingState by value
+        &mut self.channel_demod,
+        &mut self.snr_est,
+        &mut self.find_sync_scratch,
+        &mut out,
+    );
+}
+```
+
+The exact location and surrounding match-arm structure in `process()` will vary — the implementer locates the existing `Self::run_findsync_and_decode(d, ...)` call and refactors the surrounding control flow to extract `d` by value via `std::mem::replace`. The key invariants:
+1. `self.state` ends up at `State::AwaitingVis` after the call.
+2. `d` is moved into `run_findsync_and_decode` by value (no `&mut`).
+3. No other code in `process()` references `self.state` between the `mem::replace` and the `run_findsync_and_decode` call.
+
+If the existing `process()` uses a complex `match &mut self.state` block that makes the by-value extraction awkward, an alternative structure: do the buffer-fullness check first, then `std::mem::replace` only when it fires. Either approach is correct.
+
+- [ ] **Step 6: Migrate `src/bin/slowrx_cli.rs` consumers**
+
+Run:
+```bash
+grep -n "LineDecoded\|\.pixels" /data/source/slowrx.rs/src/bin/slowrx_cli.rs
+```
+
+For each `SstvEvent::LineDecoded { mode, line_index, pixels }` match arm, drop the `pixels` field:
+
+```rust
+// Before:
+SstvEvent::LineDecoded { mode, line_index, pixels } => {
+    // ... uses pixels ...
+}
+
+// After:
+SstvEvent::LineDecoded { mode, line_index } => {
+    // ... if pixels was used, replace with:
+    // let img = decoder.current_image().expect("LineDecoded fires only during Decoding");
+    // let start = (line_index as usize) * (img.width as usize);
+    // let end = start + (img.width as usize);
+    // let pixels = &img.pixels[start..end];
+    // ... uses pixels (now a slice) ...
+}
+```
+
+If the CLI doesn't actually use the pixels (just counts events or logs `line_index`), the match-arm pattern change is the only edit needed.
+
+- [ ] **Step 7: Migrate test consumers in `tests/*.rs`**
+
+Run:
+```bash
+grep -rn "LineDecoded\|\.pixels" /data/source/slowrx.rs/tests/
+```
+
+For each match arm or destructure, apply the same migration as Step 6. Most likely candidates:
+- `tests/roundtrip.rs` — exercises the full decode pipeline; if it inspects per-line pixels it'll need `current_image()` migration. If it only checks the final `ImageComplete.image.pixels`, no change needed.
+- `tests/multi_image.rs`, `tests/cli.rs`, `tests/no_vis.rs`, `tests/unknown_vis.rs` — most likely just count events; pattern-only update.
+
+For tests inside `src/decoder.rs::tests` (if any match `LineDecoded`), apply the same migration.
+
+- [ ] **Step 8: Add a `current_image()` regression test in `src/decoder.rs::tests`**
+
+In `src/decoder.rs::tests`, append a small regression test:
+
+```rust
+    #[test]
+    fn current_image_is_none_when_awaiting_vis() {
+        let decoder = SstvDecoder::new(44100).expect("rate ok");
+        assert!(decoder.current_image().is_none());
+    }
+```
+
+(One test, no decode required — exercises the new API surface. The "Some(image) during Decoding" case is implicitly covered by `tests/roundtrip.rs` if any test inspects `current_image()` between line events. The spec marked that broader test as Optional; we skip it.)
+
+This is the only net new test in this PR. Lib count: **136 → 137**.
+
+Update the lib test count expectation in T4 to reflect 137 (the spec's success-criteria said 136→136; this small addition is a deviation worth documenting in the CHANGELOG bullet).
+
+- [ ] **Step 9: Run the full gate**
+
+```bash
+cargo fmt --all
+cargo fmt --all -- --check
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test --all-features --locked --release
+RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features
+```
+
+All four must pass. Expected lib test count: **137** (136 + 1 new `current_image_is_none_when_awaiting_vis`).
+
+**Critical regression checks:**
+- `tests/roundtrip.rs` 11/11 — the pixel output across all 11 modes must be identical before and after the refactor.
+- `tests/cli.rs` + `tests/multi_image.rs` + `tests/no_vis.rs` + `tests/unknown_vis.rs` all green.
+- `LineDecoded` match arms in all test files compile (no `pixels` field references remaining).
+
+If clippy fires `clippy::unused_async` or `clippy::needless_lifetimes` on the refactored `process()`, fix at minimum scope. If `clippy::let_underscore_must_use` or related fires on the `_ = std::mem::replace(...)` (it shouldn't — `mem::replace` returns the old value and we destructure it via `let State::Decoding(d) = ...`), confirm the pattern compiles cleanly.
+
+If `RUSTDOCFLAGS="-D warnings"` fires `rustdoc::broken_intra_doc_links` on the new `[`process`]: SstvDecoder::process` doc link, the verbose `[name]: path` form should resolve. If it doesn't, switch to plain `\`process\`` code-span.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/decoder.rs src/bin/slowrx_cli.rs tests/
+git commit -m "feat(decoder)!: D5 + D6.1 + D6.2 — drop LineDecoded.pixels; current_image(); refactor (#93)
+
+BREAKING CHANGE: SstvEvent::LineDecoded no longer carries
+pixels: Vec<[u8; 3]>. Consumers call SstvDecoder::current_image()
+to borrow the in-progress image instead. (Audit #93 D5.)
+
+Also:
+- New SstvDecoder::current_image() -> Option<&SstvImage> method.
+- run_findsync_and_decode refactored to take DecodingState by value;
+  d.image moves directly into the ImageComplete event, no more
+  mem::replace + fresh SstvImage::new black image alloc. (Audit D6.2)
+- DecodingState audio/has_sync use with_capacity(target). (Audit D6.1)
+- out.reserve(image_lines + 1) before the burst emit.
+
+Consumer migration: slowrx_cli + ~5 test files updated to drop the
+pixels field from match arms (or migrate to current_image() if used).
+
+Net new test: current_image_is_none_when_awaiting_vis. Lib 136 → 137.
+tests/roundtrip.rs 11/11 unchanged — pixel output identical.
+
+Release implication: requires 0.6.0 minor bump at release time.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+(The `!` after `feat(decoder)` is conventional-commits notation for a breaking change.)
+
+---
+
+## Task 4: CHANGELOG + final gate
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Add CHANGELOG entries**
+
+Open `CHANGELOG.md`. Under `## [Unreleased]`, prepend a new `### Changed` section (above the existing `### Internal`), and add a new perf bullet to `### Internal`:
+
+```markdown
+## [Unreleased]
+
+### Changed
+
+- **`SstvEvent::LineDecoded` no longer carries `pixels: Vec<[u8; 3]>`.**
+  Consumers call [`SstvDecoder::current_image()`] (new) to borrow the
+  in-progress image instead. Row `N` is fully populated after the
+  `LineDecoded { line_index: N, .. }` event fires. **Breaking change** —
+  bumps the next release to **0.6.0**. The migration is one-line per
+  call site: drop the `pixels` field from the match-arm pattern; if
+  the pixel data was being used, fetch it via
+  `decoder.current_image().map(|img| &img.pixels[start..end])`.
+  Eliminates ~496 per-line `.to_vec()` allocations per PD240 image.
+  (#93; audit D5.)
+
+  [`SstvDecoder::current_image()`]: https://docs.rs/slowrx/0.6.0/slowrx/struct.SstvDecoder.html#method.current_image
+
+### Internal
+
+- **Performance: hoist per-channel/per-line allocations into reusable scratch**
+  (audit bundle 9 of 12). Three hot allocation sites moved out of the
+  decode hot path: (1) per-channel scratch (`pixel_times`, `stored_lum`,
+  `scratch_audio`, plus PD line-pair luma/chroma temps) now lives on
+  `ChannelDemod` and is reused via `clear()` + `reserve()`/`resize()`/
+  `extend()` — ~7000 allocations per PD240 image eliminated (audit D3);
+  (2) `find_sync`'s `sync_img` / `lines` / `x_acc` buffers (~730 KB)
+  moved to a new `pub(crate) FindSyncScratch` struct owned by
+  `SstvDecoder`; `find_sync` + `hough_detect_slant` + `find_falling_edge`
+  gain a `scratch: &mut FindSyncScratch` parameter; ~5 existing
+  `find_sync_*` tests construct `FindSyncScratch::new()` locally
+  (audit D6.3); (3) `DecodingState.audio` / `.has_sync` use
+  `with_capacity(target_audio_samples)` instead of `Vec::new()`
+  (audit D6.1); (4) `run_findsync_and_decode` now takes
+  `DecodingState` by value and moves `d.image` directly into the
+  `ImageComplete` event — eliminates the throwaway ~950 KB black-image
+  `mem::replace` workaround (audit D6.2). All hot-loop allocation
+  patterns become "0 allocs after first decode" instead of growing
+  with image size. Plus `out.reserve(image_lines + 1)` before the
+  burst-emit loop saves ~9 `Vec` growth reallocs. `tests/roundtrip.rs`
+  11/11 unchanged — pixel output is identical before and after.
+  (#93; audit D3/D6.)
+
+- **API hygiene sweep** — ... [existing #92 bullet stays as-is below]
+
+## [0.5.3] — 2026-05-14
+...
+```
+
+(The `### Changed` subsection goes ABOVE `### Internal`. This matches Keep a Changelog ordering: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `Security`, then project-specific groupings like `Internal`.)
+
+If the `[Unreleased]` section currently has only `### Internal`, the `### Changed` is a new subsection. If it has other subsections, slot `### Changed` in the canonical order.
+
+**Note on the docs.rs URL:** the `0.6.0` URL won't resolve until the release lands and crates.io publishes. Acceptable — the link will work post-release. If preferred, drop the URL footnote and inline-format the link as plain `\`SstvDecoder::current_image()\`` (code-span without URL).
+
+- [ ] **Step 2: Run the full CI gate**
+
+```bash
+cargo fmt --all
+cargo fmt --all -- --check
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test --all-features --locked --release
+RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features
+```
+
+All four must pass. Expected test counts:
+- lib: **137** (136 pre-#93 + 1 new `current_image_is_none_when_awaiting_vis`).
+- `tests/roundtrip.rs`: 11/11 (unchanged).
+- All other integration tests: unchanged.
+- Doc clean.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CHANGELOG.md
+git commit -m "docs(refactor): CHANGELOG for the perf scratch hoisting (#93)
+
+Both ### Changed (D5 breaking — drop LineDecoded.pixels, add
+current_image, requires 0.6.0) and ### Internal (D3 + D6 perf hoists)
+entries. Next release: 0.6.0.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Self-review notes (for the implementer / reviewers)
+
+- **Spec coverage:**
+  - D3 (per-channel scratch hoist) → T2.
+  - D5 (drop `LineDecoded.pixels`, add `current_image()`, pre-`reserve`) → T3 Steps 1, 2, 4 (the `out.reserve` line).
+  - D6.1 (`DecodingState::with_capacity`) → T3 Step 3.
+  - D6.2 (refactor `run_findsync_and_decode` by-value `d`; move `d.image` into event) → T3 Steps 4-5.
+  - D6.3 (`FindSyncScratch` + plumb through `find_sync` + helpers + `SstvDecoder`) → T1.
+  - CHANGELOG → T4.
+
+- **Behavior preservation guarantees:**
+  - All 3 scratch hoists are pure refactor — the buffers are fully overwritten at each use (clear() + reserve()/resize()/fill() pattern), so pixel output is bit-identical. `tests/roundtrip.rs` 11/11 is the load-bearing regression check.
+  - The throwaway black-image fix (D6.2) doesn't change the `ImageComplete.image` content — same image, just no transient black allocation in the swap.
+  - The `LineDecoded.pixels` removal (D5) doesn't change WHAT events fire or in what order — just removes a redundant data field. Consumers reading `current_image()` after `LineDecoded { line_index: N }` see the same pixels they used to get in the event.
+
+- **TDD red moments:**
+  - T3 Step 8 adds the only net new test (`current_image_is_none_when_awaiting_vis`). It's a "green from the start" structural test — `current_image()` exists after T3 Step 2; the test verifies the AwaitingVis branch returns None.
+  - No deliberately-red tests in this PR; all changes are refactors with the existing test suite as the regression net.
+
+- **Compile-time gating:**
+  - Adding a field to `SstvEvent::LineDecoded` was historically protected by `#[non_exhaustive]` on the enum — verify that's still the case. If `SstvEvent` is `#[non_exhaustive]`, removing the `pixels` field is technically still a breaking change for callers that destructure (the match-arm pattern `LineDecoded { mode, line_index, pixels }` becomes a compile error).
+  - Adding a new `pub fn current_image()` method on `SstvDecoder` is non-breaking (additive).
+
+- **Out of scope** (tracked elsewhere):
+  - SIMD'ifying the SNR power-sum (#77).
+  - Sink/callback API for `process` (deferred — V2 milestone).
+  - `impl Iterator` for events (deferred).
+
+- **Release flow:** This PR's CHANGELOG entry stays under `[Unreleased]`. The next release is a separate `chore/release-0.6.0` PR (per the established pattern from 0.5.3) that:
+  1. Bumps `Cargo.toml` 0.5.3 → 0.6.0.
+  2. Changes `[Unreleased]` → `[0.6.0] — YYYY-MM-DD` in CHANGELOG.
+  3. Adds a fresh empty `[Unreleased]` above.
+  4. Tags `v0.6.0` post-merge.
+  5. Publishes to crates.io.

--- a/docs/superpowers/specs/2026-05-15-issue-93-perf-scratch-design.md
+++ b/docs/superpowers/specs/2026-05-15-issue-93-perf-scratch-design.md
@@ -1,0 +1,337 @@
+# Issue #93 — Perf: hoist per-channel/per-line allocations into reusable scratch — Design
+
+**Issue:** [#93](https://github.com/jasonherald/slowrx.rs/issues/93) (audit bundle 9 of 12 — IDs D3, D5, D6).
+
+**Scope:** eliminate per-decode allocation churn at three sites — per-channel scratch (D3, ~7000 allocs per PD240 image), the events Vec + per-line pixel clones (D5), and the `DecodingState` capacity + `find_sync` scratch + throwaway black-image workaround (D6). One **public-API-breaking** change: drop `pixels: Vec<[u8; 3]>` from `SstvEvent::LineDecoded` and expose `SstvDecoder::current_image() -> Option<&SstvImage>` for callers that want the in-progress row data. This is a **0.6.0 minor bump** (the audit-cleanup-wave releases 0.5.1/0.5.2/0.5.3 were all non-breaking; #93 is the first since 0.5.0 to touch the public surface).
+
+---
+
+## Background — audit findings
+
+- **D3 — per-channel `Vec` churn.** `decode_one_channel_into` (the shared per-channel path used by PD / Robot / Scottie via `crate::demod`) allocates `pixel_times`, `stored_lum`, and `scratch_audio` fresh per call. Plus 4× `vec![0u8; width]` per PD line pair somewhere in the PD-specific code path. At PD240 (~496 lines × 4 channels) that's roughly 7000 allocations per decoded image.
+- **D5 — `LineDecoded.pixels` and the events Vec.** `LineDecoded` currently carries `pixels: Vec<[u8; 3]>` cloned from `d.image.pixels[start..end]`. For PD240 that's ~496 small allocations (~1920 B each, ~950 KB total in tiny allocs) duplicating data already in `d.image.pixels`. The events Vec itself grows from 0 to `image_lines + 1` entries, requiring ~9 reallocs.
+- **D6 — `DecodingState` capacity, throwaway black image, `find_sync` scratch.** Three sub-items:
+  - `DecodingState.audio` and `.has_sync` start at `Vec::new()` despite `target_audio_samples` being known at construction time.
+  - `run_findsync_and_decode` does `mem::replace(&mut d.image, SstvImage::new(...))` — allocating a fresh ~950 KB black image just to satisfy the borrow checker — so the real image can be moved into `ImageComplete`.
+  - `find_sync` (with its three helpers `hough_detect_slant`, `find_falling_edge`, `falling_edge_from_x_acc`) allocates ~730 KB of `sync_img` / `lines` / `x_acc` buffers per call.
+
+---
+
+## Architecture
+
+### D3 — Hoist channel scratch onto `ChannelDemod`
+
+`ChannelDemod` is already per-`SstvDecoder` and is the shared owner of FFT plans + Hann bank for the per-channel demod path. Adding three scratch fields keeps ownership local and avoids a new top-level struct.
+
+```rust
+// src/demod.rs
+pub(crate) struct ChannelDemod {
+    fft: Arc<dyn rustfft::Fft<f32>>,
+    fft_buf: Vec<Complex<f32>>,
+    scratch: Vec<Complex<f32>>,
+    hann_bank: HannBank,
+    /// Per-channel scratch hoisted out of `decode_one_channel_into`.
+    /// Reused across calls via `clear() + reserve()/resize()/extend()`
+    /// at the top of each invocation. (Audit #93 D3.)
+    pixel_times: Vec<i64>,
+    stored_lum: Vec<u8>,
+    scratch_audio: Vec<f32>,
+}
+```
+
+`ChannelDemod::new` initializes them as `Vec::new()` — they grow once on the first decode and stay sized for the lifetime of the `SstvDecoder`.
+
+`decode_one_channel_into` rewrites three current allocation sites to operate on `&mut self.{pixel_times, stored_lum, scratch_audio}`:
+
+```rust
+// Before (src/demod.rs:493-498):
+let mut pixel_times: Vec<i64> = Vec::with_capacity(width);
+for x in 0..width {
+    let abs = ...;
+    pixel_times.push(abs);
+}
+
+// After:
+self.pixel_times.clear();
+self.pixel_times.reserve(width);
+for x in 0..width {
+    let abs = ...;
+    self.pixel_times.push(abs);
+}
+```
+
+```rust
+// Before (src/demod.rs:508):
+let mut stored_lum = vec![0_u8; sweep_len];
+
+// After:
+self.stored_lum.clear();
+self.stored_lum.resize(sweep_len, 0);
+```
+
+```rust
+// Before (src/demod.rs:548):
+let scratch_audio: Vec<f32> = (sweep_start..sweep_end).map(read_audio).collect();
+
+// After:
+self.scratch_audio.clear();
+self.scratch_audio.extend((sweep_start..sweep_end).map(read_audio));
+```
+
+Downstream references to the local bindings (`&pixel_times`, `&stored_lum`, `&scratch_audio` in subsequent lines of the function) become `&self.pixel_times`, `&self.stored_lum`, `&self.scratch_audio`.
+
+**4× `vec![0u8; width]` per PD line pair.** The audit references `mode_pd.rs:345-348, 423, 437, 479` — those 4 buffers are PD-specific (luma + chroma temp accumulators per line pair). They live in either `src/demod.rs::decode_pd_line_pair` or `src/mode_pd.rs` (depending on the post-#85 layout — the implementer locates them via `grep -n "vec!\[0u8" src/`). If they cluster in `decode_pd_line_pair`, hoist them as 4 more fields on `ChannelDemod` (next to the three above) — `pd_line_*_scratch` — with the same `clear()+resize()` pattern at the top of each line-pair decode.
+
+### D5 — Drop `LineDecoded.pixels`; expose `current_image()`
+
+**Public API change** (breaking — 0.6.0 minor bump):
+
+```rust
+// src/decoder.rs — SstvEvent enum
+pub enum SstvEvent {
+    /// VIS detected; mode resolved. Decoder is now in `Decoding` state.
+    VisDetected { mode: SstvMode, sample_offset: u64 },
+    /// Unknown VIS code received; decoder reset to `AwaitingVis`.
+    UnknownVis { code: u8, sample_offset: u64 },
+    /// One image row has been fully decoded. The pixel data lives on
+    /// the decoder's in-progress image; call
+    /// [`SstvDecoder::current_image`] to borrow it.
+    LineDecoded {
+        mode: SstvMode,
+        line_index: u32,
+        // `pixels: Vec<[u8; 3]>` is REMOVED (audit #93 D5). Consumers
+        // call `decoder.current_image()` to borrow the row data.
+    },
+    /// Image complete; the owned image is in this event.
+    ImageComplete { image: SstvImage, partial: bool },
+}
+```
+
+**New method on `SstvDecoder`:**
+
+```rust
+impl SstvDecoder {
+    /// Borrow the in-progress image. Returns `Some(&image)` while the
+    /// decoder is in the `Decoding` state (after a `VisDetected` event
+    /// and before the `ImageComplete` event); `None` while
+    /// `AwaitingVis`. Row `N` is fully populated after the
+    /// `LineDecoded { line_index: N, .. }` event for that row has been
+    /// emitted by the most recent `process()` call. (audit #93 D5)
+    #[must_use]
+    pub fn current_image(&self) -> Option<&SstvImage> {
+        match &self.state {
+            State::Decoding(d) => Some(&d.image),
+            State::AwaitingVis => None,
+        }
+    }
+}
+```
+
+**Pre-`reserve` the events Vec at the burst-emit transition.** Inside `run_findsync_and_decode` (now taking `d: DecodingState` by value per D6):
+
+```rust
+// Image-complete burst: image_lines `LineDecoded` events + 1
+// `ImageComplete`. Pre-reserve to avoid ~9 Vec growth reallocs.
+out.reserve(d.spec.image_lines as usize + 1);
+```
+
+**Consumer migration:**
+- The 3 `out.push(SstvEvent::LineDecoded { ..., pixels: d.image.pixels[start..end].to_vec() })` sites in `run_findsync_and_decode` (one per `ChannelLayout` arm — PD, Robot, Scottie) drop the `pixels:` field and the `.to_vec()`.
+- `src/bin/slowrx_cli.rs` — scan for `LineDecoded` matches and `.pixels` field access; update to call `decoder.current_image().map(|img| &img.pixels[start..end])` where appropriate. If the CLI only matches the variant shape (no `pixels` field access), the match arm pattern needs the `pixels` removed.
+- `tests/roundtrip.rs`, `tests/cli.rs`, `tests/multi_image.rs`, `tests/no_vis.rs`, `tests/unknown_vis.rs` — same scan-and-update. Likely most tests just match the variant shape (counting events); only a few inspect `pixels`.
+
+**Perf win:** ~496 `to_vec()` allocations + ~9 Vec growth reallocs → 0.
+
+### D6 — Three sub-items
+
+**D6.1 — `DecodingState` `with_capacity` at construction.** In `process()` around line 326 (the State::AwaitingVis → State::Decoding transition):
+
+```rust
+// Before:
+audio: Vec::new(),
+has_sync: Vec::new(),
+target_audio_samples: target,
+
+// After:
+audio: Vec::with_capacity(target),
+has_sync: Vec::with_capacity(target / crate::sync::SYNC_PROBE_STRIDE),
+target_audio_samples: target,
+```
+
+`target` is the computed `target_audio_samples` (image_lines / 2 × line_seconds × FINDSYNC_AUDIO_HEADROOM × work_rate, per the existing comment). The `has_sync` track holds one entry per `SYNC_PROBE_STRIDE`-spaced sample. Pre-sizing saves ~10 reallocs as both buffers grow.
+
+**D6.2 — Black-image throwaway fix.** Current shape at `decoder.rs:589-592`:
+
+```rust
+let final_image = std::mem::replace(
+    &mut d.image,
+    SstvImage::new(d.mode, d.spec.line_pixels, d.spec.image_lines),
+);
+out.push(SstvEvent::ImageComplete { image: final_image, partial: false });
+```
+
+Refactor: take `d` by value into `run_findsync_and_decode`, move `d.image` directly into the event.
+
+```rust
+// In SstvDecoder::process — at the burst-emit transition:
+let State::Decoding(d) = std::mem::replace(&mut self.state, State::AwaitingVis) else {
+    unreachable!("matched State::Decoding above");
+};
+Self::run_findsync_and_decode(
+    *d,                              // unbox; pass by value
+    &mut self.channel_demod,
+    &mut self.snr_est,
+    &mut self.find_sync_scratch,     // D6.3
+    &mut out,
+);
+
+// run_findsync_and_decode signature:
+fn run_findsync_and_decode(
+    mut d: DecodingState,            // by value (was: &mut DecodingState)
+    channel_demod: &mut ChannelDemod,
+    snr_est: &mut SnrEstimator,
+    find_sync_scratch: &mut FindSyncScratch,
+    out: &mut Vec<SstvEvent>,
+) {
+    out.reserve(d.spec.image_lines as usize + 1);  // D5
+    // ... per-channel-layout branches continue to use &mut d.image
+    // internally for mutation. At the end:
+    out.push(SstvEvent::ImageComplete { image: d.image, partial: false });
+    //                                  ^^^^^^^ moves; no replace, no fresh alloc.
+}
+```
+
+`mut d` lets the per-pair / per-line decoders take `&mut d.image`. The final `d.image` move consumes `d` cleanly. State transition (`State::Decoding → AwaitingVis`) moves from "inside `run_findsync_and_decode` via mem::replace" to "in the caller, before the call" — cleaner ownership.
+
+**D6.3 — `FindSyncScratch` on `SstvDecoder`.** New struct in `src/sync.rs`:
+
+```rust
+/// Scratch buffers for `find_sync`. Hoisted onto `SstvDecoder` so
+/// they're reused across decode passes — the largest two are
+/// allocated once at decoder construction. (Audit #93 D6.)
+pub(crate) struct FindSyncScratch {
+    sync_img: Vec<bool>,    // X_ACC_BINS × SYNC_IMG_Y_BINS = 441,000 entries
+    lines: Vec<u16>,        // LINES_D_BINS × n_slant_bins (varies; resized per-call)
+    x_acc: Vec<u32>,        // X_ACC_BINS = 700
+}
+
+impl FindSyncScratch {
+    pub(crate) fn new() -> Self {
+        Self {
+            sync_img: vec![false; X_ACC_BINS * SYNC_IMG_Y_BINS],
+            lines: Vec::new(),  // mode-dependent line_width; resized at use site
+            x_acc: vec![0; X_ACC_BINS],
+        }
+    }
+}
+
+impl Default for FindSyncScratch {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+```
+
+`find_sync` (and the three helpers it orchestrates — `hough_detect_slant`, `find_falling_edge`, `falling_edge_from_x_acc`) gain a `scratch: &mut FindSyncScratch` parameter. Inside:
+- `let mut sync_img = vec![false; X_ACC_BINS * SYNC_IMG_Y_BINS]` → `scratch.sync_img.fill(false)` (already sized).
+- `let mut lines = vec![0u16; LINES_D_BINS * n_slant_bins]` → `scratch.lines.clear(); scratch.lines.resize(LINES_D_BINS * n_slant_bins, 0);`.
+- `let mut x_acc = vec![0u32; X_ACC_BINS]` → `scratch.x_acc.fill(0);` (already sized).
+
+`hough_detect_slant` and `find_falling_edge` borrow only the buffers they need (`sync_img` + `lines` for the Hough vote; `x_acc` for the convolution); pass `&mut scratch.sync_img`, `&mut scratch.lines`, `&mut scratch.x_acc` from `find_sync` rather than threading the whole struct.
+
+`SstvDecoder` gains a field:
+
+```rust
+pub struct SstvDecoder {
+    resampler: Resampler,
+    vis: crate::vis::VisDetector,
+    channel_demod: crate::demod::ChannelDemod,
+    snr_est: crate::snr::SnrEstimator,
+    find_sync_scratch: crate::sync::FindSyncScratch,  // NEW
+    state: State,
+    samples_processed: u64,
+    working_samples_emitted: u64,
+}
+
+impl SstvDecoder {
+    pub fn new(input_sample_rate_hz: u32) -> Result<Self> {
+        Ok(Self {
+            resampler: Resampler::new(input_sample_rate_hz)?,
+            vis: crate::vis::VisDetector::new(IS_KNOWN_VIS),
+            channel_demod: crate::demod::ChannelDemod::new(),
+            snr_est: crate::snr::SnrEstimator::new(),
+            find_sync_scratch: crate::sync::FindSyncScratch::new(),  // NEW
+            state: State::AwaitingVis,
+            samples_processed: 0,
+            working_samples_emitted: 0,
+        })
+    }
+}
+```
+
+`reset()` does NOT recreate `find_sync_scratch` (the buffers are state-free; `find_sync` clears them at each call).
+
+The `Debug for SstvDecoder` impl (added in #92) does not surface `find_sync_scratch` — it's purely internal scratch.
+
+**Tests in `src/sync.rs::tests`:** ~5 existing `find_sync_*` tests update to construct a local scratch:
+
+```rust
+// Before:
+let r = find_sync(&track, rate, spec);
+
+// After:
+let mut scratch = FindSyncScratch::new();
+let r = find_sync(&track, rate, spec, &mut scratch);
+```
+
+**Perf win:** ~730 KB allocated per `find_sync` call → 0 (after first call). Decoder construction allocs once and keeps them.
+
+---
+
+## File touch list
+
+| File | Status | Role |
+|------|--------|------|
+| `src/demod.rs` | modify | D3 fields on `ChannelDemod`; rewrite `decode_one_channel_into` to use them; if PD line-pair scratches are here, hoist those 4 too. |
+| `src/mode_pd.rs` | modify (if exists) | If the PD line-pair `vec![0u8; width]` × 4 sites live here, hoist them onto `ChannelDemod` (or a sibling `PdLineScratch` if PD-specific). |
+| `src/sync.rs` | modify | New `FindSyncScratch` struct; `find_sync` + helpers gain `scratch: &mut FindSyncScratch` parameter; existing 5 tests update. |
+| `src/decoder.rs` | modify | `SstvEvent::LineDecoded` drops `pixels`; `SstvDecoder` gains `find_sync_scratch` field; `current_image()` method added; `run_findsync_and_decode` rewritten (by-value `d`, `out.reserve`, move `d.image` into event); `DecodingState` constructor uses `with_capacity`. |
+| `src/bin/slowrx_cli.rs` | modify | `LineDecoded` consumer update (drop `pixels` field from match arm or migrate to `current_image()`). |
+| `tests/roundtrip.rs`, `tests/cli.rs`, `tests/multi_image.rs`, `tests/no_vis.rs`, `tests/unknown_vis.rs` | modify | `LineDecoded` consumer updates; scan-and-fix. |
+| `CHANGELOG.md` | modify | New `[Unreleased]` `### Changed` (breaking) section + `### Internal` for the perf bullets. |
+
+---
+
+## Out of scope
+
+- **SIMD'ifying the SNR power-sum inner loops** — separately tracked as #77; the empirical finding there was "function-level `multiversion` wrap is a no-op; needs profile-driven targeting."
+- **Sink/callback API** (`process(&mut self, audio, &mut impl FnMut(SstvEvent))`) — also a breaking change, larger lift; deferred.
+- **`impl Iterator` for events** — same; deferred.
+- **Pooling scratch across decoder instances** — single-decoder use case is the V1 norm; per-decoder ownership is fine.
+
+---
+
+## Release implications
+
+The `LineDecoded.pixels` removal is the first public-API-breaking change since 0.5.0. Per Keep a Changelog + 0.x semver convention, this warrants a **minor version bump** at release time:
+
+- Current published: 0.5.3 (from PR #108, audit-cleanup-wave release).
+- This PR's release: **0.6.0**.
+- CHANGELOG entry uses both `### Changed` (breaking: `LineDecoded.pixels` removed, `current_image()` added) and `### Internal` (perf hoists for D3 / D6) subsections.
+
+The release itself is a separate chore PR (per the established `chore/release-X.Y.Z` pattern from 0.5.3). This PR's CHANGELOG entry goes under `[Unreleased]` — the release PR finalizes the version and the date.
+
+---
+
+## Success criteria
+
+- All 3 in-scope audit findings addressed (D3, D5, D6).
+- Full CI gate green: `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --all-features --locked --release`, `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`.
+- Lib test count: **136 → 136** (no new tests; ~5 existing `find_sync_*` tests update to construct local scratch).
+- `tests/roundtrip.rs` 11/11 unchanged (perf change must not affect pixel output).
+- CLI continues to produce identical filename slugs (already guaranteed by #91/#92; this PR doesn't touch filename logic).
+- Allocation counts (qualitatively): the 3 hot-loop allocation patterns (per-channel scratch, per-line `to_vec()`, per-`find_sync` buffers) all become **0 allocs after first decode** instead of growing with image size. Quantitative profiling is out-of-scope here; if someone wants to verify, `cargo bench`-style or `dhat`-instrumented runs would show the per-PD240-image diff.
+- `SstvEvent` size (mem::size_of) shrinks by `Vec<[u8;3]>` size (3 words on x86_64 = 24 B per event).
+- New `current_image()` API gets a doctest or unit test verifying:
+  - `current_image()` returns `None` immediately after `SstvDecoder::new`.
+  - After a `LineDecoded` event for row N, `current_image().unwrap().pixels[start..end]` matches what `LineDecoded.pixels` used to contain. (Optional regression check; the existing `tests/roundtrip.rs` pixel-equality checks against the final `ImageComplete.image` cover this transitively.)

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -202,6 +202,10 @@ pub struct SstvDecoder {
     /// [`crate::mode_pd::decode_pd_line_pair`] (every
     /// [`crate::demod::SNR_REESTIMATE_STRIDE`] samples).
     snr_est: crate::snr::SnrEstimator,
+    /// Scratch buffers for `find_sync` (`sync_img` / `lines` / `x_acc`).
+    /// Hoisted here so they're reused across decode passes instead of
+    /// being allocated fresh per call. (Audit #93 D6.)
+    find_sync_scratch: crate::sync::FindSyncScratch,
     state: State,
     samples_processed: u64,
     /// Cumulative working-rate samples emitted by the resampler.
@@ -250,6 +254,7 @@ impl SstvDecoder {
             vis: crate::vis::VisDetector::new(IS_KNOWN_VIS),
             channel_demod: crate::demod::ChannelDemod::new(),
             snr_est: crate::snr::SnrEstimator::new(),
+            find_sync_scratch: crate::sync::FindSyncScratch::new(),
             state: State::AwaitingVis,
             samples_processed: 0,
             working_samples_emitted: 0,
@@ -402,6 +407,7 @@ impl SstvDecoder {
                         d,
                         &mut self.channel_demod,
                         &mut self.snr_est,
+                        &mut self.find_sync_scratch,
                         &mut out,
                     );
 
@@ -479,10 +485,11 @@ impl SstvDecoder {
         d: &mut DecodingState,
         channel_demod: &mut crate::demod::ChannelDemod,
         snr_est: &mut crate::snr::SnrEstimator,
+        find_sync_scratch: &mut crate::sync::FindSyncScratch,
         out: &mut Vec<SstvEvent>,
     ) {
         let work_rate = f64::from(crate::resample::WORKING_SAMPLE_RATE_HZ);
-        let result = find_sync(&d.has_sync, work_rate, d.spec);
+        let result = find_sync(&d.has_sync, work_rate, d.spec, find_sync_scratch);
         let rate = result.adjusted_rate_hz;
         let skip = result.skip_samples;
 

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -268,6 +268,13 @@ impl SstvDecoder {
     /// `AwaitingVis`. Row `N` is fully populated after the
     /// `LineDecoded { line_index: N, .. }` event for that row has been
     /// emitted by the most recent `process` call. (Audit #93 D5.)
+    ///
+    /// **R36/R24 caveat:** see [`SstvEvent::LineDecoded`] for the
+    /// cross-row chroma-duplication contract — row N's `Cb` (or `Cr`)
+    /// is zero-initialized when `LineDecoded(N)` fires for the first
+    /// of each row pair, and gets duplicated in by the next row's
+    /// decode. The final `ImageComplete.image` carries the fully
+    /// populated state.
     #[must_use]
     pub fn current_image(&self) -> Option<&SstvImage> {
         match &self.state {
@@ -339,10 +346,12 @@ impl SstvDecoder {
                                 spec,
                                 image,
                                 audio: {
-                                    // D6.1: pre-size to the known final length to
-                                    // avoid Vec growth reallocs over the burst.
-                                    let mut v = Vec::with_capacity(target);
-                                    v.extend(residual);
+                                    // D6.1: keep the residual move + pre-reserve
+                                    // the remaining capacity. Avoids copying
+                                    // residual bytes AND avoids Vec growth
+                                    // reallocs over the burst.
+                                    let mut v = residual;
+                                    v.reserve(target.saturating_sub(v.len()));
                                     v
                                 },
                                 has_sync: Vec::with_capacity(target / SYNC_PROBE_STRIDE),
@@ -947,6 +956,31 @@ mod tests {
     fn current_image_is_none_when_awaiting_vis() {
         let decoder = SstvDecoder::new(44100).expect("rate ok");
         assert!(decoder.current_image().is_none());
+    }
+
+    #[test]
+    fn current_image_is_some_after_vis_detected() {
+        use crate::vis::tests::synth_vis;
+        // Feed a VIS-only burst (no image audio after). Decoder transitions
+        // to Decoding with a zero-initialized image of the mode's expected
+        // dimensions. (audit #93 D5 follow-up — covers the Some(image) path.)
+        let mut decoder =
+            SstvDecoder::new(crate::resample::WORKING_SAMPLE_RATE_HZ).expect("rate ok");
+        let mut burst = synth_vis(0x5F, 0.0); // PD120
+        burst.append(&mut vec![0.0_f32; 1024]); // pad to ensure the VIS detector fires
+        let events = decoder.process(&burst);
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, SstvEvent::VisDetected { .. })),
+            "expected VisDetected event"
+        );
+        let img = decoder
+            .current_image()
+            .expect("Some(image) after VisDetected");
+        // PD120 dimensions: 640 × 496 (per ModeSpec).
+        assert_eq!(img.width, 640, "PD120 image width");
+        assert_eq!(img.height, 496, "PD120 image height");
     }
 
     // TODO(future/PR-3): mid_image_vis_emits_partial_then_new_vis

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -49,14 +49,11 @@ pub enum SstvEvent {
         sample_offset: u64,
     },
     /// One scan line completed (callers may render incrementally).
-    /// Pixel data lives on the decoder's in-progress image; call
-    /// [`SstvDecoder::current_image`] to borrow it. Row `line_index`
-    /// is fully populated after this event fires. (Audit #93 D5.)
     ///
-    /// For PD and Robot 72: the row is fully composed at emission time
+    /// For PD and Robot 72: `pixels` is fully composed at emission time
     /// (own Y/U/V or Y(odd)/Cr/Cb/Y(even) for the row).
     ///
-    /// For Robot 36 / Robot 24: the row reflects the image buffer state
+    /// For Robot 36 / Robot 24: `pixels` reflects the image buffer state
     /// at emission time, which has a transient cross-row dependency due
     /// to chroma alternation. Each radio line writes its own Cr-or-Cb
     /// AND duplicates that chroma to the NEXT image row. So row N is
@@ -73,6 +70,9 @@ pub enum SstvEvent {
         mode: SstvMode,
         /// 0-based row index for this line.
         line_index: u32,
+        /// `line_pixels` RGB triplets for this row, taken from the
+        /// in-progress image at emission time.
+        pixels: Vec<[u8; 3]>,
     },
     /// Image complete (`LineDecoded` for the final line was just emitted).
     /// `partial` is reserved for future mid-image VIS handling — V1 always
@@ -260,27 +260,6 @@ impl SstvDecoder {
             samples_processed: 0,
             working_samples_emitted: 0,
         })
-    }
-
-    /// Borrow the in-progress image. Returns `Some(&image)` while the
-    /// decoder is in the `Decoding` state (after a `VisDetected` event
-    /// and before the `ImageComplete` event); `None` while
-    /// `AwaitingVis`. Row `N` is fully populated after the
-    /// `LineDecoded { line_index: N, .. }` event for that row has been
-    /// emitted by the most recent `process` call. (Audit #93 D5.)
-    ///
-    /// **R36/R24 caveat:** see [`SstvEvent::LineDecoded`] for the
-    /// cross-row chroma-duplication contract — row N's `Cb` (or `Cr`)
-    /// is zero-initialized when `LineDecoded(N)` fires for the first
-    /// of each row pair, and gets duplicated in by the next row's
-    /// decode. The final `ImageComplete.image` carries the fully
-    /// populated state.
-    #[must_use]
-    pub fn current_image(&self) -> Option<&SstvImage> {
-        match &self.state {
-            State::Decoding(d) => Some(&d.image),
-            State::AwaitingVis => None,
-        }
     }
 
     /// Process a chunk of mono `f32` audio samples in caller's rate.
@@ -541,6 +520,7 @@ impl SstvDecoder {
         // Pre-reserve to avoid Vec growth reallocs. (Audit #93 D5.)
         out.reserve(d.spec.image_lines as usize + 1);
 
+        let line_pixels = d.spec.line_pixels as usize;
         match d.spec.channel_layout {
             crate::modespec::ChannelLayout::PdYcbcr => {
                 let pair_count = d.spec.image_lines / 2;
@@ -568,9 +548,12 @@ impl SstvDecoder {
                     let row0 = pair * 2;
                     let row1 = row0 + 1;
                     for r in [row0, row1] {
+                        let start = (r as usize) * line_pixels;
+                        let end = start + line_pixels;
                         out.push(SstvEvent::LineDecoded {
                             mode: d.mode,
                             line_index: r,
+                            pixels: d.image.pixels[start..end].to_vec(),
                         });
                     }
                 }
@@ -599,9 +582,12 @@ impl SstvDecoder {
                         snr_est,
                         d.hedr_shift_hz,
                     );
+                    let start = (line as usize) * line_pixels;
+                    let end = start + line_pixels;
                     out.push(SstvEvent::LineDecoded {
                         mode: d.mode,
                         line_index: line,
+                        pixels: d.image.pixels[start..end].to_vec(),
                     });
                 }
             }
@@ -623,16 +609,20 @@ impl SstvDecoder {
                         snr_est,
                         d.hedr_shift_hz,
                     );
+                    let start = (line as usize) * line_pixels;
+                    let end = start + line_pixels;
                     out.push(SstvEvent::LineDecoded {
                         mode: d.mode,
                         line_index: line,
+                        pixels: d.image.pixels[start..end].to_vec(),
                     });
                 }
             }
         }
 
-        // Move the now-populated image into the ImageComplete event. No more
-        // mem::replace + fresh black SstvImage allocation. (Audit #93 D6.2.)
+        // Move the now-populated image into the ImageComplete event. The
+        // by-value `d` (audit #93 D6.2) lets `d.image` move directly
+        // into the event without a fresh black-image realloc.
         out.push(SstvEvent::ImageComplete {
             image: d.image,
             partial: false,
@@ -950,37 +940,6 @@ mod tests {
             events.is_empty(),
             "reset should clear in-flight; got {events:?}"
         );
-    }
-
-    #[test]
-    fn current_image_is_none_when_awaiting_vis() {
-        let decoder = SstvDecoder::new(44100).expect("rate ok");
-        assert!(decoder.current_image().is_none());
-    }
-
-    #[test]
-    fn current_image_is_some_after_vis_detected() {
-        use crate::vis::tests::synth_vis;
-        // Feed a VIS-only burst (no image audio after). Decoder transitions
-        // to Decoding with a zero-initialized image of the mode's expected
-        // dimensions. (audit #93 D5 follow-up — covers the Some(image) path.)
-        let mut decoder =
-            SstvDecoder::new(crate::resample::WORKING_SAMPLE_RATE_HZ).expect("rate ok");
-        let mut burst = synth_vis(0x5F, 0.0); // PD120
-        burst.append(&mut vec![0.0_f32; 1024]); // pad to ensure the VIS detector fires
-        let events = decoder.process(&burst);
-        assert!(
-            events
-                .iter()
-                .any(|e| matches!(e, SstvEvent::VisDetected { .. })),
-            "expected VisDetected event"
-        );
-        let img = decoder
-            .current_image()
-            .expect("Some(image) after VisDetected");
-        // PD120 dimensions: 640 × 496 (per ModeSpec).
-        assert_eq!(img.width, 640, "PD120 image width");
-        assert_eq!(img.height, 496, "PD120 image height");
     }
 
     // TODO(future/PR-3): mid_image_vis_emits_partial_then_new_vis

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -49,11 +49,14 @@ pub enum SstvEvent {
         sample_offset: u64,
     },
     /// One scan line completed (callers may render incrementally).
+    /// Pixel data lives on the decoder's in-progress image; call
+    /// [`SstvDecoder::current_image`] to borrow it. Row `line_index`
+    /// is fully populated after this event fires. (Audit #93 D5.)
     ///
-    /// For PD and Robot 72: `pixels` is fully composed at emission time
+    /// For PD and Robot 72: the row is fully composed at emission time
     /// (own Y/U/V or Y(odd)/Cr/Cb/Y(even) for the row).
     ///
-    /// For Robot 36 / Robot 24: `pixels` reflects the image buffer state
+    /// For Robot 36 / Robot 24: the row reflects the image buffer state
     /// at emission time, which has a transient cross-row dependency due
     /// to chroma alternation. Each radio line writes its own Cr-or-Cb
     /// AND duplicates that chroma to the NEXT image row. So row N is
@@ -70,8 +73,6 @@ pub enum SstvEvent {
         mode: SstvMode,
         /// 0-based row index for this line.
         line_index: u32,
-        /// Row pixels in `[r, g, b]` order, length = mode's `line_pixels`.
-        pixels: Vec<[u8; 3]>,
     },
     /// Image complete (`LineDecoded` for the final line was just emitted).
     /// `partial` is reserved for future mid-image VIS handling — V1 always
@@ -261,6 +262,20 @@ impl SstvDecoder {
         })
     }
 
+    /// Borrow the in-progress image. Returns `Some(&image)` while the
+    /// decoder is in the `Decoding` state (after a `VisDetected` event
+    /// and before the `ImageComplete` event); `None` while
+    /// `AwaitingVis`. Row `N` is fully populated after the
+    /// `LineDecoded { line_index: N, .. }` event for that row has been
+    /// emitted by the most recent `process` call. (Audit #93 D5.)
+    #[must_use]
+    pub fn current_image(&self) -> Option<&SstvImage> {
+        match &self.state {
+            State::Decoding(d) => Some(&d.image),
+            State::AwaitingVis => None,
+        }
+    }
+
     /// Process a chunk of mono `f32` audio samples in caller's rate.
     ///
     /// Returns events produced during this call's processing window.
@@ -323,8 +338,14 @@ impl SstvDecoder {
                                 mode: spec.mode,
                                 spec,
                                 image,
-                                audio: residual,
-                                has_sync: Vec::new(),
+                                audio: {
+                                    // D6.1: pre-size to the known final length to
+                                    // avoid Vec growth reallocs over the burst.
+                                    let mut v = Vec::with_capacity(target);
+                                    v.extend(residual);
+                                    v
+                                },
+                                has_sync: Vec::with_capacity(target / SYNC_PROBE_STRIDE),
                                 next_probe_sample: 0,
                                 sync_tracker: SyncTracker::new(detected.hedr_shift_hz),
                                 hedr_shift_hz: detected.hedr_shift_hz,
@@ -403,8 +424,28 @@ impl SstvDecoder {
                     }
 
                     // Buffer is full → run FindSync once, then per-pair decode.
+                    // Capture carryback parameters + the tail audio slice
+                    // BEFORE moving `d` into `run_findsync_and_decode` (which
+                    // consumes it by value so `d.image` can move directly into
+                    // the `ImageComplete` event without a fresh black-image
+                    // realloc — Audit #93 D6.2).
+                    let work_rate = f64::from(crate::resample::WORKING_SAMPLE_RATE_HZ);
+                    let carryback = (f64::from(MULTI_IMAGE_CARRYBACK_LINES)
+                        * d.spec.line_seconds
+                        * work_rate) as usize;
+                    let carry_from = d.target_audio_samples.saturating_sub(carryback);
+                    let carry_audio: Vec<f32> = d.audio[carry_from..].to_vec();
+                    // Now extract the Box<DecodingState> by value. The
+                    // `mem::replace` swap leaves `self.state` as `AwaitingVis`
+                    // so the next loop iteration re-enters the AwaitingVis arm
+                    // (no explicit assignment needed below).
+                    let State::Decoding(d_box) =
+                        std::mem::replace(&mut self.state, State::AwaitingVis)
+                    else {
+                        unreachable!("outer match arm is Decoding");
+                    };
                     Self::run_findsync_and_decode(
-                        d,
+                        *d_box,
                         &mut self.channel_demod,
                         &mut self.snr_est,
                         &mut self.find_sync_scratch,
@@ -424,17 +465,11 @@ impl SstvDecoder {
                     // Closes #31; #90 (A2 + D4). (`sample_offset` on detections
                     // after the first is relative to the carry-forward start,
                     // not absolute — #99.)
-                    let work_rate = f64::from(crate::resample::WORKING_SAMPLE_RATE_HZ);
-                    let carryback = (f64::from(MULTI_IMAGE_CARRYBACK_LINES)
-                        * d.spec.line_seconds
-                        * work_rate) as usize;
-                    let carry_from = d.target_audio_samples.saturating_sub(carryback);
                     Self::restart_vis_detection(
                         &mut self.vis,
                         self.working_samples_emitted,
-                        &d.audio[carry_from..],
+                        &carry_audio,
                     );
-                    self.state = State::AwaitingVis;
                     remaining = &[]; // already folded into d.audio → now inside the fresh detector
                 }
             }
@@ -482,7 +517,7 @@ impl SstvDecoder {
         clippy::cast_possible_wrap
     )]
     fn run_findsync_and_decode(
-        d: &mut DecodingState,
+        mut d: DecodingState,
         channel_demod: &mut crate::demod::ChannelDemod,
         snr_est: &mut crate::snr::SnrEstimator,
         find_sync_scratch: &mut crate::sync::FindSyncScratch,
@@ -493,7 +528,10 @@ impl SstvDecoder {
         let rate = result.adjusted_rate_hz;
         let skip = result.skip_samples;
 
-        let line_pixels = d.spec.line_pixels as usize;
+        // Image-complete burst: image_lines LineDecoded events + 1 ImageComplete.
+        // Pre-reserve to avoid Vec growth reallocs. (Audit #93 D5.)
+        out.reserve(d.spec.image_lines as usize + 1);
+
         match d.spec.channel_layout {
             crate::modespec::ChannelLayout::PdYcbcr => {
                 let pair_count = d.spec.image_lines / 2;
@@ -521,12 +559,9 @@ impl SstvDecoder {
                     let row0 = pair * 2;
                     let row1 = row0 + 1;
                     for r in [row0, row1] {
-                        let start = (r as usize) * line_pixels;
-                        let end = start + line_pixels;
                         out.push(SstvEvent::LineDecoded {
                             mode: d.mode,
                             line_index: r,
-                            pixels: d.image.pixels[start..end].to_vec(),
                         });
                     }
                 }
@@ -555,12 +590,9 @@ impl SstvDecoder {
                         snr_est,
                         d.hedr_shift_hz,
                     );
-                    let start = (line as usize) * line_pixels;
-                    let end = start + line_pixels;
                     out.push(SstvEvent::LineDecoded {
                         mode: d.mode,
                         line_index: line,
-                        pixels: d.image.pixels[start..end].to_vec(),
                     });
                 }
             }
@@ -582,23 +614,18 @@ impl SstvDecoder {
                         snr_est,
                         d.hedr_shift_hz,
                     );
-                    let start = (line as usize) * line_pixels;
-                    let end = start + line_pixels;
                     out.push(SstvEvent::LineDecoded {
                         mode: d.mode,
                         line_index: line,
-                        pixels: d.image.pixels[start..end].to_vec(),
                     });
                 }
             }
         }
 
-        let final_image = std::mem::replace(
-            &mut d.image,
-            SstvImage::new(d.mode, d.spec.line_pixels, d.spec.image_lines),
-        );
+        // Move the now-populated image into the ImageComplete event. No more
+        // mem::replace + fresh black SstvImage allocation. (Audit #93 D6.2.)
         out.push(SstvEvent::ImageComplete {
-            image: final_image,
+            image: d.image,
             partial: false,
         });
     }
@@ -914,6 +941,12 @@ mod tests {
             events.is_empty(),
             "reset should clear in-flight; got {events:?}"
         );
+    }
+
+    #[test]
+    fn current_image_is_none_when_awaiting_vis() {
+        let decoder = SstvDecoder::new(44100).expect("rate ok");
+        assert!(decoder.current_image().is_none());
     }
 
     // TODO(future/PR-3): mid_image_vis_emits_partial_then_new_vis

--- a/src/demod.rs
+++ b/src/demod.rs
@@ -258,6 +258,21 @@ pub(crate) struct ChannelDemod {
     hann_bank: HannBank,
     fft_buf: Vec<Complex<f32>>,
     scratch: Vec<Complex<f32>>,
+    /// Per-channel scratch hoisted out of `decode_one_channel_into`.
+    /// Reused across calls via `clear() + reserve()/resize()/extend()`
+    /// at the top of each invocation. (Audit #93 D3.)
+    pixel_times: Vec<i64>,
+    stored_lum: Vec<u8>,
+    scratch_audio: Vec<f32>,
+    /// PD line-pair scratch buffers hoisted out of `decode_pd_line_pair`.
+    /// Reused across calls via `clear() + resize()`. (Audit #93 D3.)
+    /// `pub(crate)` because `mode_pd::decode_pd_line_pair` takes ownership
+    /// temporarily (via `std::mem::take`) to satisfy the borrow checker while
+    /// `demod` is also mutably borrowed through `DemodState`.
+    pub(crate) pd_y_odd: Vec<u8>,
+    pub(crate) pd_cr: Vec<u8>,
+    pub(crate) pd_cb: Vec<u8>,
+    pub(crate) pd_y_even: Vec<u8>,
 }
 
 impl ChannelDemod {
@@ -273,6 +288,13 @@ impl ChannelDemod {
             // (FFT_LEN=1024 is radix-2). The prior .max(FFT_LEN) was
             // dead-allocating ~8 KiB. (Audit #92 C8.)
             scratch: vec![Complex { re: 0.0, im: 0.0 }; scratch_len],
+            pixel_times: Vec::new(),
+            stored_lum: Vec::new(),
+            scratch_audio: Vec::new(),
+            pd_y_odd: Vec::new(),
+            pd_cr: Vec::new(),
+            pd_cb: Vec::new(),
+            pd_y_even: Vec::new(),
         }
     }
 
@@ -490,22 +512,24 @@ pub(crate) fn decode_one_channel_into(
     // Robot passes `line_index * line_seconds`. The helper itself is
     // mode-agnostic — it only sees an additive seconds offset folded
     // inside the single `round()`.
-    let mut pixel_times: Vec<i64> = Vec::with_capacity(width);
+    state.demod.pixel_times.clear();
+    state.demod.pixel_times.reserve(width);
     for x in 0..width {
         let secs_in_frame = chan_start_sec + pixel_secs * (x as f64 + 0.5);
         let abs = ctx.skip_samples
             + ((radio_frame_offset_seconds + secs_in_frame) * ctx.rate_hz).round() as i64;
-        pixel_times.push(abs);
+        state.demod.pixel_times.push(abs);
     }
 
-    let first_time = pixel_times[0];
-    let last_time = pixel_times[width - 1];
+    let first_time = state.demod.pixel_times[0];
+    let last_time = state.demod.pixel_times[width - 1];
     let half_fft = (FFT_LEN as i64) / 2;
     let sweep_start = first_time - half_fft;
     let sweep_end = last_time + half_fft + 1;
 
     let sweep_len = (sweep_end - sweep_start).max(0) as usize;
-    let mut stored_lum = vec![0_u8; sweep_len];
+    state.demod.stored_lum.clear();
+    state.demod.stored_lum.resize(sweep_len, 0);
 
     // SNR is sticky across the sweep; slowrx initializes with `SNR = 0`
     // (`video.c:36`) so the first `WinIdx` lookup uses index 4 (slowrx C's
@@ -545,7 +569,14 @@ pub(crate) fn decode_one_channel_into(
 
     // Pre-fill a scratch buffer the FFT can index linearly. Cheaper than
     // copying `audio[…]` per sample inside the inner loop.
-    let scratch_audio: Vec<f32> = (sweep_start..sweep_end).map(read_audio).collect();
+    // The backing allocation is hoisted onto `ChannelDemod::scratch_audio`
+    // (Audit #93 D3). We take it out here to satisfy the borrow checker
+    // (pixel_freq takes &mut self, so we cannot pass &self.scratch_audio
+    // simultaneously); the Vec is returned at the end of the fn so the
+    // capacity is retained for the next call.
+    let mut scratch_audio = std::mem::take(&mut state.demod.scratch_audio);
+    scratch_audio.clear();
+    scratch_audio.extend((sweep_start..sweep_end).map(read_audio));
 
     let mod_round = |s: i64, stride: i64| -> i64 { s.rem_euclid(stride) };
 
@@ -593,21 +624,22 @@ pub(crate) fn decode_one_channel_into(
 
         let lum = freq_to_luminance(current_freq, ctx.hedr_shift_hz);
         let idx = (s - sweep_start) as usize;
-        if idx < stored_lum.len() {
-            stored_lum[idx] = lum;
+        if idx < state.demod.stored_lum.len() {
+            state.demod.stored_lum[idx] = lum;
         }
     }
 
-    for x in 0..width {
-        let pixel_time = pixel_times[x];
+    for (out_px, &pixel_time) in out.iter_mut().zip(state.demod.pixel_times.iter()) {
         let rel = pixel_time - sweep_start;
-        let lum = if rel >= 0 && (rel as usize) < stored_lum.len() {
-            stored_lum[rel as usize]
+        let lum = if rel >= 0 && (rel as usize) < state.demod.stored_lum.len() {
+            state.demod.stored_lum[rel as usize]
         } else {
             0
         };
-        out[x] = lum;
+        *out_px = lum;
     }
+    // Return the scratch_audio allocation so it is retained for the next call.
+    state.demod.scratch_audio = scratch_audio;
 }
 
 #[cfg(test)]

--- a/src/mode_pd.rs
+++ b/src/mode_pd.rs
@@ -87,10 +87,24 @@ pub(crate) fn decode_pd_line_pair(
     let row1 = row0 + 1;
     let width_us = width as usize;
 
-    let mut y_odd = vec![0_u8; width_us];
-    let mut cr = vec![0_u8; width_us];
-    let mut cb = vec![0_u8; width_us];
-    let mut y_even = vec![0_u8; width_us];
+    // Hoist PD line-pair channel buffers (Audit #93 D3): take the backing
+    // allocations from `demod` so the borrow checker permits simultaneous
+    // mutable use of `demod` (via DemodState) inside decode_one_channel_into.
+    // The Vecs are returned to `demod` after the loop so their capacity is
+    // retained for the next pair call.
+    let mut y_odd = std::mem::take(&mut demod.pd_y_odd);
+    let mut cr = std::mem::take(&mut demod.pd_cr);
+    let mut cb = std::mem::take(&mut demod.pd_cb);
+    let mut y_even = std::mem::take(&mut demod.pd_y_even);
+
+    y_odd.clear();
+    y_odd.resize(width_us, 0);
+    cr.clear();
+    cr.resize(width_us, 0);
+    cb.clear();
+    cb.resize(width_us, 0);
+    y_even.clear();
+    y_even.resize(width_us, 0);
 
     let ctx = crate::demod::ChannelDecodeCtx {
         audio,
@@ -117,6 +131,12 @@ pub(crate) fn decode_pd_line_pair(
         image.put_pixel(x as u32, row0, rgb_odd);
         image.put_pixel(x as u32, row1, rgb_even);
     }
+
+    // Return allocations to demod for reuse on the next pair call.
+    demod.pd_y_odd = y_odd;
+    demod.pd_cr = cr;
+    demod.pd_cb = cb;
+    demod.pd_y_even = y_even;
 }
 
 #[cfg(test)]

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -83,6 +83,39 @@ const X_ACC_SLIP_THRESHOLD: i32 = (X_ACC_BINS / 2) as i32; // 350
 const SYNC_EDGE_KERNEL: [i32; 8] = [1, 1, 1, 1, -1, -1, -1, -1];
 const SYNC_EDGE_KERNEL_LEN: usize = SYNC_EDGE_KERNEL.len();
 
+/// Scratch buffers for [`find_sync`] and its helpers. Hoisted onto
+/// [`crate::decoder::SstvDecoder`] so they're reused across decode
+/// passes — the largest two (`sync_img`, `x_acc`) are sized at
+/// construction and never resized; `lines` resizes per-call because
+/// `n_slant_bins × LINES_D_BINS` depends on the mode's `line_width`.
+/// (Audit #93 D6.)
+pub(crate) struct FindSyncScratch {
+    /// `[X_ACC_BINS × SYNC_IMG_Y_BINS]` flat buffer for the 2D sync image.
+    /// Sized once; `find_sync` calls `.fill(false)` each invocation.
+    pub(crate) sync_img: Vec<bool>,
+    /// `[LINES_D_BINS × n_slant_bins]` flat buffer for the Hough
+    /// accumulator. Resized per-call (`.clear() + .resize(...)`).
+    pub(crate) lines: Vec<u16>,
+    /// `[X_ACC_BINS]` column accumulator. Sized once; `.fill(0)` per call.
+    pub(crate) x_acc: Vec<u32>,
+}
+
+impl FindSyncScratch {
+    pub(crate) fn new() -> Self {
+        Self {
+            sync_img: vec![false; X_ACC_BINS * SYNC_IMG_Y_BINS],
+            lines: Vec::new(),
+            x_acc: vec![0; X_ACC_BINS],
+        }
+    }
+}
+
+impl Default for FindSyncScratch {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// Convert degrees to radians. Matches slowrx `common.c::deg2rad`.
 fn deg2rad(deg: f64) -> f64 {
     deg * std::f64::consts::PI / 180.0
@@ -227,14 +260,20 @@ pub(crate) struct SyncResult {
     clippy::cast_sign_loss,
     clippy::cast_possible_wrap
 )]
-pub(crate) fn find_sync(has_sync: &[bool], initial_rate_hz: f64, spec: ModeSpec) -> SyncResult {
+pub(crate) fn find_sync(
+    has_sync: &[bool],
+    initial_rate_hz: f64,
+    spec: ModeSpec,
+    scratch: &mut FindSyncScratch,
+) -> SyncResult {
     let line_width: usize = ((spec.line_seconds / spec.sync_seconds) * 4.0) as usize;
     let num_lines = spec.image_lines as usize;
     let mut rate = initial_rate_hz;
     let mut slant_deg_detected: Option<f64> = None;
 
     for retry in 0..=MAX_SLANT_RETRIES {
-        let Some((slant, adjusted)) = hough_detect_slant(has_sync, rate, spec, line_width) else {
+        let Some((slant, adjusted)) = hough_detect_slant(has_sync, rate, spec, line_width, scratch)
+        else {
             // No sync pulses → no Hough peak → no rate correction.
             break;
         };
@@ -258,7 +297,7 @@ pub(crate) fn find_sync(has_sync: &[bool], initial_rate_hz: f64, spec: ModeSpec)
         }
     }
 
-    let xmax = find_falling_edge(has_sync, rate, spec, num_lines);
+    let xmax = find_falling_edge(has_sync, rate, spec, num_lines, scratch);
     let s_secs = skip_seconds_for(xmax, spec);
     let skip_samples = (s_secs * rate).round() as i64;
 
@@ -286,6 +325,7 @@ fn hough_detect_slant(
     rate_hz: f64,
     spec: ModeSpec,
     line_width: usize,
+    scratch: &mut FindSyncScratch,
 ) -> Option<(f64 /* slant_deg */, f64 /* adjusted_rate */)> {
     let n_slant_bins = ((MAX_SLANT_DEG - MIN_SLANT_DEG) / SLANT_STEP_DEG).round() as usize;
     let num_lines = spec.image_lines as usize;
@@ -309,25 +349,28 @@ fn hough_detect_slant(
         }
     };
 
+    // Reset the hoisted scratch buffers (was: fresh Vec allocations).
+    scratch.sync_img.fill(false);
+    scratch.lines.clear();
+    scratch.lines.resize(LINES_D_BINS * n_slant_bins, 0);
+
     // Draw the 2D sync signal at current rate.
-    let mut sync_img = vec![false; X_ACC_BINS * SYNC_IMG_Y_BINS];
     for y in 0..num_lines.min(SYNC_IMG_Y_BINS) {
         for x in 0..line_width.min(X_ACC_BINS) {
             let t = ((y as f64) + (x as f64) / (line_width as f64)) * spec.line_seconds;
             let idx = probe_index(t);
             if idx < has_sync.len() {
-                sync_img[sync_img_idx(x, y)] = has_sync[idx];
+                scratch.sync_img[sync_img_idx(x, y)] = has_sync[idx];
             }
         }
     }
 
     // Linear Hough transform.
-    let mut lines = vec![0u16; LINES_D_BINS * n_slant_bins];
     let mut q_most = 0_usize;
     let mut max_count = 0_u16;
     for cy in 0..num_lines.min(SYNC_IMG_Y_BINS) {
         for cx in 0..line_width.min(X_ACC_BINS) {
-            if !sync_img[sync_img_idx(cx, cy)] {
+            if !scratch.sync_img[sync_img_idx(cx, cy)] {
                 continue;
             }
             for q in 0..n_slant_bins {
@@ -337,7 +380,7 @@ fn hough_detect_slant(
                 if d_signed > 0.0 && d_signed < (line_width as f64) {
                     let d = d_signed as usize;
                     if d < LINES_D_BINS {
-                        let cell = &mut lines[lines_idx(d, q)];
+                        let cell = &mut scratch.lines[lines_idx(d, q)];
                         *cell = cell.saturating_add(1);
                         if *cell > max_count {
                             max_count = *cell;
@@ -406,7 +449,13 @@ fn falling_edge_from_x_acc(x_acc: &[u32]) -> i32 {
     clippy::cast_possible_truncation,
     clippy::cast_sign_loss
 )]
-fn find_falling_edge(has_sync: &[bool], rate_hz: f64, spec: ModeSpec, num_lines: usize) -> i32 {
+fn find_falling_edge(
+    has_sync: &[bool],
+    rate_hz: f64,
+    spec: ModeSpec,
+    num_lines: usize,
+    scratch: &mut FindSyncScratch,
+) -> i32 {
     let probe_index = |t: f64| -> usize {
         let raw = t * rate_hz / (SYNC_PROBE_STRIDE as f64);
         if raw < 0.0 {
@@ -416,9 +465,9 @@ fn find_falling_edge(has_sync: &[bool], rate_hz: f64, spec: ModeSpec, num_lines:
         }
     };
 
-    let mut x_acc = vec![0u32; X_ACC_BINS];
+    scratch.x_acc.fill(0);
     for y in 0..num_lines {
-        for (x, slot) in x_acc.iter_mut().enumerate() {
+        for (x, slot) in scratch.x_acc.iter_mut().enumerate() {
             let t = (y as f64) * spec.line_seconds
                 + ((x as f64) / (X_ACC_BINS as f64)) * spec.line_seconds;
             let idx = probe_index(t);
@@ -428,7 +477,7 @@ fn find_falling_edge(has_sync: &[bool], rate_hz: f64, spec: ModeSpec, num_lines:
         }
     }
 
-    falling_edge_from_x_acc(&x_acc)
+    falling_edge_from_x_acc(&scratch.x_acc)
 }
 
 /// Convert a falling-edge `xmax` (post-slip-wrap) to skip seconds,
@@ -543,7 +592,8 @@ mod tests {
     fn find_sync_locks_clean_track_to_90_degrees() {
         let spec = modespec::for_mode(crate::modespec::SstvMode::Pd120);
         let rate = f64::from(WORKING_SAMPLE_RATE_HZ);
-        let r = find_sync(&synth_has_sync(spec, rate), rate, spec);
+        let mut scratch = FindSyncScratch::new();
+        let r = find_sync(&synth_has_sync(spec, rate), rate, spec, &mut scratch);
         let slant = r.slant_deg.expect("sync detected");
         assert!((slant - 90.0).abs() < 1.0, "{slant:.2}°");
         assert!((r.adjusted_rate_hz - rate).abs() / rate < 0.005);
@@ -559,7 +609,8 @@ mod tests {
     fn find_sync_empty_track_has_no_slant_detected() {
         let spec = modespec::for_mode(crate::modespec::SstvMode::Pd120);
         let rate = f64::from(WORKING_SAMPLE_RATE_HZ);
-        let r = find_sync(&vec![false; 16384], rate, spec);
+        let mut scratch = FindSyncScratch::new();
+        let r = find_sync(&vec![false; 16384], rate, spec, &mut scratch);
         assert!(
             r.slant_deg.is_none(),
             "empty track should yield slant_deg=None, got {:?}",
@@ -581,7 +632,8 @@ mod tests {
         let shift = ((0.010 * rate) / (SYNC_PROBE_STRIDE as f64)) as usize;
         let mut shifted = vec![false; shift];
         shifted.append(&mut track);
-        let r = find_sync(&shifted, rate, spec);
+        let mut scratch = FindSyncScratch::new();
+        let r = find_sync(&shifted, rate, spec, &mut scratch);
         let expected = (0.010 * rate) as i64;
         // 700-bin row ≈ 0.7 ms / bin at PD120; allow a few bins for wobble.
         assert!(
@@ -595,7 +647,8 @@ mod tests {
     fn find_sync_handles_empty_track() {
         let spec = modespec::for_mode(crate::modespec::SstvMode::Pd120);
         let rate = f64::from(WORKING_SAMPLE_RATE_HZ);
-        let r = find_sync(&vec![false; 16384], rate, spec);
+        let mut scratch = FindSyncScratch::new();
+        let r = find_sync(&vec![false; 16384], rate, spec, &mut scratch);
         assert!(r.adjusted_rate_hz.is_finite());
         assert!((r.adjusted_rate_hz - rate).abs() < 1.0);
         // Rate must be bit-exact when no sync detected (no rate correction ran).
@@ -623,7 +676,8 @@ mod tests {
         let true_rate = f64::from(WORKING_SAMPLE_RATE_HZ);
         let capture_rate = true_rate * 1.005;
         let track = synth_has_sync_slanted(spec, true_rate, capture_rate);
-        let r = find_sync(&track, capture_rate, spec);
+        let mut scratch = FindSyncScratch::new();
+        let r = find_sync(&track, capture_rate, spec, &mut scratch);
         let err_pct = (r.adjusted_rate_hz - true_rate).abs() / true_rate * 100.0;
         let initial_err_pct = (capture_rate - true_rate).abs() / true_rate * 100.0;
         // Verify sync was detected at all.
@@ -655,7 +709,8 @@ mod tests {
         let true_rate = f64::from(WORKING_SAMPLE_RATE_HZ);
         let capture_rate = true_rate * 1.01;
         let track = synth_has_sync_slanted(spec, true_rate, capture_rate);
-        let r = find_sync(&track, capture_rate, spec);
+        let mut scratch = FindSyncScratch::new();
+        let r = find_sync(&track, capture_rate, spec, &mut scratch);
         let initial_err_pct = (capture_rate - true_rate).abs() / true_rate * 100.0;
         let final_err_pct = (r.adjusted_rate_hz - true_rate).abs() / true_rate * 100.0;
         assert!(
@@ -681,7 +736,8 @@ mod tests {
         let spec = modespec::for_mode(crate::modespec::SstvMode::Scottie1);
         let rate = f64::from(WORKING_SAMPLE_RATE_HZ);
         let track = synth_has_sync(spec, rate);
-        let r = find_sync(&track, rate, spec);
+        let mut scratch = FindSyncScratch::new();
+        let r = find_sync(&track, rate, spec, &mut scratch);
 
         let chan_len = f64::from(spec.line_pixels) * spec.pixel_seconds;
         let expected_secs = -chan_len / 2.0 + 2.0 * spec.porch_seconds;


### PR DESCRIPTION
## Summary

Closes audit findings **D3 / D6.1 / D6.2 / D6.3** from `docs/audits/2026-05-11-deep-code-review-audit.md` (issue #93). Eliminates per-decode allocation churn at three sites. **Non-breaking** (D5 was reverted late in the PR — see below).

- **D3 — per-channel scratch hoisted onto `ChannelDemod`.** Three core fields (`pixel_times`, `stored_lum`, `scratch_audio`) plus four PD line-pair buffers (`pd_y_odd`, `pd_y_even`, `pd_cr`, `pd_cb`). The 3 inside `decode_one_channel_into` and 4 inside `decode_pd_line_pair` use `clear()` + `reserve()`/`resize()`/`extend()` (or `std::mem::take`+restore where the borrow checker needs it — same O(1) cost, preserves heap capacity). ~7000 allocations per PD240 image eliminated.
- **D6.1 — `DecodingState.audio` / `.has_sync`** use `Vec::with_capacity(target)` instead of `Vec::new()`. The audio constructor preserves the residual move.
- **D6.2 — `run_findsync_and_decode` refactored** to take `mut d: DecodingState` by value (was `&mut`). `d.image` moves directly into the `ImageComplete` event. Eliminates the throwaway ~950 KB black-image `mem::replace` workaround.
- **D6.3 — new `pub(crate) FindSyncScratch` struct** owned by `SstvDecoder`. `find_sync`, `hough_detect_slant`, `find_falling_edge` gain a `scratch: &mut FindSyncScratch` parameter. ~7 existing `find_sync_*` tests construct local scratch. ~730 KB scratch allocated per `find_sync` call → 0 (after first call).
- Plus `out.reserve(image_lines + 1)` before the burst-emit loop saves ~9 events-Vec growth reallocs.

### D5 reverted

D5 originally aimed to drop `LineDecoded.pixels` and expose `SstvDecoder::current_image()`. CodeRabbit caught a lifecycle bug — `process()` batches all events before returning to `AwaitingVis`, so `current_image()` returned `None` by the time callers iterated the `LineDecoded` events. The architectural fix (Completed state + `take_image()`) is incompatible with `tests/multi_image.rs` which requires multiple images to complete in one `process()` call — a single `Completed(d)` variant can only hold one image. Reverted D5 entirely; deferred to a future API-design pass that accounts for multi-image streaming. PR stays non-breaking.

**Lib test count: 136 → 136** (unchanged from baseline). `tests/roundtrip.rs` 11/11 — pixel output bit-identical.

## Test plan

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo test --all-features --locked --release` — 136 lib + 11/11 roundtrip + all integration green
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features` — clean
- [x] Pre-PR code-reviewer pass → addressed 3 doc/test items
- [x] CodeRabbit catch → D5 reverted (see commit `c02a238`)

Refs: #97 (epic; **9/12** bundles after this lands, with D5 deferred), audit IDs D3/D6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * None — a previously planned breaking API change was reverted to preserve compatibility and identical pixel output.

* **Performance**
  * Reduced memory allocations and pre-sized buffers in the decode pipeline for lower memory use and improved decode throughput with no change to output.

* **Documentation**
  * Added design/spec and plan docs and updated the changelog describing the performance work and migration notes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jasonherald/slowrx.rs/pull/110)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->